### PR TITLE
Fix panic on custom white point/primaries encoding

### DIFF
--- a/jxl-encoder/src/headers/color_encoding.rs
+++ b/jxl-encoder/src/headers/color_encoding.rs
@@ -278,8 +278,9 @@ impl ColorEncoding {
         );
         writer.write_enum_default(wp)?;
         if self.white_point == WhitePoint::Custom {
-            // Custom white point coordinates would follow
-            todo!("Custom white point not implemented");
+            return Err(crate::error::Error::NotImplemented(
+                "custom white point encoding".into(),
+            ));
         }
 
         // primaries (only for RGB) - uses jxl-rs default u2S encoding
@@ -298,8 +299,9 @@ impl ColorEncoding {
             );
             writer.write_enum_default(prim)?;
             if self.primaries == Primaries::Custom {
-                // Custom primaries would follow
-                todo!("Custom primaries not implemented");
+                return Err(crate::error::Error::NotImplemented(
+                    "custom primaries encoding".into(),
+                ));
             }
         } else {
             crate::trace::debug_eprintln!(


### PR DESCRIPTION
## Summary
- Replace `todo!()` with `Err(Error::NotImplemented(...))` for custom white point and custom primaries encoding in `color_encoding.rs`
- Previously, passing a color profile with `WhitePoint::Custom` or `Primaries::Custom` would panic at runtime; now returns a proper error

## Test plan
- [x] `cargo clippy -p jxl-encoder -- -D warnings` clean
- [x] `cargo test -p jxl-encoder --lib` — 705 passed
- [ ] Verify error is surfaced correctly through the public API when a custom profile is used