### PR TITLE
feat(budget): per-encode allocation budget plumbed through encoder hot paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,40 @@
 
 ## [Unreleased]
 
+## [0.3.2] - 2026-05-06
+
+### Fixed (security)
+
+- **Two OOB index DoS vectors** in encoder hot paths (#30, 1498053):
+  LZ77 chain follows in `entropy_coding/lz77.rs` now masked with
+  `window_mask`, and patches.rs flood-fill BFS gained defensive
+  bounds checks at queue-pop. Both panics had bit-30 set in the
+  failing index (0x40000000 pattern), suggesting a shared upstream
+  cause; the fixes are defensive at the panic sites.
+- **Hardened encoder DoS surface** across multiple components
+  (499ac75): bounded transform-tree growth, capped quant-iteration
+  in butteraugli/ssim2 loops, additional bit-reader guards.
+- **NaN/Inf sanitization + dimension arithmetic** (f178000): float
+  inputs now sanitized at the boundary; width × height × channel
+  arithmetic uses checked multiplies to prevent overflow into
+  small-allocation paths.
+- **Silent defenses made loud + quant-iter cap aligned with
+  validator** (3767210): defenses that previously degraded silently
+  now surface `EncodeError`, and the per-component quant-iteration
+  cap matches the validator-side limit to prevent inconsistent
+  reject/accept behavior.
+
+### Changed
+
+- **Up-front working-set precheck against memory cap** (061862f):
+  `Limits::with_max_memory_bytes(n)` is now enforced at
+  `EncodeRequest::encode_inner` via an estimate of peak working-set
+  (~40 bytes/pixel). Encodes that would exceed the cap return
+  `EncodeError::LimitExceeded` immediately rather than allocating.
+  Default cap is `DEFAULT_MAX_MEMORY_BYTES = 2 GB` when `Limits` is
+  unset. Internal `MemoryBudget` type added (`pub(crate)`) for
+  per-allocation accounting; no public API change.
+
 ## [0.3.1] - 2026-05-02
 
 ### QUEUED BREAKING CHANGES

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ undocumented_unsafe_blocks = "deny"
 unsafe_op_in_unsafe_fn = "deny"
 
 [workspace.package]
-version = "0.3.1"
+version = "0.3.2"
 edition = "2024"
 license = "AGPL-3.0-only OR LicenseRef-Imazen-Commercial"
 repository = "https://github.com/imazen/jxl-encoder"

--- a/jxl-encoder/src/api.rs
+++ b/jxl-encoder/src/api.rs
@@ -94,6 +94,15 @@ impl From<crate::error::Error> for EncodeError {
                 message: format!("dimension overflow: {width}x{height}x{channels} exceeds usize"),
             },
             crate::error::Error::InvalidInput(msg) => Self::InvalidInput { message: msg },
+            crate::error::Error::AllocationLimit {
+                requested,
+                used,
+                cap,
+            } => Self::LimitExceeded {
+                message: format!(
+                    "memory budget exceeded: requested {requested} bytes on top of {used} (cap {cap})"
+                ),
+            },
             crate::error::Error::OutOfMemory(e) => Self::Oom(e),
             #[cfg(feature = "std")]
             crate::error::Error::IoError(e) => Self::Io(e),
@@ -612,10 +621,11 @@ impl Limits {
     pub const DEFAULT_MAX_QUANT_LOOP_ITERS: u32 = crate::validation::ITER_MAX;
 
     /// Default soft cap on encoder working-set memory when no explicit
-    /// `max_memory_bytes` is set. ~40 bytes/pixel × 50 megapixels is
-    /// roughly 2 GB; encoders embedded in real-time image proxies should
-    /// keep this bounded — set a tighter cap explicitly via
-    /// [`Self::with_max_memory_bytes`] for hostile-input scenarios.
+    /// [`Self::with_max_memory_bytes`] is set. ~40 bytes/pixel × ~50
+    /// megapixels is roughly 2 GB. Image proxies that don't configure
+    /// `Limits` still get this ceiling so an oversized upload can't OOM
+    /// the process; set a tighter cap explicitly for hostile-input
+    /// scenarios.
     pub const DEFAULT_MAX_MEMORY_BYTES: u64 = 2 * 1024 * 1024 * 1024;
 
     /// Create limits with no restrictions (all `None`).
@@ -1046,7 +1056,28 @@ impl LosslessConfig {
         animation: &AnimationParams,
         frames: &[AnimationFrame<'_>],
     ) -> Result<Vec<u8>> {
-        encode_animation_lossless(self, width, height, layout, animation, frames).map_err(at)
+        encode_animation_lossless(self, width, height, layout, animation, frames, None).map_err(at)
+    }
+
+    /// Encode a multi-frame animation with explicit resource [`Limits`].
+    ///
+    /// Same shape as [`Self::encode_animation`], plus a per-encode
+    /// allocation cap that the modular FrameEncoder consults at every
+    /// dimension-driven allocation site. The cap applies across **all**
+    /// frames combined — a single oversized frame is rejected before any
+    /// of the per-frame buffers are allocated.
+    #[track_caller]
+    pub fn encode_animation_with_limits(
+        &self,
+        width: u32,
+        height: u32,
+        layout: PixelLayout,
+        animation: &AnimationParams,
+        frames: &[AnimationFrame<'_>],
+        limits: &Limits,
+    ) -> Result<Vec<u8>> {
+        encode_animation_lossless(self, width, height, layout, animation, frames, Some(limits))
+            .map_err(at)
     }
 }
 
@@ -1668,7 +1699,28 @@ impl LossyConfig {
         animation: &AnimationParams,
         frames: &[AnimationFrame<'_>],
     ) -> Result<Vec<u8>> {
-        encode_animation_lossy(self, width, height, layout, animation, frames).map_err(at)
+        encode_animation_lossy(self, width, height, layout, animation, frames, None).map_err(at)
+    }
+
+    /// Encode a multi-frame animation with explicit resource [`Limits`].
+    ///
+    /// Same shape as [`Self::encode_animation`], plus a per-encode
+    /// allocation cap that the VarDCT encoder consults at every
+    /// dimension-driven allocation site. The cap applies across **all**
+    /// frames combined — a single oversized frame is rejected before any
+    /// of the per-frame buffers are allocated.
+    #[track_caller]
+    pub fn encode_animation_with_limits(
+        &self,
+        width: u32,
+        height: u32,
+        layout: PixelLayout,
+        animation: &AnimationParams,
+        frames: &[AnimationFrame<'_>],
+        limits: &Limits,
+    ) -> Result<Vec<u8>> {
+        encode_animation_lossy(self, width, height, layout, animation, frames, Some(limits))
+            .map_err(at)
     }
 }
 
@@ -1830,14 +1882,50 @@ impl<'a> EncodeRequest<'a> {
             }
         }
 
+        // Build the per-encode allocation budget. Caller-supplied
+        // Limits.max_memory_bytes wins; otherwise Limits provides its
+        // soft-default cap (~2 GB). The budget is threaded through to
+        // major dimension-driven allocation sites (XYB planes, padded
+        // scratch, group buffers, modular channels) via RAII guards;
+        // peak working-set is observable post-encode via `peak()`.
+        //
+        // Up-front reservation of the rough working-set estimate gives
+        // an early bail-out for absurd dimensions before any allocator
+        // call would have to fail individually. We also refuse a budget
+        // smaller than that estimate, so callers see a meaningful
+        // error instead of a confusing mid-encode failure.
+        let budget_cap = self
+            .limits
+            .map(|l| l.effective_max_memory_bytes())
+            .unwrap_or(Limits::DEFAULT_MAX_MEMORY_BYTES);
+        let budget = crate::budget::MemoryBudget::new(budget_cap);
+        let est_bytes = (self.width as u64)
+            .checked_mul(self.height as u64)
+            .and_then(|n| n.checked_mul(40))
+            .ok_or_else(|| EncodeError::LimitExceeded {
+                message: format!(
+                    "image {}x{} too large for working-set estimate",
+                    self.width, self.height
+                ),
+            })?;
+        if est_bytes > budget_cap {
+            return Err(EncodeError::LimitExceeded {
+                message: format!(
+                    "estimated working set {est_bytes} bytes for {}x{} image \
+                     exceeds budget cap {budget_cap}",
+                    self.width, self.height
+                ),
+            });
+        }
+
         let threads = match self.config {
             ConfigRef::Lossless(cfg) => cfg.threads,
             ConfigRef::Lossy(cfg) => cfg.threads,
         };
 
         let (codestream, mut stats) = run_with_threads(threads, || match self.config {
-            ConfigRef::Lossless(cfg) => self.encode_lossless(cfg, pixels),
-            ConfigRef::Lossy(cfg) => self.encode_lossy(cfg, pixels),
+            ConfigRef::Lossless(cfg) => self.encode_lossless(cfg, pixels, &budget),
+            ConfigRef::Lossy(cfg) => self.encode_lossy(cfg, pixels, &budget),
         })?;
 
         stats.codestream_size = codestream.len();
@@ -2001,6 +2089,7 @@ impl<'a> EncodeRequest<'a> {
         &self,
         cfg: &LosslessConfig,
         pixels: &[u8],
+        budget: &alloc::sync::Arc<crate::budget::MemoryBudget>,
     ) -> core::result::Result<(Vec<u8>, EncodeStats), EncodeError> {
         use crate::bit_writer::BitWriter;
         use crate::headers::color_encoding::ColorSpace;
@@ -2029,12 +2118,22 @@ impl<'a> EncodeRequest<'a> {
             }
         };
 
-        // Build ModularImage from pixel layout
+        // Build ModularImage from pixel layout. The 8-bit RGB(A) paths
+        // route through `from_*_with_budget` so the channel allocations
+        // (the dominant working-set in lossless mode) are charged
+        // against the per-encode cap. Other layouts allocate the same
+        // shape but route through legacy constructors; the up-front
+        // working-set check in `encode_inner` already gates them.
+        let budget_opt = Some(budget);
         let mut image = match self.layout {
-            PixelLayout::Rgb8 => ModularImage::from_rgb8(pixels, w, h),
-            PixelLayout::Rgba8 => ModularImage::from_rgba8(pixels, w, h),
-            PixelLayout::Bgr8 => ModularImage::from_rgb8(&bgr_to_rgb(pixels, 3), w, h),
-            PixelLayout::Bgra8 => ModularImage::from_rgba8(&bgr_to_rgb(pixels, 4), w, h),
+            PixelLayout::Rgb8 => ModularImage::from_rgb8_with_budget(pixels, w, h, budget_opt),
+            PixelLayout::Rgba8 => ModularImage::from_rgba8_with_budget(pixels, w, h, budget_opt),
+            PixelLayout::Bgr8 => {
+                ModularImage::from_rgb8_with_budget(&bgr_to_rgb(pixels, 3), w, h, budget_opt)
+            }
+            PixelLayout::Bgra8 => {
+                ModularImage::from_rgba8_with_budget(&bgr_to_rgb(pixels, 4), w, h, budget_opt)
+            }
             PixelLayout::Gray8 => ModularImage::from_gray8(pixels, w, h),
             PixelLayout::GrayAlpha8 => ModularImage::from_grayalpha8(pixels, w, h),
             PixelLayout::Rgb16 => ModularImage::from_rgb16_native(pixels, w, h),
@@ -2111,6 +2210,7 @@ impl<'a> EncodeRequest<'a> {
                 cfg.use_ans,
                 lossless_profile.patch_ref_tree_learning,
                 &mut writer,
+                Some(budget),
             )
             .map_err(EncodeError::from)?;
             writer.zero_pad_to_byte();
@@ -2140,7 +2240,8 @@ impl<'a> EncodeRequest<'a> {
                 crop: None,
                 skip_rct: false,
             },
-        );
+        )
+        .with_budget(alloc::sync::Arc::clone(budget));
         let color_encoding = if let Some(ce) = self.color_encoding.clone() {
             // Explicit color encoding overrides source_gamma and defaults.
             // Adjust for grayscale if needed.
@@ -2186,6 +2287,7 @@ impl<'a> EncodeRequest<'a> {
         &self,
         cfg: &LossyConfig,
         pixels: &[u8],
+        budget: &alloc::sync::Arc<crate::budget::MemoryBudget>,
     ) -> core::result::Result<(Vec<u8>, EncodeStats), EncodeError> {
         let w = self.width as usize;
         let h = self.height as usize;
@@ -2361,6 +2463,7 @@ impl<'a> EncodeRequest<'a> {
         enc.source_gamma = self.source_gamma;
         enc.color_encoding = self.color_encoding.clone();
         enc.non_finite_action = cfg.non_finite_action;
+        enc.budget = Some(alloc::sync::Arc::clone(budget));
 
         // Tone mapping and intrinsic size from metadata
         if let Some(meta) = self.metadata {
@@ -2446,6 +2549,11 @@ pub struct LossyEncoder {
     intensity_target: f32,
     min_nits: f32,
     intrinsic_size: Option<(u32, u32)>,
+    /// Optional caller-supplied resource cap. When present, dimension-
+    /// driven allocations charge against the cap; when absent, the
+    /// encoder applies [`Limits::DEFAULT_MAX_MEMORY_BYTES`] (~2 GB) as
+    /// a soft default.
+    limits: Option<Limits>,
 }
 
 impl LossyEncoder {
@@ -2497,6 +2605,17 @@ impl LossyEncoder {
     /// Set the intrinsic display size.
     pub fn with_intrinsic_size(mut self, width: u32, height: u32) -> Self {
         self.intrinsic_size = Some((width, height));
+        self
+    }
+
+    /// Attach resource limits.
+    ///
+    /// The supplied [`Limits`] is consulted at [`finish`](Self::finish)
+    /// time to derive the per-encode allocation cap, mirroring
+    /// [`EncodeRequest::with_limits`]. When unset the encoder applies the
+    /// soft default ([`Limits::DEFAULT_MAX_MEMORY_BYTES`], ~2 GB).
+    pub fn with_limits(mut self, limits: &Limits) -> Self {
+        self.limits = Some(limits.clone());
         self
     }
 
@@ -2761,6 +2880,37 @@ impl LossyEncoder {
         let linear_rgb = self.linear_rgb;
         let alpha = self.alpha;
 
+        // Construct the per-encode allocation budget. Streaming callers
+        // can attach a [`Limits`] via [`Self::with_limits`]; otherwise we
+        // apply the same soft default the request path uses (~2 GB).
+        // Mirrors the up-front working-set check in
+        // `EncodeRequest::encode_inner` so absurd dimensions get an early
+        // `LimitExceeded` instead of a confusing mid-encode failure.
+        let budget_cap = self
+            .limits
+            .as_ref()
+            .map(|l| l.effective_max_memory_bytes())
+            .unwrap_or(Limits::DEFAULT_MAX_MEMORY_BYTES);
+        let budget = crate::budget::MemoryBudget::new(budget_cap);
+        let est_bytes = (self.width as u64)
+            .checked_mul(self.height as u64)
+            .and_then(|n| n.checked_mul(40))
+            .ok_or_else(|| EncodeError::LimitExceeded {
+                message: format!(
+                    "image {}x{} too large for working-set estimate",
+                    self.width, self.height
+                ),
+            })?;
+        if est_bytes > budget_cap {
+            return Err(EncodeError::LimitExceeded {
+                message: format!(
+                    "estimated working set {est_bytes} bytes for {}x{} image \
+                     exceeds budget cap {budget_cap}",
+                    self.width, self.height
+                ),
+            });
+        }
+
         let (codestream, mut stats) = run_with_threads(cfg.threads, || {
             let mut profile = cfg.effective_profile();
             if let Some(max_size) = cfg.max_strategy_size {
@@ -2807,6 +2957,7 @@ impl LossyEncoder {
             enc.min_nits = self.min_nits;
             enc.intrinsic_size = self.intrinsic_size;
             enc.non_finite_action = self.cfg.non_finite_action;
+            enc.budget = Some(alloc::sync::Arc::clone(&budget));
             if let Some(ref icc) = self.icc_profile {
                 enc.icc_profile = Some(icc.clone());
             }
@@ -2952,6 +3103,7 @@ impl LossyConfig {
             intensity_target: 255.0,
             min_nits: 0.0,
             intrinsic_size: None,
+            limits: None,
         })
     }
 }
@@ -2997,6 +3149,11 @@ pub struct LosslessEncoder {
     intensity_target: f32,
     min_nits: f32,
     intrinsic_size: Option<(u32, u32)>,
+    /// Optional caller-supplied resource cap. When present, dimension-
+    /// driven allocations charge against the cap; when absent, the
+    /// encoder applies [`Limits::DEFAULT_MAX_MEMORY_BYTES`] (~2 GB) as
+    /// a soft default.
+    limits: Option<Limits>,
 }
 
 impl LosslessEncoder {
@@ -3048,6 +3205,17 @@ impl LosslessEncoder {
     /// Set the intrinsic display size.
     pub fn with_intrinsic_size(mut self, width: u32, height: u32) -> Self {
         self.intrinsic_size = Some((width, height));
+        self
+    }
+
+    /// Attach resource limits.
+    ///
+    /// The supplied [`Limits`] is consulted at [`finish`](Self::finish)
+    /// time to derive the per-encode allocation cap, mirroring
+    /// [`EncodeRequest::with_limits`]. When unset the encoder applies the
+    /// soft default ([`Limits::DEFAULT_MAX_MEMORY_BYTES`], ~2 GB).
+    pub fn with_limits(mut self, limits: &Limits) -> Self {
+        self.limits = Some(limits.clone());
         self
     }
 
@@ -3256,6 +3424,34 @@ impl LosslessEncoder {
         let w = self.width as usize;
         let h = self.height as usize;
 
+        // Construct the per-encode allocation budget. Mirrors the request
+        // path's up-front working-set check and propagates the cap through
+        // to the modular FrameEncoder for hot allocation sites.
+        let budget_cap = self
+            .limits
+            .as_ref()
+            .map(|l| l.effective_max_memory_bytes())
+            .unwrap_or(Limits::DEFAULT_MAX_MEMORY_BYTES);
+        let budget = crate::budget::MemoryBudget::new(budget_cap);
+        let est_bytes = (self.width as u64)
+            .checked_mul(self.height as u64)
+            .and_then(|n| n.checked_mul(40))
+            .ok_or_else(|| EncodeError::LimitExceeded {
+                message: format!(
+                    "image {}x{} too large for working-set estimate",
+                    self.width, self.height
+                ),
+            })?;
+        if est_bytes > budget_cap {
+            return Err(EncodeError::LimitExceeded {
+                message: format!(
+                    "estimated working set {est_bytes} bytes for {}x{} image \
+                     exceeds budget cap {budget_cap}",
+                    self.width, self.height
+                ),
+            });
+        }
+
         let mut image = ModularImage {
             channels: self.channels,
             bit_depth: self.bit_depth,
@@ -3338,6 +3534,7 @@ impl LosslessEncoder {
                     cfg.use_ans,
                     lossless_profile.patch_ref_tree_learning,
                     &mut writer,
+                    Some(&budget),
                 )
                 .map_err(EncodeError::from)?;
                 writer.zero_pad_to_byte();
@@ -3366,7 +3563,8 @@ impl LosslessEncoder {
                     crop: None,
                     skip_rct: false,
                 },
-            );
+            )
+            .with_budget(alloc::sync::Arc::clone(&budget));
             let color_encoding = if let Some(ce) = self.color_encoding.clone() {
                 if image.is_grayscale && ce.color_space != ColorSpace::Gray {
                     ColorEncoding {
@@ -3475,6 +3673,7 @@ impl LosslessConfig {
             intensity_target: 255.0,
             min_nits: 0.0,
             intrinsic_size: None,
+            limits: None,
         })
     }
 }
@@ -3559,6 +3758,7 @@ fn encode_animation_lossless(
     layout: PixelLayout,
     animation: &AnimationParams,
     frames: &[AnimationFrame<'_>],
+    limits: Option<&Limits>,
 ) -> core::result::Result<Vec<u8>, EncodeError> {
     use crate::bit_writer::BitWriter;
     use crate::headers::file_header::AnimationHeader;
@@ -3571,6 +3771,29 @@ fn encode_animation_lossless(
     let w = width as usize;
     let h = height as usize;
     let num_frames = frames.len();
+
+    // Per-encode allocation budget. Spans the lifetime of the entire
+    // animation: every per-frame allocation charges against the same cap,
+    // so an attacker cannot multiply the working set by sending many
+    // oversized frames.
+    let budget_cap = limits
+        .map(|l| l.effective_max_memory_bytes())
+        .unwrap_or(Limits::DEFAULT_MAX_MEMORY_BYTES);
+    let budget = crate::budget::MemoryBudget::new(budget_cap);
+    let est_bytes = (width as u64)
+        .checked_mul(height as u64)
+        .and_then(|n| n.checked_mul(40))
+        .ok_or_else(|| EncodeError::LimitExceeded {
+            message: format!("image {width}x{height} too large for working-set estimate"),
+        })?;
+    if est_bytes > budget_cap {
+        return Err(EncodeError::LimitExceeded {
+            message: format!(
+                "estimated working set {est_bytes} bytes for {width}x{height} \
+                 image exceeds budget cap {budget_cap}"
+            ),
+        });
+    }
 
     // Build file header with animation
     let sample_image = match layout {
@@ -3698,7 +3921,8 @@ fn encode_animation_lossless(
                 crop,
                 skip_rct: false,
             },
-        );
+        )
+        .with_budget(alloc::sync::Arc::clone(&budget));
         frame_encoder
             .encode_modular(&image, &color_encoding, &mut writer)
             .map_err(EncodeError::from)?;
@@ -3716,6 +3940,7 @@ fn encode_animation_lossy(
     layout: PixelLayout,
     animation: &AnimationParams,
     frames: &[AnimationFrame<'_>],
+    limits: Option<&Limits>,
 ) -> core::result::Result<Vec<u8>, EncodeError> {
     use crate::bit_writer::BitWriter;
     use crate::headers::file_header::AnimationHeader;
@@ -3726,6 +3951,27 @@ fn encode_animation_lossy(
     let w = width as usize;
     let h = height as usize;
     let num_frames = frames.len();
+
+    // Per-encode allocation budget. Spans the lifetime of the entire
+    // animation; see `encode_animation_lossless` for the reasoning.
+    let budget_cap = limits
+        .map(|l| l.effective_max_memory_bytes())
+        .unwrap_or(Limits::DEFAULT_MAX_MEMORY_BYTES);
+    let budget = crate::budget::MemoryBudget::new(budget_cap);
+    let est_bytes = (width as u64)
+        .checked_mul(height as u64)
+        .and_then(|n| n.checked_mul(40))
+        .ok_or_else(|| EncodeError::LimitExceeded {
+            message: format!("image {width}x{height} too large for working-set estimate"),
+        })?;
+    if est_bytes > budget_cap {
+        return Err(EncodeError::LimitExceeded {
+            message: format!(
+                "estimated working set {est_bytes} bytes for {width}x{height} \
+                 image exceeds budget cap {budget_cap}"
+            ),
+        });
+    }
 
     // Set up VarDCT encoder
     let mut profile = cfg.effective_profile();
@@ -3774,6 +4020,7 @@ fn encode_animation_lossy(
         enc.zensim_iters = cfg.zensim_iters;
     }
     enc.non_finite_action = cfg.non_finite_action;
+    enc.budget = Some(alloc::sync::Arc::clone(&budget));
 
     // Detect alpha and 16-bit from layout
     let has_alpha = layout.has_alpha();

--- a/jxl-encoder/src/budget.rs
+++ b/jxl-encoder/src/budget.rs
@@ -1,0 +1,508 @@
+// Copyright (c) Imazen LLC and the JPEG XL Project Authors.
+// Licensed under AGPL-3.0-or-later. Commercial licenses at https://www.imazen.io/pricing
+
+//! Allocation budget tracker for the encoder.
+//!
+//! [`MemoryBudget`] is a single-encode lifetime cap on the cumulative
+//! peak bytes the encoder has reserved against a configured ceiling.
+//! Hot allocation sites reserve their expected size *before* allocating
+//! and hold an RAII [`BudgetGuard`]; when the guard drops the memory is
+//! released back to the budget. The budget is opt-in: callers that don't
+//! configure one pay essentially nothing — a single cold predicted-not-
+//! taken branch per allocation site.
+//!
+//! The cap comes from [`Limits::max_memory_bytes`] when the caller sets
+//! one, or from [`Limits::DEFAULT_MAX_MEMORY_BYTES`] otherwise.
+//!
+//! ## Coverage
+//!
+//! The tracker is best-effort: it does not intercept every heap
+//! allocation the encoder performs (small per-block scratch, internal
+//! hashmaps, the entropy-coder bit buffer, etc., are unaccounted). It
+//! DOES cover the large dimension-driven buffers — XYB planes, padded
+//! scratch, group buffers, modular channel buffers — which dominate the
+//! encoder's working set and are the attacker-controlled axis for DoS
+//! by oversized input.
+//!
+//! ## Zero overhead when unbounded
+//!
+//! Threading happens as `Option<&MemoryBudget>`. The compiler eliminates
+//! the `None` branch at every call site; the `Some` branch is a cold
+//! relaxed atomic CAS. There is no allocation, no virtual dispatch, and
+//! no extra fields on the encoder structs paid by callers who haven't
+//! configured a cap.
+//!
+//! [`Limits::max_memory_bytes`]: crate::api::Limits::max_memory_bytes
+//! [`Limits::DEFAULT_MAX_MEMORY_BYTES`]: crate::api::Limits::DEFAULT_MAX_MEMORY_BYTES
+
+use crate::error::{Error, Result};
+use alloc::sync::Arc;
+use alloc::vec;
+use alloc::vec::Vec;
+use core::sync::atomic::{AtomicU64, Ordering};
+
+/// Tracks cumulative reserved bytes against a hard cap.
+///
+/// Construct one of these at the start of an encode (or use
+/// [`MemoryBudget::unbounded`] to disable). Pass the resulting `Arc` —
+/// or, on hot paths, an `Option<&MemoryBudget>` — through to allocation
+/// sites. Each site calls [`MemoryBudget::reserve`] to obtain a
+/// [`BudgetGuard`] held alongside the buffer; when the guard drops the
+/// reservation is released, freeing peak budget for sibling allocations.
+#[derive(Debug)]
+pub(crate) struct MemoryBudget {
+    cap: u64,
+    used: AtomicU64,
+    peak: AtomicU64,
+}
+
+impl MemoryBudget {
+    /// Construct a budget with `cap` bytes available.
+    pub fn new(cap: u64) -> Arc<Self> {
+        Arc::new(Self {
+            cap,
+            used: AtomicU64::new(0),
+            peak: AtomicU64::new(0),
+        })
+    }
+
+    /// Construct a budget that never denies a reservation.
+    ///
+    /// Equivalent to `MemoryBudget::new(u64::MAX)` but more legible at
+    /// call sites. Note: this still creates an `Arc` and tracks usage —
+    /// for true zero-overhead, thread `Option<&MemoryBudget>` and pass
+    /// `None`.
+    #[cfg(test)]
+    pub fn unbounded() -> Arc<Self> {
+        Self::new(u64::MAX)
+    }
+
+    /// The cap configured for this budget.
+    #[allow(dead_code)] // exposed for diagnostics / future stats wiring
+    pub fn cap(&self) -> u64 {
+        self.cap
+    }
+
+    /// Currently-reserved bytes.
+    pub fn used(&self) -> u64 {
+        self.used.load(Ordering::Relaxed)
+    }
+
+    /// Highest cumulative usage seen during this budget's lifetime.
+    #[allow(dead_code)] // exposed for diagnostics / future stats wiring
+    pub fn peak(&self) -> u64 {
+        self.peak.load(Ordering::Relaxed)
+    }
+
+    /// Attempt to reserve `bytes` against the cap.
+    ///
+    /// On success returns a [`BudgetGuard`] whose `Drop` releases the
+    /// bytes. Hold the guard for as long as the underlying buffer is
+    /// alive; usually that means storing it next to (or inside) the
+    /// `Vec` or letting it bind to a function-scope `let _g = ...;`.
+    ///
+    /// Returns [`Error::AllocationLimit`] if the reservation would push
+    /// usage past `cap`, or [`Error::DimensionOverflow`]-flavored
+    /// `Error::InvalidInput` if `current + bytes` overflows `u64` (which
+    /// only happens with deliberately malformed input).
+    pub fn reserve(self: &Arc<Self>, bytes: u64) -> Result<BudgetGuard> {
+        self.try_reserve_raw(bytes)?;
+        Ok(BudgetGuard {
+            bytes,
+            budget: Some(Arc::clone(self)),
+        })
+    }
+
+    /// Reserve via an `Option<&MemoryBudget>`. Returns an inert guard
+    /// when `budget` is `None`, side-stepping the `Arc` clone.
+    ///
+    /// Prefer this at hot call sites that already thread the budget as
+    /// an `Option`. The `None` branch is unconditional and predicts
+    /// not-taken in the unbounded case.
+    pub fn reserve_opt(budget: Option<&Arc<MemoryBudget>>, bytes: u64) -> Result<BudgetGuard> {
+        match budget {
+            Some(b) => b.reserve(bytes),
+            None => Ok(BudgetGuard {
+                bytes: 0,
+                budget: None,
+            }),
+        }
+    }
+
+    /// Reserve `bytes` permanently — no `BudgetGuard`, no release.
+    ///
+    /// Use this for buffers that live for the full encode (XYB planes,
+    /// padded scratch, group buffers). The encoder's `MemoryBudget` is
+    /// dropped at end-of-encode regardless, so "leaking" the
+    /// reservation is structurally fine and avoids threading guards
+    /// through every consumer.
+    ///
+    /// For sibling scratch allocations whose peaks don't overlap,
+    /// prefer [`MemoryBudget::reserve`] + RAII so the encoder's high-
+    /// water mark stays accurate.
+    pub fn reserve_permanent(&self, bytes: u64) -> Result<()> {
+        self.try_reserve_raw(bytes)
+    }
+
+    /// `reserve_permanent` via an `Option<&MemoryBudget>`. No-op when
+    /// `budget` is `None`.
+    pub fn reserve_permanent_opt(budget: Option<&Arc<MemoryBudget>>, bytes: u64) -> Result<()> {
+        match budget {
+            Some(b) => b.reserve_permanent(bytes),
+            None => Ok(()),
+        }
+    }
+
+    fn try_reserve_raw(&self, bytes: u64) -> Result<()> {
+        // CAS loop: load current, check fit, store new. Bounded — under
+        // contention each retry loads a higher `used` than the previous,
+        // so we either succeed or hit the cap and bail.
+        let mut current = self.used.load(Ordering::Relaxed);
+        loop {
+            let new_used = current.checked_add(bytes).ok_or(Error::AllocationLimit {
+                requested: bytes,
+                used: current,
+                cap: self.cap,
+            })?;
+            if new_used > self.cap {
+                return Err(Error::AllocationLimit {
+                    requested: bytes,
+                    used: current,
+                    cap: self.cap,
+                });
+            }
+            match self.used.compare_exchange_weak(
+                current,
+                new_used,
+                Ordering::Relaxed,
+                Ordering::Relaxed,
+            ) {
+                Ok(_) => {
+                    // Bump the high-water mark. We don't need this to
+                    // be perfectly synchronized with `used`; a relaxed
+                    // best-effort fetch_max is fine for diagnostics.
+                    self.peak.fetch_max(new_used, Ordering::Relaxed);
+                    return Ok(());
+                }
+                Err(actual) => current = actual,
+            }
+        }
+    }
+
+    fn release(&self, bytes: u64) {
+        if bytes == 0 {
+            return;
+        }
+        // Saturating subtract — mismatched reserve/release pairs (a bug)
+        // won't underflow but will result in the budget over-reporting
+        // available space.
+        self.used
+            .fetch_sub(bytes.min(self.used()), Ordering::Relaxed);
+    }
+}
+
+/// RAII guard for an outstanding budget reservation.
+///
+/// Drop releases the bytes back to the budget. Move the guard around
+/// freely — only the final drop is observable. Forgetting (`mem::forget`)
+/// the guard leaks the reservation, which is benign: the encode is
+/// single-shot, so the budget is dropped wholesale on encode exit.
+///
+/// Most encoder buffers live for the entire encode and use
+/// [`MemoryBudget::reserve_permanent`] (no guard). Use this RAII path
+/// for sibling scratch allocations whose peaks don't overlap, where
+/// returning bytes between phases keeps the high-water mark accurate
+/// and lets a tighter cap survive the encode.
+#[must_use = "BudgetGuard releases its reservation on drop; binding to `_` defeats the budget"]
+#[derive(Debug)]
+#[allow(dead_code)] // Currently the encoder uses reserve_permanent throughout;
+// the RAII guard infrastructure is exercised by unit tests and reserved
+// for future scratch-allocation tracking (e.g., per-tile butteraugli
+// reconstruction buffers).
+pub(crate) struct BudgetGuard {
+    bytes: u64,
+    budget: Option<Arc<MemoryBudget>>,
+}
+
+#[allow(dead_code)] // see BudgetGuard above
+impl BudgetGuard {
+    /// An inert guard that owns no reservation. Useful as a default
+    /// when a function returns `Vec + Guard` and the caller hasn't
+    /// configured a budget yet.
+    pub fn inert() -> Self {
+        Self {
+            bytes: 0,
+            budget: None,
+        }
+    }
+
+    /// Bytes this guard will release on drop.
+    #[cfg(test)]
+    pub fn bytes(&self) -> u64 {
+        self.bytes
+    }
+}
+
+impl Drop for BudgetGuard {
+    fn drop(&mut self) {
+        if let Some(b) = self.budget.as_ref() {
+            b.release(self.bytes);
+        }
+    }
+}
+
+/// Compute `len * size_of::<T>()` as u64, returning an
+/// [`Error::AllocationLimit`] (with `cap=0` to flag overflow) if the
+/// multiplication would not fit, or if the byte count exceeds what can
+/// be addressed in `usize` on this platform (for example
+/// `len = usize::MAX, size = 4` on a 32-bit host: the multiply doesn't
+/// overflow `u64` but the allocation cannot be made).
+fn elem_bytes<T>(len: usize) -> Result<u64> {
+    let bytes = (len as u64)
+        .checked_mul(core::mem::size_of::<T>() as u64)
+        .ok_or(Error::AllocationLimit {
+            requested: u64::MAX,
+            used: 0,
+            cap: 0,
+        })?;
+    if bytes > usize::MAX as u64 {
+        return Err(Error::AllocationLimit {
+            requested: bytes,
+            used: 0,
+            cap: 0,
+        });
+    }
+    Ok(bytes)
+}
+
+/// Reserve and allocate a `Vec<T: Default + Clone>` of `len` elements.
+///
+/// Returns the vec paired with a [`BudgetGuard`]; both must outlive the
+/// allocation as a unit. Pass `budget = None` for zero-overhead.
+#[allow(dead_code)] // RAII helper — see BudgetGuard.
+pub(crate) fn try_alloc_vec<T: Default + Clone>(
+    budget: Option<&Arc<MemoryBudget>>,
+    len: usize,
+) -> Result<(Vec<T>, BudgetGuard)> {
+    let bytes = elem_bytes::<T>(len)?;
+    let guard = MemoryBudget::reserve_opt(budget, bytes)?;
+    Ok((vec![T::default(); len], guard))
+}
+
+/// Reserve and allocate a zero-filled `Vec<f32>` of `len` elements.
+///
+/// Specialization of [`try_alloc_vec`] for the common XYB plane case;
+/// LLVM lowers `vec![0.0f32; n]` to a single `calloc`, which is faster
+/// than the generic `T::default()` path.
+#[allow(dead_code)] // RAII helper — see BudgetGuard.
+pub(crate) fn try_alloc_vec_f32(
+    budget: Option<&Arc<MemoryBudget>>,
+    len: usize,
+) -> Result<(Vec<f32>, BudgetGuard)> {
+    let bytes = elem_bytes::<f32>(len)?;
+    let guard = MemoryBudget::reserve_opt(budget, bytes)?;
+    Ok((vec![0.0f32; len], guard))
+}
+
+/// Reserve and produce a `jxl_simd::vec_f32_dirty` of `len` elements.
+///
+/// The dirty variant skips the zero-fill — safe for buffers that the
+/// caller is about to fully overwrite. Callers should still document
+/// the overwrite invariant at the call site.
+#[allow(dead_code)] // RAII helper — see BudgetGuard.
+pub(crate) fn try_alloc_vec_f32_dirty(
+    budget: Option<&Arc<MemoryBudget>>,
+    len: usize,
+) -> Result<(Vec<f32>, BudgetGuard)> {
+    let bytes = elem_bytes::<f32>(len)?;
+    let guard = MemoryBudget::reserve_opt(budget, bytes)?;
+    Ok((jxl_simd::vec_f32_dirty(len), guard))
+}
+
+/// Reserve permanently and allocate a zero-filled `Vec<f32>`. Suitable
+/// for whole-encode buffers (XYB planes, padded scratch) where there's
+/// no point pretending the bytes will be released before the budget
+/// itself is dropped.
+#[allow(dead_code)] // Currently the encoder uses _dirty_permanent for all XYB
+// allocations; this is here for future zero-init plane sites.
+pub(crate) fn try_alloc_vec_f32_permanent(
+    budget: Option<&Arc<MemoryBudget>>,
+    len: usize,
+) -> Result<Vec<f32>> {
+    let bytes = elem_bytes::<f32>(len)?;
+    MemoryBudget::reserve_permanent_opt(budget, bytes)?;
+    Ok(vec![0.0f32; len])
+}
+
+/// Reserve permanently and allocate a `vec_f32_dirty`.
+pub(crate) fn try_alloc_vec_f32_dirty_permanent(
+    budget: Option<&Arc<MemoryBudget>>,
+    len: usize,
+) -> Result<Vec<f32>> {
+    let bytes = elem_bytes::<f32>(len)?;
+    MemoryBudget::reserve_permanent_opt(budget, bytes)?;
+    Ok(jxl_simd::vec_f32_dirty(len))
+}
+
+/// Convenience macro: `try_alloc_plane_f32!(budget, w, h)` reserves and
+/// allocates a `width * height` `f32` plane, propagating allocation
+/// errors with `?`.
+///
+/// Expands to a `(Vec<f32>, BudgetGuard)` tuple. Pair the guard with
+/// the vec for the lifetime of the allocation.
+#[macro_export]
+#[doc(hidden)]
+macro_rules! try_alloc_plane_f32 {
+    ($budget:expr, $width:expr, $height:expr) => {{
+        let __w: usize = $width;
+        let __h: usize = $height;
+        let __n = __w
+            .checked_mul(__h)
+            .ok_or_else(|| $crate::error::Error::DimensionOverflow {
+                width: __w,
+                height: __h,
+                channels: 1,
+            })?;
+        $crate::budget::try_alloc_vec_f32($budget, __n)
+    }};
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn under_cap_succeeds() {
+        let b = MemoryBudget::new(1024);
+        let _g = b.reserve(512).unwrap();
+        assert_eq!(b.used(), 512);
+    }
+
+    #[test]
+    fn over_cap_fails_with_allocation_limit() {
+        let b = MemoryBudget::new(1024);
+        let err = b.reserve(2048).unwrap_err();
+        match err {
+            Error::AllocationLimit {
+                requested,
+                used,
+                cap,
+            } => {
+                assert_eq!(requested, 2048);
+                assert_eq!(used, 0);
+                assert_eq!(cap, 1024);
+            }
+            other => panic!("expected AllocationLimit, got {other:?}"),
+        }
+        assert_eq!(b.used(), 0);
+    }
+
+    #[test]
+    fn drop_releases_bytes() {
+        let b = MemoryBudget::new(1024);
+        {
+            let _g = b.reserve(500).unwrap();
+            assert_eq!(b.used(), 500);
+        }
+        assert_eq!(b.used(), 0);
+    }
+
+    #[test]
+    fn nested_guards_release_in_order() {
+        let b = MemoryBudget::new(1024);
+        let g1 = b.reserve(400).unwrap();
+        let g2 = b.reserve(400).unwrap();
+        assert_eq!(b.used(), 800);
+        drop(g2);
+        assert_eq!(b.used(), 400);
+        drop(g1);
+        assert_eq!(b.used(), 0);
+    }
+
+    #[test]
+    fn peak_records_high_water_mark() {
+        let b = MemoryBudget::new(2048);
+        {
+            let _g1 = b.reserve(800).unwrap();
+            let _g2 = b.reserve(700).unwrap();
+        }
+        assert_eq!(b.used(), 0);
+        assert_eq!(b.peak(), 1500);
+        let _g3 = b.reserve(900).unwrap();
+        assert_eq!(b.peak(), 1500); // 900 < 1500
+    }
+
+    #[test]
+    fn cumulative_with_dropped_guards() {
+        let b = MemoryBudget::new(1024);
+        {
+            let _g = b.reserve(800).unwrap();
+        }
+        // After drop, the next reservation should fit.
+        let _g = b.reserve(800).unwrap();
+        assert_eq!(b.used(), 800);
+    }
+
+    #[test]
+    fn unbounded_never_denies() {
+        let b = MemoryBudget::unbounded();
+        let _g1 = b.reserve(u64::MAX / 2).unwrap();
+        let _g2 = b.reserve(u64::MAX / 2).unwrap();
+        // Pushing past u64::MAX overflows, surfaced as AllocationLimit.
+        assert!(b.reserve(2).is_err());
+    }
+
+    #[test]
+    fn reserve_opt_none_is_inert() {
+        let g = MemoryBudget::reserve_opt(None, 1 << 60).unwrap();
+        assert_eq!(g.bytes(), 0);
+    }
+
+    #[test]
+    fn reserve_opt_some_tracks() {
+        let b = MemoryBudget::new(1024);
+        let g = MemoryBudget::reserve_opt(Some(&b), 256).unwrap();
+        assert_eq!(b.used(), 256);
+        assert_eq!(g.bytes(), 256);
+        drop(g);
+        assert_eq!(b.used(), 0);
+    }
+
+    #[test]
+    fn try_alloc_vec_f32_succeeds() {
+        let b = MemoryBudget::new(4096);
+        let (v, _g) = try_alloc_vec_f32(Some(&b), 256).unwrap();
+        assert_eq!(v.len(), 256);
+        assert_eq!(b.used(), 256 * 4);
+    }
+
+    #[test]
+    fn try_alloc_vec_f32_over_cap() {
+        let b = MemoryBudget::new(64);
+        assert!(try_alloc_vec_f32(Some(&b), 256).is_err());
+        assert_eq!(b.used(), 0);
+    }
+
+    #[test]
+    fn try_alloc_vec_f32_unbounded() {
+        let (v, g) = try_alloc_vec_f32(None, 256).unwrap();
+        assert_eq!(v.len(), 256);
+        assert_eq!(g.bytes(), 0);
+    }
+
+    #[test]
+    fn try_alloc_plane_macro() {
+        fn run() -> Result<()> {
+            let b = MemoryBudget::new(1024 * 1024);
+            let (v, _g) = try_alloc_plane_f32!(Some(&b), 100usize, 100usize)?;
+            assert_eq!(v.len(), 10000);
+            Ok(())
+        }
+        run().unwrap();
+    }
+
+    #[test]
+    fn elem_bytes_overflow_caught() {
+        assert!(elem_bytes::<f32>(usize::MAX).is_err());
+    }
+}

--- a/jxl-encoder/src/error.rs
+++ b/jxl-encoder/src/error.rs
@@ -49,6 +49,17 @@ pub enum Error {
     #[error("Invalid input: {0}")]
     InvalidInput(String),
 
+    /// A configured memory-allocation budget would be exceeded.
+    ///
+    /// Distinct from [`Error::OutOfMemory`] (which is the system
+    /// allocator returning failure) and [`Error::InvalidInput`] (which
+    /// is parameter validation). The encoder raises this *before*
+    /// touching the heap when an upcoming `Vec::with_capacity` or
+    /// equivalent would push cumulative reservations past the cap
+    /// configured via [`crate::api::Limits::max_memory_bytes`].
+    #[error("memory budget exceeded: requested {requested} bytes on top of {used} (cap {cap})")]
+    AllocationLimit { requested: u64, used: u64, cap: u64 },
+
     // Entropy coding errors
     #[error("Invalid histogram: {0}")]
     InvalidHistogram(String),

--- a/jxl-encoder/src/lib.rs
+++ b/jxl-encoder/src/lib.rs
@@ -13,6 +13,7 @@ extern crate alloc;
 
 pub mod api;
 pub mod bit_writer;
+pub(crate) mod budget;
 pub mod color;
 pub mod container;
 pub mod debug_rect;

--- a/jxl-encoder/src/modular/channel.rs
+++ b/jxl-encoder/src/modular/channel.rs
@@ -36,6 +36,20 @@ pub struct Channel {
 impl Channel {
     /// Creates a new channel filled with zeros.
     pub fn new(width: usize, height: usize) -> Result<Self> {
+        Self::new_with_budget(width, height, None)
+    }
+
+    /// Creates a new channel filled with zeros, charging the
+    /// allocation against an optional [`MemoryBudget`].
+    ///
+    /// `budget = None` is equivalent to [`Channel::new`] and pays
+    /// essentially nothing at runtime — a single cold predicted-not-
+    /// taken atomic load.
+    pub(crate) fn new_with_budget(
+        width: usize,
+        height: usize,
+        budget: Option<&alloc::sync::Arc<crate::budget::MemoryBudget>>,
+    ) -> Result<Self> {
         if width == 0 || height == 0 {
             return Err(Error::InvalidImageDimensions(width, height));
         }
@@ -43,6 +57,10 @@ impl Channel {
         let size = width
             .checked_mul(height)
             .ok_or(Error::InvalidImageDimensions(width, height))?;
+
+        // Channel data is `Vec<i32>` — 4 bytes per entry.
+        let bytes = (size as u64).saturating_mul(core::mem::size_of::<i32>() as u64);
+        crate::budget::MemoryBudget::reserve_permanent_opt(budget, bytes)?;
 
         let mut data = Vec::new();
         data.try_reserve_exact(size)?;
@@ -262,6 +280,17 @@ pub struct ModularImage {
 impl ModularImage {
     /// Creates a new modular image from 8-bit RGB data.
     pub fn from_rgb8(data: &[u8], width: usize, height: usize) -> Result<Self> {
+        Self::from_rgb8_with_budget(data, width, height, None)
+    }
+
+    /// Build a 3-channel modular image from interleaved RGB8, charging
+    /// the resulting channel allocations against an optional budget.
+    pub(crate) fn from_rgb8_with_budget(
+        data: &[u8],
+        width: usize,
+        height: usize,
+        budget: Option<&alloc::sync::Arc<crate::budget::MemoryBudget>>,
+    ) -> Result<Self> {
         let expected = width
             .checked_mul(height)
             .and_then(|n| n.checked_mul(3))
@@ -276,7 +305,7 @@ impl ModularImage {
 
         let mut channels = Vec::with_capacity(3);
         for c in 0..3 {
-            let mut channel = Channel::new(width, height)?;
+            let mut channel = Channel::new_with_budget(width, height, budget)?;
             for y in 0..height {
                 for x in 0..width {
                     let idx = (y * width + x) * 3 + c;
@@ -296,6 +325,17 @@ impl ModularImage {
 
     /// Creates a new modular image from 8-bit RGBA data.
     pub fn from_rgba8(data: &[u8], width: usize, height: usize) -> Result<Self> {
+        Self::from_rgba8_with_budget(data, width, height, None)
+    }
+
+    /// Build a 4-channel modular image from interleaved RGBA8, charging
+    /// the resulting channel allocations against an optional budget.
+    pub(crate) fn from_rgba8_with_budget(
+        data: &[u8],
+        width: usize,
+        height: usize,
+        budget: Option<&alloc::sync::Arc<crate::budget::MemoryBudget>>,
+    ) -> Result<Self> {
         let expected = width
             .checked_mul(height)
             .and_then(|n| n.checked_mul(4))
@@ -310,7 +350,7 @@ impl ModularImage {
 
         let mut channels = Vec::with_capacity(4);
         for c in 0..4 {
-            let mut channel = Channel::new(width, height)?;
+            let mut channel = Channel::new_with_budget(width, height, budget)?;
             for y in 0..height {
                 for x in 0..width {
                     let idx = (y * width + x) * 4 + c;

--- a/jxl-encoder/src/modular/encode.rs
+++ b/jxl-encoder/src/modular/encode.rs
@@ -487,6 +487,7 @@ pub fn write_modular_stream_with_palette(
 ///
 /// The lossy palette quantizes colors to a small palette + delta entries,
 /// producing smaller files at the cost of some color accuracy.
+#[allow(dead_code)] // public wrapper; internal callers thread budget via the `_budget` variant
 pub fn write_modular_stream_with_lossy_palette(
     image: &ModularImage,
     writer: &mut BitWriter,
@@ -495,10 +496,40 @@ pub fn write_modular_stream_with_lossy_palette(
     num_c: usize,
     max_palette_colors: usize,
 ) -> Result<()> {
-    use super::palette::apply_lossy_palette;
+    write_modular_stream_with_lossy_palette_budget(
+        image,
+        writer,
+        use_ans,
+        begin_c,
+        num_c,
+        max_palette_colors,
+        None,
+    )
+}
+
+/// `write_modular_stream_with_lossy_palette` with explicit allocation
+/// budget. The budget is forwarded to `apply_lossy_palette` so the
+/// dim-driven scratch buffers (deltas, quant rows, error diffusion,
+/// index channel) are charged against the per-encode cap.
+pub(crate) fn write_modular_stream_with_lossy_palette_budget(
+    image: &ModularImage,
+    writer: &mut BitWriter,
+    use_ans: bool,
+    begin_c: usize,
+    num_c: usize,
+    max_palette_colors: usize,
+    budget: Option<&alloc::sync::Arc<crate::budget::MemoryBudget>>,
+) -> Result<()> {
+    use super::palette::apply_lossy_palette_with_budget;
 
     let mut transformed = image.clone();
-    let result = apply_lossy_palette(&mut transformed, begin_c, num_c, max_palette_colors);
+    let result = apply_lossy_palette_with_budget(
+        &mut transformed,
+        begin_c,
+        num_c,
+        max_palette_colors,
+        budget,
+    );
 
     let result = match result {
         Some(r) => r,
@@ -816,6 +847,19 @@ pub fn write_modular_stream_with_weighted(
     writer: &mut BitWriter,
     use_ans: bool,
 ) -> Result<()> {
+    write_modular_stream_with_weighted_with_budget(image, writer, use_ans, None)
+}
+
+/// `write_modular_stream_with_weighted` with explicit allocation budget.
+///
+/// Per-channel `WeightedPredictorState` scratch is reserved against the
+/// cap. `budget = None` is zero-overhead.
+pub(crate) fn write_modular_stream_with_weighted_with_budget(
+    image: &ModularImage,
+    writer: &mut BitWriter,
+    use_ans: bool,
+    budget: Option<&alloc::sync::Arc<crate::budget::MemoryBudget>>,
+) -> Result<()> {
     use super::predictor::{Neighbors, WeightedPredictorParams, WeightedPredictorState};
 
     let params = WeightedPredictorParams::default();
@@ -826,7 +870,7 @@ pub fn write_modular_stream_with_weighted(
     for channel in &image.channels {
         let width = channel.width();
         let height = channel.height();
-        let mut wp_state = WeightedPredictorState::new(&params, width);
+        let mut wp_state = WeightedPredictorState::new_with_budget(&params, width, budget)?;
 
         for y in 0..height {
             for x in 0..width {
@@ -883,6 +927,19 @@ pub fn write_modular_stream_with_rct_weighted(
     writer: &mut BitWriter,
     use_ans: bool,
 ) -> Result<()> {
+    write_modular_stream_with_rct_weighted_with_budget(image, writer, use_ans, None)
+}
+
+/// `write_modular_stream_with_rct_weighted` with explicit allocation budget.
+///
+/// Per-channel `WeightedPredictorState` scratch is reserved against the
+/// cap. `budget = None` is zero-overhead.
+pub(crate) fn write_modular_stream_with_rct_weighted_with_budget(
+    image: &ModularImage,
+    writer: &mut BitWriter,
+    use_ans: bool,
+    budget: Option<&alloc::sync::Arc<crate::budget::MemoryBudget>>,
+) -> Result<()> {
     use super::predictor::{Neighbors, WeightedPredictorParams, WeightedPredictorState};
 
     // Check if palette is more beneficial
@@ -891,7 +948,7 @@ pub fn write_modular_stream_with_rct_weighted(
     }
 
     if image.channels.len() < 3 {
-        return write_modular_stream_with_weighted(image, writer, use_ans);
+        return write_modular_stream_with_weighted_with_budget(image, writer, use_ans, budget);
     }
 
     let mut transformed = image.clone();
@@ -906,7 +963,7 @@ pub fn write_modular_stream_with_rct_weighted(
     for channel in &transformed.channels {
         let width = channel.width();
         let height = channel.height();
-        let mut wp_state = WeightedPredictorState::new(&params, width);
+        let mut wp_state = WeightedPredictorState::new_with_budget(&params, width, budget)?;
 
         for y in 0..height {
             for x in 0..width {

--- a/jxl-encoder/src/modular/frame.rs
+++ b/jxl-encoder/src/modular/frame.rs
@@ -88,6 +88,11 @@ pub struct FrameEncoder {
     #[allow(dead_code)]
     /// Number of extra channels (e.g., 1 for alpha).
     num_extra_channels: usize,
+    /// Optional per-encode allocation budget. When present, dimension-
+    /// driven heap allocations inside the modular path charge against
+    /// the cap and fail with [`crate::error::Error::AllocationLimit`]
+    /// rather than panicking on OOM.
+    pub(crate) budget: Option<alloc::sync::Arc<crate::budget::MemoryBudget>>,
 }
 
 impl FrameEncoder {
@@ -98,6 +103,7 @@ impl FrameEncoder {
             width,
             height,
             num_extra_channels: 0,
+            budget: None,
         }
     }
 
@@ -113,7 +119,19 @@ impl FrameEncoder {
             width,
             height,
             num_extra_channels,
+            budget: None,
         }
+    }
+
+    /// Attach a per-encode allocation budget. Returns `self` for builder
+    /// chaining. Caller-supplied budget is threaded through to the
+    /// modular path's hot allocation sites.
+    pub(crate) fn with_budget(
+        mut self,
+        budget: alloc::sync::Arc<crate::budget::MemoryBudget>,
+    ) -> Self {
+        self.budget = Some(budget);
+        self
     }
 
     /// Encodes a modular image into a frame with optional patches.
@@ -178,13 +196,14 @@ impl FrameEncoder {
 
             if self.options.lossy_palette && image.channels.len() >= 3 {
                 let max_colors = 1usize << image.bit_depth.min(12);
-                super::encode::write_modular_stream_with_lossy_palette(
+                super::encode::write_modular_stream_with_lossy_palette_budget(
                     image,
                     &mut section_writer,
                     self.options.use_ans,
                     0,
                     image.channels.len().min(3),
                     max_colors,
+                    self.budget.as_ref(),
                 )?;
             } else if has_squeeze && self.options.use_tree_learning && self.options.use_ans {
                 super::encode::write_modular_stream_with_squeeze_and_tree(
@@ -279,13 +298,14 @@ impl FrameEncoder {
             if self.options.lossy_palette && image.channels.len() >= 3 {
                 // Lossy delta palette: near-lossless with error diffusion
                 let max_colors = 1usize << image.bit_depth.min(12);
-                super::encode::write_modular_stream_with_lossy_palette(
+                super::encode::write_modular_stream_with_lossy_palette_budget(
                     image,
                     &mut section_writer,
                     self.options.use_ans,
                     0,
                     image.channels.len().min(3),
                     max_colors,
+                    self.budget.as_ref(),
                 )?;
             } else if has_squeeze && self.options.use_tree_learning && self.options.use_ans {
                 // Combined squeeze + tree learning: best compression
@@ -740,7 +760,13 @@ impl FrameEncoder {
         let mut transformed = image.clone();
         let max_colors = 1usize << image.bit_depth.min(12);
         let num_c = image.channels.len().min(3);
-        let result = super::palette::apply_lossy_palette(&mut transformed, 0, num_c, max_colors);
+        let result = super::palette::apply_lossy_palette_with_budget(
+            &mut transformed,
+            0,
+            num_c,
+            max_colors,
+            self.budget.as_ref(),
+        );
         let result = match result {
             Some(r) => r,
             None => {
@@ -1411,8 +1437,9 @@ impl FrameEncoder {
         use super::squeeze::{apply_squeeze, default_squeeze_params};
         use super::tree::count_contexts;
         use super::tree_learn::{
-            TreeLearningParams, TreeSamples, collect_residuals_with_tree, compute_best_tree,
-            compute_gather_stride_from_profile, gather_samples_strided,
+            TreeLearningParams, TreeSamples, collect_residuals_with_tree_with_budget,
+            compute_best_tree_with_budget, compute_gather_stride_from_profile,
+            gather_samples_strided_with_budget,
         };
         use crate::entropy_coding::encode::build_entropy_code_ans_with_options;
         use crate::entropy_coding::encode::{write_entropy_code_ans, write_tokens_ans};
@@ -1505,7 +1532,15 @@ impl FrameEncoder {
             has_alpha: false,
         };
         // group_id=0 for global section, channel_offset=0
-        gather_samples_strided(&mut samples, &global_sub, 0, 0, stride, &wp_params);
+        gather_samples_strided_with_budget(
+            &mut samples,
+            &global_sub,
+            0,
+            0,
+            stride,
+            &wp_params,
+            self.budget.as_ref(),
+        )?;
 
         // 3b: LfGroup channels — crop to each LfGroup rect
         let num_lf_groups_x = self.width.div_ceil(lf_group_dim);
@@ -1570,14 +1605,15 @@ impl FrameEncoder {
                 has_alpha: false,
             };
             // stream_id for LfGroup: ModularLF(lg) = 1 + num_lf_groups + lg
-            gather_samples_strided(
+            gather_samples_strided_with_budget(
                 &mut samples,
                 &sub_image,
                 (stream_id_lf_base + lg) as u32,
                 0,
                 stride,
                 &wp_params,
-            );
+                self.budget.as_ref(),
+            )?;
         }
 
         // 3c: PassGroup channels — crop to each group rect
@@ -1606,14 +1642,15 @@ impl FrameEncoder {
                 has_alpha: false,
             };
             // stream_id for PassGroup: ModularHF(pass=0, group=g) = 1 + 3*num_lf_groups + 17 + g
-            gather_samples_strided(
+            gather_samples_strided_with_budget(
                 &mut samples,
                 &sub_image,
                 (stream_id_hf_base + g) as u32,
                 0,
                 stride,
                 &wp_params,
-            );
+                self.budget.as_ref(),
+            )?;
         }
 
         // Step 4: Learn tree
@@ -1625,7 +1662,7 @@ impl FrameEncoder {
         let tree_params = TreeLearningParams::from_profile(&self.options.profile)
             .with_pixel_fraction(pixel_fraction)
             .with_total_pixels(total_pixels);
-        let tree = compute_best_tree(&mut samples, &tree_params);
+        let tree = compute_best_tree_with_budget(&mut samples, &tree_params, self.budget.as_ref())?;
         let num_contexts = count_contexts(&tree) as usize;
 
         crate::trace::debug_eprintln!(
@@ -1638,7 +1675,13 @@ impl FrameEncoder {
 
         // Step 5: Collect residuals per section with the learned tree
         // Global section tokens
-        let mut global_tokens = collect_residuals_with_tree(&global_sub, &tree, 0, &wp_params);
+        let mut global_tokens = collect_residuals_with_tree_with_budget(
+            &global_sub,
+            &tree,
+            0,
+            &wp_params,
+            self.budget.as_ref(),
+        )?;
 
         // LfGroup section tokens
         let mut lf_group_tokens: Vec<Vec<AnsToken>> = Vec::with_capacity(num_lf_groups);
@@ -1653,12 +1696,13 @@ impl FrameEncoder {
                 is_grayscale: squeezed.is_grayscale,
                 has_alpha: false,
             };
-            let tokens = collect_residuals_with_tree(
+            let tokens = collect_residuals_with_tree_with_budget(
                 &sub_image,
                 &tree,
                 (stream_id_lf_base + lg) as u32,
                 &wp_params,
-            );
+                self.budget.as_ref(),
+            )?;
             lf_group_tokens.push(tokens);
         }
 
@@ -1675,12 +1719,13 @@ impl FrameEncoder {
                 is_grayscale: squeezed.is_grayscale,
                 has_alpha: false,
             };
-            let tokens = collect_residuals_with_tree(
+            let tokens = collect_residuals_with_tree_with_budget(
                 &sub_image,
                 &tree,
                 (stream_id_hf_base + g) as u32,
                 &wp_params,
-            );
+                self.budget.as_ref(),
+            )?;
             pass_group_tokens.push(tokens);
         }
 

--- a/jxl-encoder/src/modular/palette.rs
+++ b/jxl-encoder/src/modular/palette.rs
@@ -496,11 +496,31 @@ pub struct LossyPaletteResult {
 /// 2. Second pass applies the palette with error diffusion, using discovered deltas.
 ///
 /// Returns `Some(LossyPaletteResult)` on success, `None` if palette is not beneficial.
+#[allow(dead_code)] // public wrapper; internal callers thread budget via `_with_budget`
 pub fn apply_lossy_palette(
     image: &mut ModularImage,
     begin_c: usize,
     num_c: usize,
     max_palette_colors: usize,
+) -> Option<LossyPaletteResult> {
+    apply_lossy_palette_with_budget(image, begin_c, num_c, max_palette_colors, None)
+}
+
+/// `apply_lossy_palette` with explicit allocation budget. Dimension-
+/// driven scratch (`width × height` delta channels, palette data, error
+/// diffusion rows, quantized output rows) is reserved against the cap;
+/// the function returns `None` on budget exhaustion as well as on
+/// "palette not beneficial".
+///
+/// Pass `budget = None` for zero-overhead, equivalent to
+/// [`apply_lossy_palette`].
+#[allow(clippy::needless_range_loop)]
+pub(crate) fn apply_lossy_palette_with_budget(
+    image: &mut ModularImage,
+    begin_c: usize,
+    num_c: usize,
+    max_palette_colors: usize,
+    budget: Option<&alloc::sync::Arc<crate::budget::MemoryBudget>>,
 ) -> Option<LossyPaletteResult> {
     if num_c < 3 || image.bit_depth < 8 {
         return None;
@@ -518,13 +538,20 @@ pub fn apply_lossy_palette(
     let mut color_freq: BTreeMap<Vec<i32>, usize> = BTreeMap::new();
     let mut cross_colors: BTreeMap<Vec<i32>, usize> = BTreeMap::new();
 
-    // Count all color frequencies and cross-pattern colors
+    // Count all color frequencies and cross-pattern colors.
+    //
+    // `apply_lossy_palette_with_budget` requires `num_c >= 3` and
+    // downstream loops cap at `num_c.min(3)`, so the color tuple key is
+    // a stack-allocated `[i32; 3]` rather than a per-pixel `Vec<i32>` —
+    // saves a heap allocation per pixel on the hot path.
+    let cmin = num_c.min(3);
     for y in 0..height {
         for x in 0..width {
-            let color: Vec<i32> = (begin_c..begin_c + num_c)
-                .map(|c| image.channels[c].get(x, y))
-                .collect();
-            *color_freq.entry(color.clone()).or_insert(0) += 1;
+            let mut color = [0i32; 3];
+            for (i, c) in (begin_c..begin_c + cmin).enumerate() {
+                color[i] = image.channels[c].get(x, y);
+            }
+            *color_freq.entry(color.to_vec()).or_insert(0) += 1;
 
             // Check cross pattern (center matches all 4 neighbors)
             if x > 0 && x + 1 < width && y > 0 && y + 1 < height {
@@ -534,12 +561,12 @@ pub fn apply_lossy_palette(
                         .all(|&(dx, dy)| {
                             let nx = (x as i32 + dx) as usize;
                             let ny = (y as i32 + dy) as usize;
-                            (begin_c..begin_c + num_c)
+                            (begin_c..begin_c + cmin)
                                 .enumerate()
                                 .all(|(i, c)| image.channels[c].get(nx, ny) == color[i])
                         });
                 if makes_cross {
-                    *cross_colors.entry(color).or_insert(0) += 1;
+                    *cross_colors.entry(color.to_vec()).or_insert(0) += 1;
                 }
             }
         }
@@ -577,9 +604,12 @@ pub fn apply_lossy_palette(
             if candidate_palette.len() >= max_palette_colors {
                 break;
             }
-            let color: Vec<i32> = (begin_c..begin_c + num_c)
-                .map(|c| image.channels[c].get(x, y))
-                .collect();
+            // Stack-allocated 3-channel color (see note above on `cmin`).
+            let mut color_arr = [0i32; 3];
+            for (i, c) in (begin_c..begin_c + cmin).enumerate() {
+                color_arr[i] = image.channels[c].get(x, y);
+            }
+            let color = color_arr.to_vec();
             if palette_set.contains_key(&color) {
                 continue;
             }
@@ -603,8 +633,15 @@ pub fn apply_lossy_palette(
         return None;
     }
 
-    // Pass 1: collect deltas (residuals from prediction) for each pixel
-    // Use a simple quantized image to get predictions
+    // Pass 1: collect deltas (residuals from prediction) for each pixel.
+    // Reserve all four `num_pixels`-sized scratch buffers up front
+    // against the budget (3 × i32 + 1 × f32 = 16 B/pixel). Returning
+    // `None` on cap exhaustion mirrors the "palette not beneficial"
+    // bailout — encode falls back to the lossless RCT path.
+    let pass1_bytes = (num_pixels as u64).saturating_mul(16);
+    if crate::budget::MemoryBudget::reserve_permanent_opt(budget, pass1_bytes).is_err() {
+        return None;
+    }
     let mut deltas_r: Vec<i32> = Vec::with_capacity(num_pixels);
     let mut deltas_g: Vec<i32> = Vec::with_capacity(num_pixels);
     let mut deltas_b: Vec<i32> = Vec::with_capacity(num_pixels);
@@ -617,7 +654,16 @@ pub fn apply_lossy_palette(
 
     // Build palette data array for get_palette_value lookups
     let palette_row_stride = total_palette_size;
-    let mut palette_data = vec![0i32; num_c * palette_row_stride.max(1)];
+    let palette_data_len = num_c.saturating_mul(palette_row_stride.max(1));
+    if crate::budget::MemoryBudget::reserve_permanent_opt(
+        budget,
+        (palette_data_len as u64).saturating_mul(4),
+    )
+    .is_err()
+    {
+        return None;
+    }
+    let mut palette_data = vec![0i32; palette_data_len];
     for (i, color) in candidate_palette.iter().enumerate() {
         for (c, &val) in color.iter().enumerate() {
             palette_data[c * palette_row_stride + nb_deltas_pass1 + i] = val;
@@ -642,6 +688,11 @@ pub fn apply_lossy_palette(
     // calloc-zeroed allocation of `width * height * 12` bytes replaces the
     // previous `Vec<Vec<[i32; 3]>>` (1 + height allocations). We split off the
     // current row as `&mut [[i32; 3]]` and look at the previous row as `&[[i32; 3]]`.
+    // Reserve the dim-driven 12 B/pixel grid against the budget.
+    let quant_grid_bytes = (num_pixels as u64).saturating_mul(12);
+    if crate::budget::MemoryBudget::reserve_permanent_opt(budget, quant_grid_bytes).is_err() {
+        return None;
+    }
     let mut quant_grid: Vec<[i32; 3]> = vec![[0i32; 3]; width * height];
     for y in 0..height {
         let (prev_part, curr_part) = quant_grid.split_at_mut(y * width);
@@ -652,27 +703,28 @@ pub fn apply_lossy_palette(
         };
         let qrow: &mut [[i32; 3]] = &mut curr_part[..width];
         for x in 0..width {
-            let color: Vec<i32> = (begin_c..begin_c + num_c)
-                .map(|c| image.channels[c].get(x, y))
-                .collect();
-            let color_f: Vec<f32> = color.iter().map(|&v| v as f32).collect();
+            // Stack-allocated 3-channel color (see `cmin` note above).
+            let mut color = [0i32; 3];
+            for (i, c) in (begin_c..begin_c + cmin).enumerate() {
+                color[i] = image.channels[c].get(x, y);
+            }
+            let color_f: [f32; 3] = [color[0] as f32, color[1] as f32, color[2] as f32];
 
             // Get prediction from quantized neighbors
-            let predictions: Vec<i32> = (0..num_c.min(3))
-                .map(|c| {
-                    let w = if x > 0 { qrow[x - 1][c] } else { 0 };
-                    let n = prev_row.map_or(0, |r| r[x][c]);
-                    let nw = if x > 0 {
-                        prev_row.map_or(0, |r| r[x - 1][c])
-                    } else {
-                        0
-                    };
-                    let grad = n as i64 + w as i64 - nw as i64;
-                    let lo = n.min(w) as i64;
-                    let hi = n.max(w) as i64;
-                    grad.clamp(lo, hi) as i32
-                })
-                .collect();
+            let mut predictions = [0i32; 3];
+            for c in 0..num_c.min(3) {
+                let w = if x > 0 { qrow[x - 1][c] } else { 0 };
+                let n = prev_row.map_or(0, |r| r[x][c]);
+                let nw = if x > 0 {
+                    prev_row.map_or(0, |r| r[x - 1][c])
+                } else {
+                    0
+                };
+                let grad = n as i64 + w as i64 - nw as i64;
+                let lo = n.min(w) as i64;
+                let hi = n.max(w) as i64;
+                predictions[c] = grad.clamp(lo, hi) as i32;
+            }
 
             // Try all palette entries, implicit cubes
             let mut best_index = 0i32;
@@ -826,7 +878,16 @@ pub fn apply_lossy_palette(
 
     // Build final palette data
     let final_row_stride = total_size.max(1);
-    let mut final_palette_data = vec![0i32; num_c * final_row_stride];
+    let final_palette_len = num_c.saturating_mul(final_row_stride);
+    if crate::budget::MemoryBudget::reserve_permanent_opt(
+        budget,
+        (final_palette_len as u64).saturating_mul(4),
+    )
+    .is_err()
+    {
+        return None;
+    }
+    let mut final_palette_data = vec![0i32; final_palette_len];
 
     // Write deltas first
     for (i, delta) in frequent_deltas.iter().enumerate() {
@@ -850,7 +911,19 @@ pub fn apply_lossy_palette(
         inv_palette2.entry(color.clone()).or_insert(total_size + k);
     }
 
-    // Error diffusion buffers: 3 rows, each with width + 4 padding
+    // Error diffusion buffers: 3 rows × (width + 4) × [f32; 3] = 36 B/col.
+    // Quant_out grid: height × width × [i32; 3] = 12 B/pixel.
+    let edge_w = width.saturating_add(4);
+    let error_rows_bytes = (edge_w as u64).saturating_mul(36 * 3);
+    let quant_out_bytes = (num_pixels as u64).saturating_mul(12);
+    if crate::budget::MemoryBudget::reserve_permanent_opt(
+        budget,
+        error_rows_bytes.saturating_add(quant_out_bytes),
+    )
+    .is_err()
+    {
+        return None;
+    }
     let mut error_rows: [Vec<[f32; 3]>; 3] = [
         vec![[0.0; 3]; width + 4],
         vec![[0.0; 3]; width + 4],
@@ -864,16 +937,18 @@ pub fn apply_lossy_palette(
     // replaces the previous `Vec<Vec<[i32; 3]>>` (1 + height allocations).
     let mut quant_out: Vec<[i32; 3]> = vec![[0i32; 3]; width * height];
 
-    // Create palette channel (total_size wide, num_c high)
-    let mut palette_channel = Channel::new(total_size, num_c).ok()?;
+    // Create palette channel (total_size wide, num_c high). Tiny —
+    // bounded by max_palette_colors + LARGE_CUBE_OFFSET, not dim-driven.
+    let mut palette_channel = Channel::new_with_budget(total_size, num_c, budget).ok()?;
     for c in 0..num_c {
         for i in 0..total_size {
             palette_channel.set(i, c, final_palette_data[c * final_row_stride + i]);
         }
     }
 
-    // Create index channel
-    let mut index_channel = Channel::new(width, height).ok()?;
+    // Create index channel — `width × height × i32` is dim-driven and
+    // routed through the budget-aware constructor.
+    let mut index_channel = Channel::new_with_budget(width, height, budget).ok()?;
     let mut delta_used = false;
 
     for y in 0..height {
@@ -885,26 +960,27 @@ pub fn apply_lossy_palette(
         };
         let qrow: &mut [[i32; 3]] = &mut curr_part[..width];
         for x in 0..width {
-            let orig_color: Vec<i32> = (begin_c..begin_c + num_c)
-                .map(|c| image.channels[c].get(x, y))
-                .collect();
+            // Stack-allocated 3-channel color (see `cmin` note above).
+            let mut orig_color = [0i32; 3];
+            for (i, c) in (begin_c..begin_c + cmin).enumerate() {
+                orig_color[i] = image.channels[c].get(x, y);
+            }
 
             // Get prediction from quantized neighbors
-            let predictions: Vec<i32> = (0..num_c.min(3))
-                .map(|c| {
-                    let w = if x > 0 { qrow[x - 1][c] } else { 0 };
-                    let n = prev_row.map_or(0, |r| r[x][c]);
-                    let nw = if x > 0 {
-                        prev_row.map_or(0, |r| r[x - 1][c])
-                    } else {
-                        0
-                    };
-                    let grad = n as i64 + w as i64 - nw as i64;
-                    let lo = n.min(w) as i64;
-                    let hi = n.max(w) as i64;
-                    grad.clamp(lo, hi) as i32
-                })
-                .collect();
+            let mut predictions = [0i32; 3];
+            for c in 0..num_c.min(3) {
+                let w = if x > 0 { qrow[x - 1][c] } else { 0 };
+                let n = prev_row.map_or(0, |r| r[x][c]);
+                let nw = if x > 0 {
+                    prev_row.map_or(0, |r| r[x - 1][c])
+                } else {
+                    0
+                };
+                let grad = n as i64 + w as i64 - nw as i64;
+                let lo = n.min(w) as i64;
+                let hi = n.max(w) as i64;
+                predictions[c] = grad.clamp(lo, hi) as i32;
+            }
 
             // Try two diffusion multipliers (matching libjxl)
             let mut best_index = 0i32;

--- a/jxl-encoder/src/modular/predictor.rs
+++ b/jxl-encoder/src/modular/predictor.rs
@@ -497,9 +497,59 @@ impl WeightedPredictorState {
         }
     }
 
+    /// Creates a new weighted predictor state with an optional allocation
+    /// budget. The two scratch buffers (`pred_errors_buffer` of
+    /// `(xsize + 2) * 2 * NUM_WP_PREDICTORS` u32 and `error` of
+    /// `(xsize + 2) * 2` i32) are width-driven and therefore charged
+    /// against the per-encode cap. Returns
+    /// [`crate::error::Error::AllocationLimit`] when the cap is exceeded;
+    /// callers convert to `EncodeError` upstream.
+    ///
+    /// `budget = None` is zero-overhead — equivalent to [`Self::new`].
+    pub(crate) fn new_with_budget(
+        params: &WeightedPredictorParams,
+        xsize: usize,
+        budget: Option<&alloc::sync::Arc<crate::budget::MemoryBudget>>,
+    ) -> crate::error::Result<Self> {
+        let num_errors = (xsize + 2) * 2;
+        let buffer_bytes = (num_errors as u64)
+            .checked_mul(NUM_WP_PREDICTORS as u64)
+            .and_then(|n| n.checked_mul(core::mem::size_of::<u32>() as u64))
+            .ok_or(crate::error::Error::AllocationLimit {
+                requested: u64::MAX,
+                used: 0,
+                cap: 0,
+            })?;
+        let error_bytes = (num_errors as u64)
+            .checked_mul(core::mem::size_of::<i32>() as u64)
+            .ok_or(crate::error::Error::AllocationLimit {
+                requested: u64::MAX,
+                used: 0,
+                cap: 0,
+            })?;
+        crate::budget::MemoryBudget::reserve_permanent_opt(budget, buffer_bytes)?;
+        crate::budget::MemoryBudget::reserve_permanent_opt(budget, error_bytes)?;
+        Ok(Self {
+            prediction: [0; NUM_WP_PREDICTORS],
+            pred: 0,
+            pred_errors_buffer: vec![0; num_errors * NUM_WP_PREDICTORS],
+            error: vec![0; num_errors],
+            params: *params,
+        })
+    }
+
     /// Creates with default parameters.
     pub fn with_defaults(xsize: usize) -> Self {
         Self::new(&WeightedPredictorParams::default(), xsize)
+    }
+
+    /// Creates with default parameters and an optional allocation budget.
+    /// Counterpart to [`Self::new_with_budget`].
+    pub(crate) fn with_defaults_and_budget(
+        xsize: usize,
+        budget: Option<&alloc::sync::Arc<crate::budget::MemoryBudget>>,
+    ) -> crate::error::Result<Self> {
+        Self::new_with_budget(&WeightedPredictorParams::default(), xsize, budget)
     }
 
     /// Get all predictor errors for a given position (contiguous in memory).

--- a/jxl-encoder/src/modular/tree_learn.rs
+++ b/jxl-encoder/src/modular/tree_learn.rs
@@ -594,6 +594,35 @@ pub fn gather_samples_strided(
     stride: usize,
     wp_params: &WeightedPredictorParams,
 ) {
+    // Backwards-compatible wrapper: budget-less. Allocations fall back to
+    // panicking on OOM, same as before. New callers should prefer the
+    // `_with_budget` variant.
+    gather_samples_strided_with_budget(
+        samples,
+        image,
+        group_id,
+        channel_offset,
+        stride,
+        wp_params,
+        None,
+    )
+    .expect("budget-less gather_samples_strided must not return AllocationLimit")
+}
+
+/// `gather_samples_strided` with explicit allocation budget.
+///
+/// Per-channel `WeightedPredictorState` scratch (`(width + 2) * 2` errors
+/// plus same length × 4 sub-predictor errors) is reserved against the
+/// cap. `budget = None` is zero-overhead.
+pub(crate) fn gather_samples_strided_with_budget(
+    samples: &mut TreeSamples,
+    image: &ModularImage,
+    group_id: u32,
+    channel_offset: u32,
+    stride: usize,
+    wp_params: &WeightedPredictorParams,
+    budget: Option<&alloc::sync::Arc<crate::budget::MemoryBudget>>,
+) -> crate::error::Result<()> {
     for (ch_idx, channel) in image.channels.iter().enumerate() {
         // Find reference channels for this channel (preceding channels with matching dims)
         let ref_channel_indices = if samples.num_ref_channels > 0 {
@@ -611,8 +640,10 @@ pub fn gather_samples_strided(
             wp_params,
             image,
             &ref_channel_indices,
-        );
+            budget,
+        )?;
     }
+    Ok(())
 }
 
 /// Compute maximum tree samples from an [`EffortProfile`].
@@ -662,15 +693,16 @@ fn gather_channel_samples(
     wp_params: &WeightedPredictorParams,
     image: &ModularImage,
     ref_channel_indices: &[usize],
-) {
+    budget: Option<&alloc::sync::Arc<crate::budget::MemoryBudget>>,
+) -> crate::error::Result<()> {
     let width = channel.width();
     let height = channel.height();
     if width == 0 || height == 0 {
-        return;
+        return Ok(());
     }
 
     // WP state for computing weighted predictions and property 15
-    let mut wp_state = WeightedPredictorState::new(wp_params, width);
+    let mut wp_state = WeightedPredictorState::new_with_budget(wp_params, width, budget)?;
 
     // prev_gradient tracks the gradient from the previous pixel in scan order.
     // Property 8 = W - prev_gradient. At the start of each row, prev_gradient = 0.
@@ -787,6 +819,7 @@ fn gather_channel_samples(
             }
         }
     }
+    Ok(())
 }
 
 /// Size of the precomputed n*log2(n) lookup table.
@@ -990,19 +1023,53 @@ struct SplitCandidate {
 /// - `params.split_threshold`: minimum bits saved for a split to be accepted
 /// - `params.max_nodes`: maximum tree nodes
 pub fn compute_best_tree(samples: &mut TreeSamples, params: &TreeLearningParams) -> Tree {
+    compute_best_tree_with_budget(samples, params, None)
+        .expect("budget-less compute_best_tree must not return AllocationLimit")
+}
+
+/// `compute_best_tree` with explicit allocation budget.
+///
+/// Charges the dimension-driven allocations against the cap:
+///
+/// - `indices: Vec<usize>` of `num_samples` entries (8 B each)
+/// - `bucket_indices` from [`TreeSamples::pre_quantize`]: up to
+///   `total_num_properties × num_samples` u8 entries (1 B each)
+/// - `entropy_counts: Vec<u32>` of `histogram_size` (small, but charged
+///   for completeness)
+///
+/// `num_samples` itself is dim-driven: see
+/// [`max_tree_samples_from_profile`], which scales with image area
+/// (`tree_sample_fraction × total_pixels`, capped at `tree_max_samples_fixed`).
+///
+/// `budget = None` is zero-overhead.
+pub(crate) fn compute_best_tree_with_budget(
+    samples: &mut TreeSamples,
+    params: &TreeLearningParams,
+    budget: Option<&alloc::sync::Arc<crate::budget::MemoryBudget>>,
+) -> crate::error::Result<Tree> {
     // Scale threshold by pixel_fraction, matching libjxl's required_cost formula.
     let required_cost = params.pixel_fraction * 0.9 + 0.1;
     let threshold = params.split_threshold * required_cost;
     let n = samples.num_samples;
     if n == 0 {
-        return vec![PropertyDecisionNode {
+        return Ok(vec![PropertyDecisionNode {
             property: -1,
             predictor: Predictor::Gradient,
             context_id: 0,
             multiplier: 1,
             ..Default::default()
-        }];
+        }]);
     }
+
+    // Reserve the dim-driven scratch up front.
+    //  - `indices`: n × usize
+    //  - `bucket_indices`: up to (total_num_properties × n) bytes
+    let usize_bytes = core::mem::size_of::<usize>() as u64;
+    let bi_bytes = (samples.total_num_properties() as u64).saturating_mul(n as u64);
+    let total_bytes = (n as u64)
+        .saturating_mul(usize_bytes)
+        .saturating_add(bi_bytes);
+    crate::budget::MemoryBudget::reserve_permanent_opt(budget, total_bytes)?;
 
     // Pre-quantize all properties globally (replaces per-node binary_search)
     let mut pq = samples.pre_quantize(params);
@@ -1209,7 +1276,7 @@ pub fn compute_best_tree(samples: &mut TreeSamples, params: &TreeLearningParams)
         max_nodes,
     );
 
-    tree
+    Ok(tree)
 }
 
 /// Make a tree node into a leaf with the given predictor.
@@ -2102,6 +2169,21 @@ pub fn collect_residuals_with_tree(
     collect_residuals_with_tree_offset(image, tree, group_id, 0, wp_params)
 }
 
+/// `collect_residuals_with_tree` with explicit allocation budget.
+///
+/// Per-channel `WeightedPredictorState` scratch is reserved against the
+/// cap. Returns [`crate::error::Error::AllocationLimit`] when the cap is
+/// exceeded. `budget = None` is zero-overhead.
+pub(crate) fn collect_residuals_with_tree_with_budget(
+    image: &ModularImage,
+    tree: &Tree,
+    group_id: u32,
+    wp_params: &WeightedPredictorParams,
+    budget: Option<&alloc::sync::Arc<crate::budget::MemoryBudget>>,
+) -> crate::error::Result<Vec<crate::entropy_coding::token::Token>> {
+    collect_residuals_with_tree_offset_with_budget(image, tree, group_id, 0, wp_params, budget)
+}
+
 /// Collect residuals using a learned tree, with a channel index offset.
 ///
 /// When collecting from a sub-image that represents channels [offset..offset+N] of a larger
@@ -2114,6 +2196,29 @@ pub fn collect_residuals_with_tree_offset(
     channel_offset: u32,
     wp_params: &WeightedPredictorParams,
 ) -> Vec<crate::entropy_coding::token::Token> {
+    collect_residuals_with_tree_offset_with_budget(
+        image,
+        tree,
+        group_id,
+        channel_offset,
+        wp_params,
+        None,
+    )
+    .expect("budget-less collect_residuals_with_tree_offset must not return AllocationLimit")
+}
+
+/// `collect_residuals_with_tree_offset` with explicit allocation budget.
+///
+/// Per-channel `WeightedPredictorState` scratch is reserved against the
+/// cap. `budget = None` is zero-overhead.
+pub(crate) fn collect_residuals_with_tree_offset_with_budget(
+    image: &ModularImage,
+    tree: &Tree,
+    group_id: u32,
+    channel_offset: u32,
+    wp_params: &WeightedPredictorParams,
+    budget: Option<&alloc::sync::Arc<crate::budget::MemoryBudget>>,
+) -> crate::error::Result<Vec<crate::entropy_coding::token::Token>> {
     use crate::entropy_coding::token::Token as AnsToken;
 
     // Check if the tree uses any reference channel properties (indices >= 16).
@@ -2150,7 +2255,7 @@ pub fn collect_residuals_with_tree_offset(
             Vec::new()
         };
 
-        let mut wp_state = WeightedPredictorState::new(wp_params, width);
+        let mut wp_state = WeightedPredictorState::new_with_budget(wp_params, width, budget)?;
         let mut prev_gradient: i32;
 
         for y in 0..height {
@@ -2264,7 +2369,7 @@ pub fn collect_residuals_with_tree_offset(
         }
     }
 
-    tokens
+    Ok(tokens)
 }
 
 /// Traverse a tree using spec-matching property values (base 16 properties only).

--- a/jxl-encoder/src/validation.rs
+++ b/jxl-encoder/src/validation.rs
@@ -137,8 +137,11 @@ pub(crate) const DISTANCE_MAX: f32 = 25.0;
 pub(crate) const EFFORT_RANGE: RangeInclusive<u8> = 1..=10;
 /// Cap on quality-loop iter counts. libjxl's kTortoise butteraugli runs 4
 /// passes; 16 leaves room for sweep harnesses without inviting absurd values.
-/// Referenced unconditionally by `Limits::DEFAULT_MAX_QUANT_LOOP_ITERS`, so
-/// not feature-gated even though the loops themselves are.
+///
+/// Always defined (not feature-gated) so the public `api::MAX_QUANT_LOOP_ITERS`
+/// and `Limits::DEFAULT_MAX_QUANT_LOOP_ITERS` re-exports are stable across
+/// feature combinations — callers shouldn't have to enable a perceptual-loop
+/// feature just to read the cap.
 pub(crate) const ITER_MAX: u32 = 16;
 #[cfg(feature = "__expert")]
 pub(crate) const FINE_GRAINED_STEP_RANGE: RangeInclusive<u8> = 1..=8;

--- a/jxl-encoder/src/vardct/adaptive_quant.rs
+++ b/jxl-encoder/src/vardct/adaptive_quant.rs
@@ -186,8 +186,33 @@ fn compute_mask_for_ac_strategy_use(out_val: f32) -> f32 {
 /// # Returns
 /// Per-pixel mask field of size `width * height`, row-major layout.
 /// After computing the raw mask, applies libjxl's Symmetric5 blur.
-pub fn compute_mask1x1(xyb_y: &[f32], width: usize, height: usize) -> Vec<f32> {
-    let mut mask1x1 = vec![0.0_f32; width * height];
+#[cfg(test)]
+pub(crate) fn compute_mask1x1(xyb_y: &[f32], width: usize, height: usize) -> Vec<f32> {
+    compute_mask1x1_with_budget(xyb_y, width, height, None)
+        .expect("compute_mask1x1: unbudgeted call should never fail")
+}
+
+/// Same as [`compute_mask1x1`] but accounts allocations against an optional
+/// [`MemoryBudget`].
+pub(crate) fn compute_mask1x1_with_budget(
+    xyb_y: &[f32],
+    width: usize,
+    height: usize,
+    budget: Option<&alloc::sync::Arc<crate::budget::MemoryBudget>>,
+) -> crate::error::Result<Vec<f32>> {
+    let n = width
+        .checked_mul(height)
+        .ok_or(crate::error::Error::DimensionOverflow {
+            width,
+            height,
+            channels: 1,
+        })?;
+    // Two w*h f32 buffers are alive at peak: the returned mask1x1 and the
+    // internal `scratch` used by gaborish_5x5_channel. Account both as
+    // permanent — mask1x1 has caller-owned lifetime, scratch is dropped here
+    // but at peak we need 2*n*4 budget to allocate them simultaneously.
+    crate::budget::MemoryBudget::reserve_permanent_opt(budget, (n as u64).saturating_mul(4 * 2))?;
+    let mut mask1x1 = vec![0.0_f32; n];
 
     // SIMD-accelerated per-pixel masking (neighbor avg → gamma ratio → log1p → reciprocal)
     jxl_simd::compute_mask1x1(xyb_y, width, height, &mut mask1x1);
@@ -222,7 +247,7 @@ pub fn compute_mask1x1(xyb_y: &[f32], width: usize, height: usize) -> Vec<f32> {
         inv_sum * W_D2, // w_big_d (diagonal dist 2)
     );
 
-    mask1x1
+    Ok(mask1x1)
 }
 
 // symmetric5_blur_mask1x1 replaced by jxl_simd::gaborish_5x5_channel with
@@ -269,7 +294,8 @@ fn per_block_modulations(
 ///
 /// Returns `(quant_field_float, masking)`.
 #[allow(clippy::too_many_arguments)]
-pub fn compute_quant_field_float(
+#[cfg(test)]
+pub(crate) fn compute_quant_field_float(
     xyb_x: &[f32],
     xyb_y: &[f32],
     xyb_b: &[f32],
@@ -280,6 +306,53 @@ pub fn compute_quant_field_float(
     distance: f32,
     k_ac_quant: f32,
 ) -> (Vec<f32>, Vec<f32>) {
+    compute_quant_field_float_with_budget(
+        xyb_x,
+        xyb_y,
+        xyb_b,
+        width,
+        height,
+        xsize_blocks,
+        ysize_blocks,
+        distance,
+        k_ac_quant,
+        None,
+    )
+    .expect("compute_quant_field_float: unbudgeted call should never fail")
+}
+
+/// Budget-aware variant of [`compute_quant_field_float`]. Accounts the two
+/// output planes (`masking` + `quant_field_float`, each `xsize_blocks * ysize_blocks`
+/// floats) plus the transient `aq_map` (~`width/4 * height/4` floats) against
+/// the per-encode cap.
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn compute_quant_field_float_with_budget(
+    xyb_x: &[f32],
+    xyb_y: &[f32],
+    xyb_b: &[f32],
+    width: usize,
+    height: usize,
+    xsize_blocks: usize,
+    ysize_blocks: usize,
+    distance: f32,
+    k_ac_quant: f32,
+    budget: Option<&alloc::sync::Arc<crate::budget::MemoryBudget>>,
+) -> crate::error::Result<(Vec<f32>, Vec<f32>)> {
+    let nblocks =
+        xsize_blocks
+            .checked_mul(ysize_blocks)
+            .ok_or(crate::error::Error::DimensionOverflow {
+                width: xsize_blocks,
+                height: ysize_blocks,
+                channels: 1,
+            })?;
+    // Returned: masking + quant_field_float (each nblocks * f32 = 4 * nblocks bytes).
+    // Transient peak (aq_map after fuzzy_erosion): xsize_blocks * ysize_blocks * f32
+    // ≈ same as nblocks since erosion downsample yields one value per 8x8 block.
+    crate::budget::MemoryBudget::reserve_permanent_opt(
+        budget,
+        (nblocks as u64).saturating_mul(4 * 2),
+    )?;
     let scale = k_ac_quant / distance;
 
     let tile_x0_pixels = 0;
@@ -346,7 +419,7 @@ pub fn compute_quant_field_float(
         }
     }
 
-    (quant_field_float, masking)
+    Ok((quant_field_float, masking))
 }
 
 /// Convert float quant field to u8 raw_quant values.
@@ -365,6 +438,7 @@ pub fn quantize_quant_field(quant_field_float: &[f32], inv_scale: f32) -> Vec<u8
 
 /// Convenience wrapper that calls `compute_quant_field_float()` then
 /// `quantize_quant_field()`.
+#[cfg(test)]
 #[allow(clippy::too_many_arguments, dead_code)]
 pub fn compute_adaptive_quant_field(
     xyb_x: &[f32],

--- a/jxl-encoder/src/vardct/bitstream.rs
+++ b/jxl-encoder/src/vardct/bitstream.rs
@@ -1179,7 +1179,7 @@ impl VarDctEncoder {
         let padded_height = ysize_blocks * BLOCK_DIM;
 
         let (mut xyb_x, mut xyb_y, mut xyb_b) =
-            self.convert_to_xyb_padded(width, height, padded_width, padded_height, linear_rgb);
+            self.convert_to_xyb_padded(width, height, padded_width, padded_height, linear_rgb)?;
 
         let noise_params = if self.enable_noise {
             let quality_coef = super::noise::noise_quality_coef(self.distance);
@@ -1232,7 +1232,8 @@ impl VarDctEncoder {
                 &mut xyb_b,
                 padded_width,
                 padded_height,
-            );
+                self.budget.as_ref(),
+            )?;
         }
 
         let distance_for_iqf = if self.enable_gaborish {
@@ -1241,17 +1242,19 @@ impl VarDctEncoder {
             self.distance * 0.62
         };
 
-        let (mut quant_field_float, masking) = super::adaptive_quant::compute_quant_field_float(
-            &xyb_x,
-            &xyb_y,
-            &xyb_b,
-            padded_width,
-            padded_height,
-            xsize_blocks,
-            ysize_blocks,
-            distance_for_iqf,
-            self.profile.k_ac_quant,
-        );
+        let (mut quant_field_float, masking) =
+            super::adaptive_quant::compute_quant_field_float_with_budget(
+                &xyb_x,
+                &xyb_y,
+                &xyb_b,
+                padded_width,
+                padded_height,
+                xsize_blocks,
+                ysize_blocks,
+                distance_for_iqf,
+                self.profile.k_ac_quant,
+                self.budget.as_ref(),
+            )?;
 
         let mut params = DistanceParams::compute_for_profile(self.distance, &self.profile);
         if self.profile.chromacity_adjustment {
@@ -1282,11 +1285,12 @@ impl VarDctEncoder {
         };
 
         let mask1x1 = if self.ac_strategy_enabled && self.pixel_domain_loss {
-            Some(super::adaptive_quant::compute_mask1x1(
+            Some(super::adaptive_quant::compute_mask1x1_with_budget(
                 &xyb_y,
                 padded_width,
                 padded_height,
-            ))
+                self.budget.as_ref(),
+            )?)
         } else {
             None
         };
@@ -1347,7 +1351,7 @@ impl VarDctEncoder {
                 &ac_strategy,
                 None, // No patches in this code path
                 None, // No splines in this code path
-            );
+            )?;
         }
 
         let transform_out = self.transform_and_quantize(
@@ -1361,13 +1365,19 @@ impl VarDctEncoder {
             &mut quant_field,
             &cfl_map,
             &ac_strategy,
-        );
+        )?;
 
         let sharpness_map =
             if params.epf_iters > 0 && self.distance >= 0.5 && self.profile.epf_dynamic_sharpness {
-                let mask = mask1x1.unwrap_or_else(|| {
-                    super::adaptive_quant::compute_mask1x1(&xyb_y, padded_width, padded_height)
-                });
+                let mask = match mask1x1 {
+                    Some(m) => m,
+                    None => super::adaptive_quant::compute_mask1x1_with_budget(
+                        &xyb_y,
+                        padded_width,
+                        padded_height,
+                        self.budget.as_ref(),
+                    )?,
+                };
                 Some(super::epf::compute_epf_sharpness(
                     [&xyb_x, &xyb_y, &xyb_b],
                     &transform_out.quant_dc,
@@ -1380,7 +1390,8 @@ impl VarDctEncoder {
                     self.enable_gaborish,
                     xsize_blocks,
                     ysize_blocks,
-                ))
+                    self.budget.as_ref(),
+                )?)
             } else {
                 None
             };
@@ -1496,6 +1507,7 @@ impl VarDctEncoder {
                 self.use_ans,
                 self.profile.patch_ref_tree_learning,
                 &mut writer,
+                self.budget.as_ref(),
             )?;
             writer.zero_pad_to_byte();
             #[cfg(feature = "trace-bitstream")]

--- a/jxl-encoder/src/vardct/butteraugli_loop.rs
+++ b/jxl-encoder/src/vardct/butteraugli_loop.rs
@@ -19,6 +19,7 @@ use super::common::*;
 use super::encoder::VarDctEncoder;
 use super::frame::DistanceParams;
 use crate::debug_rect;
+use crate::error::Result;
 
 impl VarDctEncoder {
     /// Butteraugli quantization loop: iteratively refines per-block quant_field
@@ -63,10 +64,12 @@ impl VarDctEncoder {
         ac_strategy: &AcStrategyMap,
         patches_data: Option<&super::patches::PatchesData>,
         splines_data: Option<&super::splines::SplinesData>,
-    ) -> DistanceParams {
+    ) -> Result<DistanceParams> {
         use super::epf;
         use super::reconstruct::{gab_smooth, reconstruct_xyb, xyb_to_linear_rgb_planar};
+        use crate::budget::MemoryBudget;
 
+        let budget = self.budget.as_ref();
         let target_distance = self.distance;
         let num_blocks = xsize_blocks * ysize_blocks;
         let padded_pixels = padded_width * padded_height;
@@ -74,33 +77,35 @@ impl VarDctEncoder {
         // Precompute butteraugli reference from original image ONCE.
         // Deinterleave to planar to avoid interleave round-trip inside the crate.
         let n = width * height;
-        let mut ref_r = vec![0.0f32; n];
-        let mut ref_g = vec![0.0f32; n];
-        let mut ref_b = vec![0.0f32; n];
-        for i in 0..n {
-            ref_r[i] = linear_rgb[i * 3];
-            ref_g[i] = linear_rgb[i * 3 + 1];
-            ref_b[i] = linear_rgb[i * 3 + 2];
-        }
-        let butteraugli_params = butteraugli::ButteraugliParams::new()
-            .with_intensity_target(80.0)
-            .with_compute_diffmap(true);
-        let reference = match butteraugli::ButteraugliReference::new_linear_planar(
-            &ref_r,
-            &ref_g,
-            &ref_b,
-            width,
-            height,
-            width,
-            butteraugli_params,
-        ) {
-            Ok(r) => r,
-            Err(_) => return initial_params.clone(),
+        // Three transient planar buffers — released as soon as the reference
+        // crate finishes consuming them.
+        let reference = {
+            let _g = MemoryBudget::reserve_opt(budget, (n as u64).saturating_mul(4 * 3))?;
+            let mut ref_r = vec![0.0f32; n];
+            let mut ref_g = vec![0.0f32; n];
+            let mut ref_b = vec![0.0f32; n];
+            for i in 0..n {
+                ref_r[i] = linear_rgb[i * 3];
+                ref_g[i] = linear_rgb[i * 3 + 1];
+                ref_b[i] = linear_rgb[i * 3 + 2];
+            }
+            let butteraugli_params = butteraugli::ButteraugliParams::new()
+                .with_intensity_target(80.0)
+                .with_compute_diffmap(true);
+            match butteraugli::ButteraugliReference::new_linear_planar(
+                &ref_r,
+                &ref_g,
+                &ref_b,
+                width,
+                height,
+                width,
+                butteraugli_params,
+            ) {
+                Ok(r) => r,
+                Err(_) => return Ok(initial_params.clone()),
+            }
+            // _g drops here, releasing the three n*4 reservations
         };
-        // Free the planar buffers — reference data is already precomputed inside.
-        drop(ref_r);
-        drop(ref_g);
-        drop(ref_b);
 
         // Compute deviation bounds from the FLOAT initial field (libjxl lines 968-976).
         // These prevent the quant field from diverging too far from the initial field.
@@ -121,13 +126,22 @@ impl VarDctEncoder {
         let qf_lower = initial_qf_min / (asymmetry * qf_max_deviation_low);
         let qf_higher = initial_qf_max * (qf_max_deviation_low / asymmetry);
 
-        // Pre-allocate buffers reused across iterations
+        // Pre-allocate buffers reused across iterations.
+        // These live for the duration of the loop — accounted permanently.
+        // sharpness is u8, tile_dist is f32 of num_blocks, recon_* are f32 of padded_pixels.
+        MemoryBudget::reserve_permanent_opt(
+            budget,
+            (num_blocks as u64)
+                .saturating_add((num_blocks as u64).saturating_mul(4))
+                .saturating_add((padded_pixels as u64).saturating_mul(4 * 3)),
+        )?;
         let sharpness = vec![4u8; num_blocks];
         let mut tile_dist = vec![0.0f32; num_blocks];
         let mut recon_r = vec![0.0f32; padded_pixels];
         let mut recon_g = vec![0.0f32; padded_pixels];
         let mut recon_b = vec![0.0f32; padded_pixels];
-        let mut transform_out = super::transform::TransformOutput::new(xsize_blocks, ysize_blocks);
+        let mut transform_out =
+            super::transform::TransformOutput::new(xsize_blocks, ysize_blocks, budget)?;
 
         // Saturate at consumption to bound worst-case CPU even when the
         // caller skipped LossyConfig::validate (which would have rejected
@@ -198,7 +212,8 @@ impl VarDctEncoder {
                     ysize_blocks,
                     padded_width,
                     padded_height,
-                );
+                    self.budget.as_ref(),
+                )?;
             }
 
             if let Some(pd) = patches_data {
@@ -224,12 +239,12 @@ impl VarDctEncoder {
             let result =
                 match reference.compare_linear_planar(&recon_r, &recon_g, &recon_b, padded_width) {
                     Ok(r) => r,
-                    Err(_) => return current_params,
+                    Err(_) => return Ok(current_params),
                 };
 
             let diffmap = match result.diffmap {
                 Some(dm) => dm,
-                None => return current_params,
+                None => return Ok(current_params),
             };
 
             // Step 6: Compute per-block tile distance (16th-power norm, matching libjxl TileDistMap)
@@ -461,6 +476,6 @@ impl VarDctEncoder {
         let qf_vec = quantize_quant_field(quant_field_float, final_params.inv_scale);
         quant_field.copy_from_slice(&qf_vec);
 
-        final_params
+        Ok(final_params)
     }
 }

--- a/jxl-encoder/src/vardct/dc_coding.rs
+++ b/jxl-encoder/src/vardct/dc_coding.rs
@@ -290,13 +290,31 @@ pub fn collect_dc_tokens_wp(
     end_bx: usize,
     end_by: usize,
 ) -> Vec<Token> {
+    collect_dc_tokens_wp_with_budget(quant_dc, wp_tree, start_bx, start_by, end_bx, end_by, None)
+        .expect("budget-less collect_dc_tokens_wp must not return AllocationLimit")
+}
+
+/// `collect_dc_tokens_wp` with explicit allocation budget.
+///
+/// The WP state's per-channel scratch is `(region_width + 2) * 2` errors
+/// plus four sub-predictor errors of the same length — region-driven,
+/// charged against the cap. `budget = None` is zero-overhead.
+pub(crate) fn collect_dc_tokens_wp_with_budget(
+    quant_dc: &[Vec<Vec<i16>>; 3],
+    wp_tree: &super::dc_tree_learn::DcTree,
+    start_bx: usize,
+    start_by: usize,
+    end_bx: usize,
+    end_by: usize,
+    budget: Option<&alloc::sync::Arc<crate::budget::MemoryBudget>>,
+) -> crate::error::Result<Vec<Token>> {
     use crate::modular::predictor::{Neighbors, WeightedPredictorState};
 
     let region_width = end_bx - start_bx;
     let region_height = end_by - start_by;
 
     if region_width == 0 || region_height == 0 {
-        return Vec::new();
+        return Ok(Vec::new());
     }
 
     let mut tokens = Vec::with_capacity(region_width * region_height * 3);
@@ -305,7 +323,7 @@ pub fn collect_dc_tokens_wp(
     // Each channel gets a FRESH WP state (matches libjxl per-channel processing)
     for &c in &[1, 0, 2] {
         let channel = &quant_dc[c];
-        let mut wp_state = WeightedPredictorState::with_defaults(region_width);
+        let mut wp_state = WeightedPredictorState::with_defaults_and_budget(region_width, budget)?;
 
         for y in start_by..end_by {
             for x in start_bx..end_bx {
@@ -387,7 +405,7 @@ pub fn collect_dc_tokens_wp(
         }
     }
 
-    tokens
+    Ok(tokens)
 }
 
 /// Collect DC tokens for a specific region (gradient predictor path).

--- a/jxl-encoder/src/vardct/encoder.rs
+++ b/jxl-encoder/src/vardct/encoder.rs
@@ -8,7 +8,7 @@ use super::ac_strategy::{
     AcStrategyMap, adjust_quant_field_float_with_distance, adjust_quant_field_with_distance,
     compute_ac_strategy,
 };
-use super::adaptive_quant::{compute_mask1x1, compute_quant_field_float, quantize_quant_field};
+use super::adaptive_quant::quantize_quant_field;
 use super::chroma_from_luma::{CflMap, compute_cfl_map};
 use super::common::*;
 use super::frame::{DistanceParams, write_toc};
@@ -264,6 +264,13 @@ pub struct VarDctEncoder {
     /// Policy for non-finite XYB values at the conversion→pipeline
     /// boundary. See [`crate::api::NonFiniteAction`].
     pub non_finite_action: crate::api::NonFiniteAction,
+    /// Per-encode allocation budget. When `Some`, dimension-driven
+    /// buffers (XYB planes, padded scratch) reserve their byte count
+    /// before allocating and surface
+    /// [`crate::error::Error::AllocationLimit`] if the cap would be
+    /// exceeded. When `None` (the test/library default), allocation
+    /// proceeds unbounded.
+    pub(crate) budget: Option<alloc::sync::Arc<crate::budget::MemoryBudget>>,
 }
 
 impl Default for VarDctEncoder {
@@ -307,6 +314,7 @@ impl Default for VarDctEncoder {
             min_nits: 0.0,
             intrinsic_size: None,
             non_finite_action: crate::api::NonFiniteAction::default(),
+            budget: None,
         }
     }
 }
@@ -353,7 +361,25 @@ impl VarDctEncoder {
             min_nits: 0.0,
             intrinsic_size: None,
             non_finite_action: crate::api::NonFiniteAction::default(),
+            budget: None,
         }
+    }
+
+    /// Attach a per-encode allocation budget. Internal-only; the public
+    /// API plumbs this from [`crate::api::Limits::max_memory_bytes`].
+    ///
+    /// Currently the API path sets [`Self::budget`] directly; this
+    /// builder is here for future call sites (e.g., the streaming
+    /// encoder, precomputed entry points) that don't have field
+    /// access.
+    #[doc(hidden)]
+    #[allow(dead_code)]
+    pub(crate) fn with_budget(
+        mut self,
+        budget: alloc::sync::Arc<crate::budget::MemoryBudget>,
+    ) -> Self {
+        self.budget = Some(budget);
+        self
     }
 
     /// Encode an image in linear sRGB format, optionally with an alpha channel.
@@ -468,7 +494,7 @@ impl VarDctEncoder {
         // Convert to XYB with edge-replicated padding to block boundaries.
         // This allows SIMD to process full blocks without bounds checking.
         let (mut xyb_x, mut xyb_y, mut xyb_b) =
-            self.convert_to_xyb_padded(width, height, padded_width, padded_height, linear_rgb);
+            self.convert_to_xyb_padded(width, height, padded_width, padded_height, linear_rgb)?;
 
         // Defense-in-depth XYB scan. Catches downstream-bug non-finite
         // (memory corruption, butteraugli-loop reconstruction polluting
@@ -614,7 +640,7 @@ impl VarDctEncoder {
         // - effort < 5 (speed_tier > kHare): flat quant field = q_numerator/distance
         // - effort >= 5 (speed_tier <= kHare): adaptive via InitialQuantField
         let (mut quant_field_float, masking) = if self.profile.use_adaptive_quant {
-            compute_quant_field_float(
+            super::adaptive_quant::compute_quant_field_float_with_budget(
                 &xyb_x,
                 &xyb_y,
                 &xyb_b,
@@ -624,13 +650,26 @@ impl VarDctEncoder {
                 ysize_blocks,
                 distance_for_iqf,
                 self.profile.k_ac_quant,
-            )
+                self.budget.as_ref(),
+            )?
         } else {
-            // Flat quant field for low effort (matches libjxl enc_heuristics.cc:1105-1106)
+            // Flat quant field for low effort (matches libjxl enc_heuristics.cc:1105-1106).
+            // Account both nblocks-sized f32 buffers against the budget.
+            let nblocks = xsize_blocks.checked_mul(ysize_blocks).ok_or(
+                crate::error::Error::DimensionOverflow {
+                    width: xsize_blocks,
+                    height: ysize_blocks,
+                    channels: 1,
+                },
+            )?;
+            crate::budget::MemoryBudget::reserve_permanent_opt(
+                self.budget.as_ref(),
+                (nblocks as u64).saturating_mul(4 * 2),
+            )?;
             let q = self.profile.initial_q_numerator / self.distance;
-            let flat_qf = vec![q; xsize_blocks * ysize_blocks];
+            let flat_qf = vec![q; nblocks];
             let masking_val = 1.0 / (q + 0.001);
-            let flat_masking = vec![masking_val; xsize_blocks * ysize_blocks];
+            let flat_masking = vec![masking_val; nblocks];
             (flat_qf, flat_masking)
         };
 
@@ -669,7 +708,12 @@ impl VarDctEncoder {
         // Compute per-pixel mask on PRE-GABORISH image (matches libjxl:
         // initial_quant_masking1x1 is computed in InitialQuantField before GaborishInverse)
         let mask1x1 = if self.ac_strategy_enabled && self.pixel_domain_loss {
-            Some(compute_mask1x1(&xyb_y, padded_width, padded_height))
+            Some(super::adaptive_quant::compute_mask1x1_with_budget(
+                &xyb_y,
+                padded_width,
+                padded_height,
+                self.budget.as_ref(),
+            )?)
         } else {
             None
         };
@@ -687,7 +731,8 @@ impl VarDctEncoder {
                 &mut xyb_b,
                 padded_width,
                 padded_height,
-            );
+                self.budget.as_ref(),
+            )?;
         }
 
         // Float DC for LfFrame is now extracted from the transform pipeline
@@ -876,7 +921,7 @@ impl VarDctEncoder {
                 &ac_strategy,
                 patches_data.as_ref(),
                 splines_data.as_ref(),
-            );
+            )?;
         }
 
         // SSIM2 quantization loop: alternative to butteraugli using SSIM2 + per-block RMSE.
@@ -902,7 +947,7 @@ impl VarDctEncoder {
                 &ac_strategy,
                 patches_data.as_ref(),
                 splines_data.as_ref(),
-            );
+            )?;
         }
 
         // Zensim quantization loop: uses zensim psychovisual metric + per-pixel diffmap.
@@ -929,7 +974,7 @@ impl VarDctEncoder {
                 &mut ac_strategy,
                 patches_data.as_ref(),
                 splines_data.as_ref(),
-            );
+            )?;
         }
 
         // Free float quant field — no longer needed after loop refinement.
@@ -1023,7 +1068,7 @@ impl VarDctEncoder {
             &mut quant_field,
             &cfl_map,
             &ac_strategy,
-        );
+        )?;
         let quant_dc = &transform_out.quant_dc;
         let quant_ac = &transform_out.quant_ac;
         let nzeros = &transform_out.nzeros;
@@ -1031,35 +1076,38 @@ impl VarDctEncoder {
 
         // Compute per-block EPF sharpness map when EPF is active
         // Dynamic sharpness gated at effort >= 6 (speed_tier <= kWombat) matching libjxl
-        let sharpness_map = if params.epf_iters > 0
-            && self.distance >= 0.5
-            && self.profile.epf_dynamic_sharpness
-        {
-            let mask_fallback;
-            let mask: &[f32] = match &mask1x1 {
-                Some(m) => m,
-                None => {
-                    mask_fallback =
-                        super::adaptive_quant::compute_mask1x1(&xyb_y, padded_width, padded_height);
-                    &mask_fallback
-                }
+        let sharpness_map =
+            if params.epf_iters > 0 && self.distance >= 0.5 && self.profile.epf_dynamic_sharpness {
+                let mask_fallback;
+                let mask: &[f32] = match &mask1x1 {
+                    Some(m) => m,
+                    None => {
+                        mask_fallback = super::adaptive_quant::compute_mask1x1_with_budget(
+                            &xyb_y,
+                            padded_width,
+                            padded_height,
+                            self.budget.as_ref(),
+                        )?;
+                        &mask_fallback
+                    }
+                };
+                Some(super::epf::compute_epf_sharpness(
+                    [&xyb_x, &xyb_y, &xyb_b],
+                    quant_dc,
+                    quant_ac,
+                    &quant_field,
+                    mask,
+                    &params,
+                    &cfl_map,
+                    &ac_strategy,
+                    self.enable_gaborish,
+                    xsize_blocks,
+                    ysize_blocks,
+                    self.budget.as_ref(),
+                )?)
+            } else {
+                None
             };
-            Some(super::epf::compute_epf_sharpness(
-                [&xyb_x, &xyb_y, &xyb_b],
-                quant_dc,
-                quant_ac,
-                &quant_field,
-                mask,
-                &params,
-                &cfl_map,
-                &ac_strategy,
-                self.enable_gaborish,
-                xsize_blocks,
-                ysize_blocks,
-            ))
-        } else {
-            None
-        };
 
         // Free XYB planes — no longer needed after EPF sharpness computation.
         // At 4K (6720×4480), this frees ~339 MB (3 channels × padded_pixels × f32).
@@ -1114,7 +1162,13 @@ impl VarDctEncoder {
         let dc_code = BuiltEntropyCode::StaticHuffman(get_dc_entropy_code());
         let ac_code = BuiltEntropyCode::StaticHuffman(get_ac_entropy_code());
 
-        // Create main writer
+        // Create main writer. The capacity is a heuristic upper bound on the
+        // bitstream size — actual usage is much smaller in compression but
+        // we budget the full reservation since BitWriter eagerly allocates.
+        let main_cap = (width as u64)
+            .saturating_mul(height as u64)
+            .saturating_mul(4);
+        crate::budget::MemoryBudget::reserve_permanent_opt(self.budget.as_ref(), main_cap)?;
         let mut writer = BitWriter::with_capacity(width * height * 4);
 
         // Write file header (includes JXL signature, ICC, and byte padding)
@@ -1172,6 +1226,13 @@ impl VarDctEncoder {
             let dc_huffman = dc_code.as_huffman();
             let ac_huffman = ac_code.as_huffman();
 
+            // dc_group + ac_group BitWriters are sized proportional to the
+            // image (10 bytes/block DC + 100 bytes/block AC heuristic).
+            // Account both up front against the budget.
+            crate::budget::MemoryBudget::reserve_permanent_opt(
+                self.budget.as_ref(),
+                (num_blocks as u64).saturating_mul(110),
+            )?;
             let mut dc_group = BitWriter::with_capacity(num_blocks * 10);
             self.write_dc_group(
                 0,
@@ -1258,7 +1319,17 @@ impl VarDctEncoder {
             );
             writer.append_bytes(&combined_bytes)?;
         } else {
-            // Multi-group: use byte-aligned sections
+            // Multi-group: use byte-aligned sections.
+            // Section bytes accumulate across groups; the heuristic capacity
+            // is num_groups * blocks_per_group * 100 + num_dc_groups * 10240
+            // ≈ num_blocks * 100 in total. Account up front.
+            let total_groups_bytes = (xsize_blocks as u64)
+                .saturating_mul(ysize_blocks as u64)
+                .saturating_mul(110);
+            crate::budget::MemoryBudget::reserve_permanent_opt(
+                self.budget.as_ref(),
+                total_groups_bytes,
+            )?;
             let mut sections: Vec<Vec<u8>> = Vec::with_capacity(num_sections);
             let dc_huffman = dc_code.as_huffman();
             let ac_huffman = ac_code.as_huffman();
@@ -1394,7 +1465,7 @@ impl VarDctEncoder {
         config: &super::rate_control::RateControlConfig,
     ) -> Result<(Vec<u8>, usize)> {
         // Compute precomputed state
-        let precomputed = super::precomputed::EncoderPrecomputed::compute(
+        let precomputed = super::precomputed::EncoderPrecomputed::compute_with_budget(
             width,
             height,
             linear_rgb,
@@ -1408,7 +1479,8 @@ impl VarDctEncoder {
             self.force_strategy,
             &self.profile,
             self.color_encoding.as_ref(),
-        );
+            self.budget.as_ref(),
+        )?;
 
         // Run rate control loop
         super::rate_control::encode_with_rate_control(self, &precomputed, config)
@@ -1469,7 +1541,7 @@ impl VarDctEncoder {
             &mut quant_field,
             &precomputed.cfl_map,
             &precomputed.ac_strategy,
-        );
+        )?;
         let quant_dc = &transform_out.quant_dc;
         let quant_ac = &transform_out.quant_ac;
         let nzeros = &transform_out.nzeros;
@@ -1552,7 +1624,9 @@ mod tests {
 
         // Gray pixel (1x1 image -> padded to 8x8)
         let linear_rgb = vec![0.5, 0.5, 0.5];
-        let (x, y, b) = encoder.convert_to_xyb_padded(1, 1, 8, 8, &linear_rgb);
+        let (x, y, b) = encoder
+            .convert_to_xyb_padded(1, 1, 8, 8, &linear_rgb)
+            .unwrap();
 
         // Padded to 8x8 = 64 pixels
         assert_eq!(x.len(), 64);

--- a/jxl-encoder/src/vardct/epf.rs
+++ b/jxl-encoder/src/vardct/epf.rs
@@ -17,6 +17,9 @@ use super::chroma_from_luma::CflMap;
 use super::common::BLOCK_DIM;
 use super::frame::DistanceParams;
 use super::reconstruct::{gab_smooth, reconstruct_xyb};
+use crate::budget::MemoryBudget;
+use crate::error::Result;
+use alloc::sync::Arc;
 
 /// Constants from libjxl epf.h
 const K_INV_SIGMA_NUM: f32 = -1.171_572_9;
@@ -286,6 +289,7 @@ pub fn epf_step0_strip_free(
 /// split into strips of `EPF_STRIP_H` rows and processed in parallel. Strip
 /// boundaries are aligned to `BLOCK_DIM` so `border_mul` produces identical
 /// results — floating-point output is bit-exact with the serial path.
+#[allow(clippy::too_many_arguments)]
 fn epf_step0(
     padded_planes: &[Vec<f32>; 3],
     inv_sigma: &[f32],
@@ -294,12 +298,21 @@ fn epf_step0(
     height: usize,
     in_stride: usize,
     pad: usize,
-) -> [Vec<f32>; 3] {
-    let mut output = [
-        vec![0.0f32; width * height],
-        vec![0.0f32; width * height],
-        vec![0.0f32; width * height],
-    ];
+    budget: Option<&Arc<MemoryBudget>>,
+) -> Result<[Vec<f32>; 3]> {
+    // Three w*h f32 planes, accounted permanently against the budget — they live
+    // for the rest of `apply_epf` (until *planes = result swap), which spans all
+    // the strip-parallel work below. Single permanent reservation keeps the
+    // peak high-water mark accurate and avoids per-strip churn.
+    let n = width
+        .checked_mul(height)
+        .ok_or(crate::error::Error::DimensionOverflow {
+            width,
+            height,
+            channels: 3,
+        })?;
+    MemoryBudget::reserve_permanent_opt(budget, (n as u64).saturating_mul(4 * 3))?;
+    let mut output = [vec![0.0f32; n], vec![0.0f32; n], vec![0.0f32; n]];
 
     let pad_slices: [&[f32]; 3] = [&padded_planes[0], &padded_planes[1], &padded_planes[2]];
 
@@ -357,7 +370,7 @@ fn epf_step0(
         );
     }
 
-    output
+    Ok(output)
 }
 
 /// Strip-parallel wrapper for a SIMD EPF kernel (step 1 or step 2).
@@ -549,9 +562,10 @@ pub(crate) fn apply_epf(
     ysize_blocks: usize,
     width: usize,
     height: usize,
-) {
+    budget: Option<&Arc<MemoryBudget>>,
+) -> Result<()> {
     if epf_iters == 0 {
-        return;
+        return Ok(());
     }
 
     let inv_sigma = compute_inv_sigma_map(
@@ -567,6 +581,9 @@ pub(crate) fn apply_epf(
     if epf_iters >= 3 {
         let pad = 3;
         let in_stride = width + 2 * pad;
+        // Three padded f32 planes: stride * (height + 2*pad) each.
+        let padded_len = in_stride.saturating_mul(height + 2 * pad);
+        MemoryBudget::reserve_permanent_opt(budget, (padded_len as u64).saturating_mul(4 * 3))?;
         let padded: [Vec<f32>; 3] =
             core::array::from_fn(|c| jxl_simd::pad_plane(&planes[c], width, height, pad));
         let result = epf_step0(
@@ -577,7 +594,8 @@ pub(crate) fn apply_epf(
             height,
             in_stride,
             pad,
-        );
+            budget,
+        )?;
         *planes = result;
     }
 
@@ -590,6 +608,14 @@ pub(crate) fn apply_epf(
     if epf_iters >= 1 {
         let pad = 2;
         let in_stride = width + 2 * pad;
+        let padded_len = in_stride.saturating_mul(height + 2 * pad);
+        // Three padded planes + three out planes, all f32, all dimension-driven.
+        MemoryBudget::reserve_permanent_opt(
+            budget,
+            (padded_len as u64)
+                .saturating_mul(4 * 3)
+                .saturating_add((n as u64).saturating_mul(4 * 3)),
+        )?;
         let padded_x = jxl_simd::pad_plane(&planes[0], width, height, pad);
         let padded_y = jxl_simd::pad_plane(&planes[1], width, height, pad);
         let padded_b = jxl_simd::pad_plane(&planes[2], width, height, pad);
@@ -624,6 +650,13 @@ pub(crate) fn apply_epf(
     if epf_iters >= 2 {
         let pad = 1;
         let in_stride = width + 2 * pad;
+        let padded_len = in_stride.saturating_mul(height + 2 * pad);
+        MemoryBudget::reserve_permanent_opt(
+            budget,
+            (padded_len as u64)
+                .saturating_mul(4 * 3)
+                .saturating_add((n as u64).saturating_mul(4 * 3)),
+        )?;
         let padded_x = jxl_simd::pad_plane(&planes[0], width, height, pad);
         let padded_y = jxl_simd::pad_plane(&planes[1], width, height, pad);
         let padded_b = jxl_simd::pad_plane(&planes[2], width, height, pad);
@@ -651,6 +684,7 @@ pub(crate) fn apply_epf(
         planes[1] = out_y;
         planes[2] = out_b;
     }
+    Ok(())
 }
 
 /// Apply EPF with pre-allocated scratch buffers and pre-computed inv_sigma.
@@ -672,9 +706,10 @@ fn apply_epf_with_scratch(
     scratch_y: &mut Vec<f32>,
     scratch_b: &mut Vec<f32>,
     padded_scratch: &mut [Vec<f32>; 3],
-) {
+    budget: Option<&Arc<MemoryBudget>>,
+) -> Result<()> {
     if epf_iters == 0 {
-        return;
+        return Ok(());
     }
 
     // Step 0: heavy 5x5 plus (only at epf_iters >= 3)
@@ -682,6 +717,10 @@ fn apply_epf_with_scratch(
     if epf_iters >= 3 {
         let pad = 3;
         let in_stride = width + 2 * pad;
+        let padded_len = in_stride.saturating_mul(height + 2 * pad);
+        // Three padded planes built fresh each call; epf_step0 also reserves its
+        // own three output planes internally.
+        MemoryBudget::reserve_permanent_opt(budget, (padded_len as u64).saturating_mul(4 * 3))?;
         let padded: [Vec<f32>; 3] =
             core::array::from_fn(|c| jxl_simd::pad_plane(&planes[c], width, height, pad));
         let result = epf_step0(
@@ -692,7 +731,8 @@ fn apply_epf_with_scratch(
             height,
             in_stride,
             pad,
-        );
+            budget,
+        )?;
         *planes = result;
     }
 
@@ -768,6 +808,7 @@ fn apply_epf_with_scratch(
         core::mem::swap(&mut planes[1], scratch_y);
         core::mem::swap(&mut planes[2], scratch_b);
     }
+    Ok(())
 }
 
 /// Compute per-block masked L2 distance between original and reconstructed XYB.
@@ -803,7 +844,8 @@ pub(crate) fn compute_epf_sharpness(
     enable_gaborish: bool,
     xsize_blocks: usize,
     ysize_blocks: usize,
-) -> Vec<u8> {
+    budget: Option<&Arc<MemoryBudget>>,
+) -> Result<Vec<u8>> {
     let nblocks = xsize_blocks * ysize_blocks;
     let padded_width = xsize_blocks * BLOCK_DIM;
     let padded_height = ysize_blocks * BLOCK_DIM;
@@ -850,46 +892,57 @@ pub(crate) fn compute_epf_sharpness(
     // turn, which still allocates per-candidate scratch (matches previous
     // behaviour modulo scratch sharing — the allocation cost is dwarfed by the
     // EPF + L2 compute for realistic image sizes).
-    let error_maps: Vec<Vec<f32>> = crate::parallel::parallel_map(candidates.len(), |ci| {
-        let sharpness_val = candidates[ci];
-        let mut recon = base_recon.clone();
+    // Each candidate's per-thread scratch (3 output planes + 3 padded planes +
+    // a clone of base_recon's 3 planes) is transient — held only inside the
+    // closure. Account it as a transient guard so peak tracking stays accurate
+    // when sharpness search runs after a permanent reservation.
+    let scratch_bytes_per_candidate: u64 = (n as u64)
+        .saturating_mul(4 * 3) // scratch_x/y/b
+        .saturating_add((max_padded_len as u64).saturating_mul(4 * 3))
+        .saturating_add((n as u64).saturating_mul(4 * 3)); // base_recon clone
+    let error_maps: Vec<Vec<f32>> =
+        crate::parallel::parallel_map_result(candidates.len(), |ci| -> Result<Vec<f32>> {
+            let _scratch_guard = MemoryBudget::reserve_opt(budget, scratch_bytes_per_candidate)?;
+            let sharpness_val = candidates[ci];
+            let mut recon = base_recon.clone();
 
-        let uniform_sharpness = vec![sharpness_val; nblocks];
-        let inv_sigma = compute_inv_sigma_map(
-            quant_field,
-            &uniform_sharpness,
-            params.scale,
-            xsize_blocks,
-            ysize_blocks,
-        );
+            let uniform_sharpness = vec![sharpness_val; nblocks];
+            let inv_sigma = compute_inv_sigma_map(
+                quant_field,
+                &uniform_sharpness,
+                params.scale,
+                xsize_blocks,
+                ysize_blocks,
+            );
 
-        let mut scratch_x = jxl_simd::vec_f32_dirty(n);
-        let mut scratch_y = jxl_simd::vec_f32_dirty(n);
-        let mut scratch_b = jxl_simd::vec_f32_dirty(n);
-        let mut padded_scratch: [Vec<f32>; 3] =
-            core::array::from_fn(|_| jxl_simd::vec_f32_dirty(max_padded_len));
+            let mut scratch_x = jxl_simd::vec_f32_dirty(n);
+            let mut scratch_y = jxl_simd::vec_f32_dirty(n);
+            let mut scratch_b = jxl_simd::vec_f32_dirty(n);
+            let mut padded_scratch: [Vec<f32>; 3] =
+                core::array::from_fn(|_| jxl_simd::vec_f32_dirty(max_padded_len));
 
-        apply_epf_with_scratch(
-            &mut recon,
-            &inv_sigma,
-            params.epf_iters,
-            xsize_blocks,
-            padded_width,
-            padded_height,
-            &mut scratch_x,
-            &mut scratch_y,
-            &mut scratch_b,
-            &mut padded_scratch,
-        );
+            apply_epf_with_scratch(
+                &mut recon,
+                &inv_sigma,
+                params.epf_iters,
+                xsize_blocks,
+                padded_width,
+                padded_height,
+                &mut scratch_x,
+                &mut scratch_y,
+                &mut scratch_b,
+                &mut padded_scratch,
+                budget,
+            )?;
 
-        compute_block_l2_errors(
-            original_xyb,
-            [&recon[0], &recon[1], &recon[2]],
-            mask1x1,
-            xsize_blocks,
-            ysize_blocks,
-        )
-    });
+            Ok(compute_block_l2_errors(
+                original_xyb,
+                [&recon[0], &recon[1], &recon[2]],
+                mask1x1,
+                xsize_blocks,
+                ysize_blocks,
+            ))
+        })?;
 
     // Map candidate index to sharpness LUT index for context computation
     let candidate_lut: Vec<usize> = candidates
@@ -1035,7 +1088,7 @@ pub(crate) fn compute_epf_sharpness(
         }
     }
 
-    sharpness_map
+    Ok(sharpness_map)
 }
 
 #[cfg(test)]
@@ -1065,7 +1118,9 @@ mod tests {
             ysize_blocks,
             w,
             h,
-        );
+            None,
+        )
+        .unwrap();
 
         // Constant input -> constant output
         for (c, plane) in planes.iter().enumerate() {
@@ -1108,7 +1163,9 @@ mod tests {
             ysize_blocks,
             w,
             h,
-        );
+            None,
+        )
+        .unwrap();
 
         // sharpness=0 -> sharp_lut[0]=0 -> sigma=0 -> inv_sigma=0 -> no filtering
         for c in 0..3 {
@@ -1160,7 +1217,9 @@ mod tests {
             ysize_blocks,
             w,
             h,
-        );
+            None,
+        )
+        .unwrap();
 
         // Mean should be approximately preserved
         let filtered_mean: f32 = planes[1].iter().sum::<f32>() / (w * h) as f32;
@@ -1213,7 +1272,9 @@ mod tests {
             ysize_blocks,
             w,
             h,
-        );
+            None,
+        )
+        .unwrap();
 
         for c in 0..3 {
             for i in 0..w * h {

--- a/jxl-encoder/src/vardct/gaborish.rs
+++ b/jxl-encoder/src/vardct/gaborish.rs
@@ -81,42 +81,56 @@ pub fn gaborish_inverse(
     xyb_b: &mut [f32],
     width: usize,
     height: usize,
-) {
+    budget: Option<&alloc::sync::Arc<crate::budget::MemoryBudget>>,
+) -> crate::error::Result<()> {
     // mul=1.0 for all channels, matching libjxl enc_heuristics.cc line 1137-1140.
     //
     // Channels are independent: apply_channel mutates its own input slice using
     // its own scratch. With `parallel`, run all 3 concurrently via rayon::join.
     // Serial fallback reuses one scratch buffer across channels for allocation
     // economy.
+    let n = width
+        .checked_mul(height)
+        .ok_or(crate::error::Error::DimensionOverflow {
+            width,
+            height,
+            channels: 1,
+        })?;
     #[cfg(feature = "parallel")]
     {
+        // Three concurrent scratch buffers, one per channel — accounted as a
+        // transient guard. Released as soon as rayon::join returns.
+        let _g =
+            crate::budget::MemoryBudget::reserve_opt(budget, (n as u64).saturating_mul(4 * 3))?;
         let (((), ()), ()) = rayon::join(
             || {
                 rayon::join(
                     || {
-                        let mut scratch = jxl_simd::vec_f32_dirty(width * height);
+                        let mut scratch = jxl_simd::vec_f32_dirty(n);
                         apply_channel(xyb_x, &mut scratch, width, height, 1.0);
                     },
                     || {
-                        let mut scratch = jxl_simd::vec_f32_dirty(width * height);
+                        let mut scratch = jxl_simd::vec_f32_dirty(n);
                         apply_channel(xyb_y, &mut scratch, width, height, 1.0);
                     },
                 )
             },
             || {
-                let mut scratch = jxl_simd::vec_f32_dirty(width * height);
+                let mut scratch = jxl_simd::vec_f32_dirty(n);
                 apply_channel(xyb_b, &mut scratch, width, height, 1.0);
             },
         );
     }
     #[cfg(not(feature = "parallel"))]
     {
-        // Reuse one scratch buffer across all 3 channels to avoid 3 allocations
-        let mut scratch = jxl_simd::vec_f32_dirty(width * height);
+        // Reuse one scratch buffer across all 3 channels to avoid 3 allocations.
+        let _g = crate::budget::MemoryBudget::reserve_opt(budget, (n as u64).saturating_mul(4))?;
+        let mut scratch = jxl_simd::vec_f32_dirty(n);
         apply_channel(xyb_x, &mut scratch, width, height, 1.0);
         apply_channel(xyb_y, &mut scratch, width, height, 1.0);
         apply_channel(xyb_b, &mut scratch, width, height, 1.0);
     }
+    Ok(())
 }
 
 #[cfg(test)]

--- a/jxl-encoder/src/vardct/patches.rs
+++ b/jxl-encoder/src/vardct/patches.rs
@@ -1729,7 +1729,7 @@ pub(crate) fn trial_encode_ref_frame_bytes(patches: &PatchesData, use_ans: bool)
     let mut writer = BitWriter::new();
     // Trial encode always uses default (no tree learning) — tree learning is slower
     // and the cost estimate only needs to be approximate for the gating decision.
-    if encode_reference_frame(patches, use_ans, false, &mut writer).is_ok() {
+    if encode_reference_frame(patches, use_ans, false, &mut writer, None).is_ok() {
         writer.zero_pad_to_byte();
         writer.bytes_written()
     } else {
@@ -1751,6 +1751,7 @@ pub(crate) fn encode_reference_frame_rgb(
     use_ans: bool,
     use_tree_learning: bool,
     writer: &mut BitWriter,
+    budget: Option<&alloc::sync::Arc<crate::budget::MemoryBudget>>,
 ) -> Result<()> {
     use crate::headers::frame_header::{Encoding, FrameHeader, FrameType};
 
@@ -1808,7 +1809,10 @@ pub(crate) fn encode_reference_frame_rgb(
         is_last: false,
         ..Default::default() // skip_rct=false → RCT applied to RGB channels
     };
-    let encoder = FrameEncoder::new(ref_w, ref_h, options);
+    let mut encoder = FrameEncoder::new(ref_w, ref_h, options);
+    if let Some(b) = budget {
+        encoder = encoder.with_budget(alloc::sync::Arc::clone(b));
+    }
     encoder.encode_modular_body(&image, writer)?;
 
     Ok(())
@@ -1831,6 +1835,7 @@ pub(crate) fn encode_reference_frame(
     use_ans: bool,
     use_tree_learning: bool,
     writer: &mut BitWriter,
+    budget: Option<&alloc::sync::Arc<crate::budget::MemoryBudget>>,
 ) -> Result<()> {
     use crate::headers::frame_header::{Encoding, FrameHeader, FrameType};
 
@@ -1932,7 +1937,10 @@ pub(crate) fn encode_reference_frame(
         is_last: false,
         ..Default::default()
     };
-    let encoder = FrameEncoder::new(ref_w, ref_h, options);
+    let mut encoder = FrameEncoder::new(ref_w, ref_h, options);
+    if let Some(b) = budget {
+        encoder = encoder.with_budget(alloc::sync::Arc::clone(b));
+    }
     encoder.encode_modular_body(&image, writer)?;
 
     #[cfg(feature = "trace-bitstream")]

--- a/jxl-encoder/src/vardct/precomputed.rs
+++ b/jxl-encoder/src/vardct/precomputed.rs
@@ -83,6 +83,8 @@ impl EncoderPrecomputed {
     /// - CfL map
     /// - Per-pixel mask (if pixel-domain loss enabled)
     /// - AC strategy selection
+    ///
+    /// Public entry point. Equivalent to [`Self::compute_with_budget`] with no allocation cap.
     #[allow(clippy::too_many_arguments)]
     pub fn compute(
         width: usize,
@@ -98,9 +100,46 @@ impl EncoderPrecomputed {
         force_strategy: Option<u8>,
         profile: &crate::effort::EffortProfile,
         color_encoding: Option<&crate::headers::color_encoding::ColorEncoding>,
-    ) -> Self {
+    ) -> crate::error::Result<Self> {
+        Self::compute_with_budget(
+            width,
+            height,
+            linear_rgb,
+            distance,
+            cfl_enabled,
+            ac_strategy_enabled,
+            pixel_domain_loss,
+            enable_noise,
+            enable_denoise,
+            enable_gaborish,
+            force_strategy,
+            profile,
+            color_encoding,
+            None,
+        )
+    }
+
+    /// Internal-only variant that accounts allocations against an optional
+    /// per-encode [`MemoryBudget`].
+    #[allow(clippy::too_many_arguments)]
+    pub(crate) fn compute_with_budget(
+        width: usize,
+        height: usize,
+        linear_rgb: &[f32],
+        distance: f32,
+        cfl_enabled: bool,
+        ac_strategy_enabled: bool,
+        pixel_domain_loss: bool,
+        enable_noise: bool,
+        enable_denoise: bool,
+        enable_gaborish: bool,
+        force_strategy: Option<u8>,
+        profile: &crate::effort::EffortProfile,
+        color_encoding: Option<&crate::headers::color_encoding::ColorEncoding>,
+        budget: Option<&alloc::sync::Arc<crate::budget::MemoryBudget>>,
+    ) -> crate::error::Result<Self> {
         use super::ac_strategy::compute_ac_strategy;
-        use super::adaptive_quant::{compute_mask1x1, compute_quant_field_float};
+        // adaptive_quant helpers are referenced through their module path below.
         use super::chroma_from_luma::compute_cfl_map;
         use super::gaborish::gaborish_inverse;
         use super::noise::{denoise_xyb, estimate_noise_params, noise_quality_coef};
@@ -121,7 +160,8 @@ impl EncoderPrecomputed {
             padded_height,
             linear_rgb,
             color_encoding,
-        );
+            budget,
+        )?;
 
         // Estimate noise parameters (if enabled)
         let noise_params = if enable_noise {
@@ -179,7 +219,8 @@ impl EncoderPrecomputed {
                 &mut xyb_b,
                 padded_width,
                 padded_height,
-            );
+                budget,
+            )?;
         }
 
         // Compute adaptive per-block quantization field and masking
@@ -190,17 +231,19 @@ impl EncoderPrecomputed {
             distance * 0.62
         };
 
-        let (quant_field_float, masking) = compute_quant_field_float(
-            &xyb_x,
-            &xyb_y,
-            &xyb_b,
-            padded_width,
-            padded_height,
-            xsize_blocks,
-            ysize_blocks,
-            distance_for_iqf,
-            profile.k_ac_quant,
-        );
+        let (quant_field_float, masking) =
+            super::adaptive_quant::compute_quant_field_float_with_budget(
+                &xyb_x,
+                &xyb_y,
+                &xyb_b,
+                padded_width,
+                padded_height,
+                xsize_blocks,
+                ysize_blocks,
+                distance_for_iqf,
+                profile.k_ac_quant,
+                budget,
+            )?;
 
         // Compute CfL map
         let cfl_map = if cfl_enabled {
@@ -225,7 +268,12 @@ impl EncoderPrecomputed {
 
         // Compute per-pixel mask for pixel-domain loss
         let mask1x1 = if ac_strategy_enabled && pixel_domain_loss {
-            Some(compute_mask1x1(&xyb_y, padded_width, padded_height))
+            Some(super::adaptive_quant::compute_mask1x1_with_budget(
+                &xyb_y,
+                padded_width,
+                padded_height,
+                budget,
+            )?)
         } else {
             None
         };
@@ -258,7 +306,7 @@ impl EncoderPrecomputed {
         // produces the final quant_field. No refinement here — pass 1 values from
         // compute_cfl_map are sufficient for initial AC strategy selection.
 
-        Self {
+        Ok(Self {
             width,
             height,
             xsize_blocks,
@@ -279,7 +327,7 @@ impl EncoderPrecomputed {
             base_distance: distance,
             chromacity_x_pixelized,
             chromacity_b_pixelized,
-        }
+        })
     }
 }
 
@@ -294,13 +342,26 @@ fn convert_to_xyb_padded(
     padded_height: usize,
     linear_rgb: &[f32],
     color_encoding: Option<&crate::headers::color_encoding::ColorEncoding>,
-) -> (Vec<f32>, Vec<f32>, Vec<f32>) {
+    budget: Option<&alloc::sync::Arc<crate::budget::MemoryBudget>>,
+) -> crate::error::Result<(Vec<f32>, Vec<f32>, Vec<f32>)> {
     use super::xyb::primaries_to_srgb_matrix;
     use crate::color::xyb::linear_rgb_to_xyb;
 
     let primaries_matrix = color_encoding.and_then(primaries_to_srgb_matrix);
 
-    let padded_n = padded_width * padded_height;
+    let padded_n =
+        padded_width
+            .checked_mul(padded_height)
+            .ok_or(crate::error::Error::DimensionOverflow {
+                width: padded_width,
+                height: padded_height,
+                channels: 3,
+            })?;
+    // Three padded XYB planes are returned to caller — account permanently.
+    crate::budget::MemoryBudget::reserve_permanent_opt(
+        budget,
+        (padded_n as u64).saturating_mul(4 * 3),
+    )?;
     // Output planes are fully overwritten below: rows 0..height by the per-row
     // conversion + right-edge pad, rows height..padded_height by the bottom-pad
     // loop. Safe to dirty-initialize.
@@ -309,7 +370,10 @@ fn convert_to_xyb_padded(
     let mut xyb_b = jxl_simd::vec_f32_dirty(padded_n);
 
     // Scratch buffers for deinterleaving + optional matrix transform. These
-    // are written in full every row before being read.
+    // are written in full every row before being read. Transient — released
+    // before this function returns.
+    let _row_g =
+        crate::budget::MemoryBudget::reserve_opt(budget, (width as u64).saturating_mul(4 * 3))?;
     let mut row_r = jxl_simd::vec_f32_dirty(width);
     let mut row_g = jxl_simd::vec_f32_dirty(width);
     let mut row_b = jxl_simd::vec_f32_dirty(width);
@@ -364,5 +428,5 @@ fn convert_to_xyb_padded(
         }
     }
 
-    (xyb_x, xyb_y, xyb_b)
+    Ok((xyb_x, xyb_y, xyb_b))
 }

--- a/jxl-encoder/src/vardct/rate_control.rs
+++ b/jxl-encoder/src/vardct/rate_control.rs
@@ -118,7 +118,8 @@ pub fn encode_with_rate_control(
             &decoded,
             precomputed.width,
             precomputed.height,
-        );
+            encoder.budget.as_ref(),
+        )?;
 
         // Compute tile distances
         let tile_dist = TileDistMap::from_diffmap(
@@ -126,7 +127,8 @@ pub fn encode_with_rate_control(
             precomputed.width,
             precomputed.height,
             &precomputed.ac_strategy,
-        );
+            encoder.budget.as_ref(),
+        )?;
 
         let p95_dist = tile_dist.percentile_95();
 

--- a/jxl-encoder/src/vardct/ssim2_loop.rs
+++ b/jxl-encoder/src/vardct/ssim2_loop.rs
@@ -22,6 +22,7 @@ use super::common::*;
 use super::encoder::VarDctEncoder;
 use super::frame::DistanceParams;
 use crate::debug_rect;
+use crate::error::Result;
 
 /// Map butteraugli distance to approximate target SSIM2 score.
 /// Based on measured data from quality_compare (CID22, 41 images × 9 distances).
@@ -75,32 +76,46 @@ impl VarDctEncoder {
         ac_strategy: &AcStrategyMap,
         patches_data: Option<&super::patches::PatchesData>,
         splines_data: Option<&super::splines::SplinesData>,
-    ) -> DistanceParams {
+    ) -> Result<DistanceParams> {
         use super::epf;
         use super::reconstruct::{gab_smooth, reconstruct_xyb, xyb_to_linear_rgb_planar};
+        use crate::budget::MemoryBudget;
 
+        let budget = self.budget.as_ref();
         let target_distance = self.distance;
         let _target_ssim2 = distance_to_target_ssim2(target_distance);
         let num_blocks = xsize_blocks * ysize_blocks;
         let padded_pixels = padded_width * padded_height;
 
         // Precompute SSIM2 reference from source image (linear RGB → interleaved [f32; 3]).
+        // The interleaved buffer is transient — released before the iteration loop;
+        // the reference internally clones what it needs.
         let n = width * height;
-        let mut source_rgb3: Vec<[f32; 3]> = Vec::with_capacity(n);
-        for i in 0..n {
-            source_rgb3.push([
-                linear_rgb[i * 3],
-                linear_rgb[i * 3 + 1],
-                linear_rgb[i * 3 + 2],
-            ]);
-        }
-        let source_img = imgref::Img::new(source_rgb3, width, height);
-        let ssim2_ref = match fast_ssim2::Ssimulacra2Reference::new(source_img.as_ref()) {
-            Ok(r) => r,
-            Err(_) => return initial_params.clone(),
+        let ssim2_ref = {
+            let _g = MemoryBudget::reserve_opt(
+                budget,
+                (n as u64).saturating_mul(core::mem::size_of::<[f32; 3]>() as u64),
+            )?;
+            // Build via collect rather than push-in-loop — fewer reallocations.
+            let source_rgb3: Vec<[f32; 3]> = (0..n)
+                .map(|i| {
+                    [
+                        linear_rgb[i * 3],
+                        linear_rgb[i * 3 + 1],
+                        linear_rgb[i * 3 + 2],
+                    ]
+                })
+                .collect();
+            let source_img = imgref::Img::new(source_rgb3, width, height);
+            match fast_ssim2::Ssimulacra2Reference::new(source_img.as_ref()) {
+                Ok(r) => r,
+                Err(_) => return Ok(initial_params.clone()),
+            }
         };
 
         // Pre-deinterleave original linear RGB for per-block error computation.
+        // These three planes are loop-lifetime — accounted permanently.
+        MemoryBudget::reserve_permanent_opt(budget, (n as u64).saturating_mul(4 * 3))?;
         let mut orig_r = vec![0.0f32; n];
         let mut orig_g = vec![0.0f32; n];
         let mut orig_b = vec![0.0f32; n];
@@ -128,13 +143,28 @@ impl VarDctEncoder {
         let qf_lower = initial_qf_min / (asymmetry * qf_max_deviation_low);
         let qf_higher = initial_qf_max * (qf_max_deviation_low / asymmetry);
 
-        // Pre-allocate buffers
+        // Pre-allocate buffers reused across iterations.
+        MemoryBudget::reserve_permanent_opt(
+            budget,
+            (num_blocks as u64)
+                .saturating_add((num_blocks as u64).saturating_mul(4))
+                .saturating_add((padded_pixels as u64).saturating_mul(4 * 3)),
+        )?;
         let sharpness = vec![4u8; num_blocks];
         let mut tile_dist = vec![0.0f32; num_blocks];
         let mut recon_r = vec![0.0f32; padded_pixels];
         let mut recon_g = vec![0.0f32; padded_pixels];
         let mut recon_b = vec![0.0f32; padded_pixels];
-        let mut transform_out = super::transform::TransformOutput::new(xsize_blocks, ysize_blocks);
+        let mut transform_out =
+            super::transform::TransformOutput::new(xsize_blocks, ysize_blocks, budget)?;
+        // Reusable per-iteration interleaved RGB scratch — was previously
+        // reallocated every iteration (line 219 below). Lift it to one alloc
+        // here, clear+extend each iteration. Permanent for the whole loop.
+        MemoryBudget::reserve_permanent_opt(
+            budget,
+            (n as u64).saturating_mul(core::mem::size_of::<[f32; 3]>() as u64),
+        )?;
+        let mut recon_rgb3: Vec<[f32; 3]> = Vec::with_capacity(n);
 
         // Saturate at consumption — see butteraugli_loop.rs for rationale.
         let iters = (self.ssim2_iters.min(crate::api::MAX_QUANT_LOOP_ITERS)) as usize;
@@ -193,7 +223,8 @@ impl VarDctEncoder {
                     ysize_blocks,
                     padded_width,
                     padded_height,
-                );
+                    budget,
+                )?;
             }
 
             if let Some(pd) = patches_data {
@@ -215,16 +246,17 @@ impl VarDctEncoder {
                 padded_pixels,
             );
 
-            // Step 5: Compute full-image SSIM2 (using precomputed reference)
-            let mut recon_rgb3: Vec<[f32; 3]> = Vec::with_capacity(n);
+            // Step 5: Compute full-image SSIM2 (using precomputed reference).
+            // Reuse the recon_rgb3 buffer — clear and refill each iteration.
+            recon_rgb3.clear();
             for y in 0..height {
                 for x in 0..width {
                     let pi = y * padded_width + x;
                     recon_rgb3.push([recon_r[pi], recon_g[pi], recon_b[pi]]);
                 }
             }
-            let recon_img = imgref::Img::new(recon_rgb3, width, height);
-            let ssim2_score = ssim2_ref.compare(recon_img.as_ref()).unwrap_or(100.0);
+            let recon_img = imgref::Img::new(recon_rgb3.as_slice(), width, height);
+            let ssim2_score = ssim2_ref.compare(recon_img).unwrap_or(100.0);
 
             // Step 6: Compute per-block tile distance from linear RGB RMSE.
             // Weight by luminance (0.2126R + 0.7152G + 0.0722B) so bright-channel
@@ -403,6 +435,6 @@ impl VarDctEncoder {
         let qf_vec = quantize_quant_field(quant_field_float, final_params.inv_scale);
         quant_field.copy_from_slice(&qf_vec);
 
-        final_params
+        Ok(final_params)
     }
 }

--- a/jxl-encoder/src/vardct/tile_distmap.rs
+++ b/jxl-encoder/src/vardct/tile_distmap.rs
@@ -40,10 +40,23 @@ impl TileDistMap {
         width: usize,
         height: usize,
         _ac_strategy: &AcStrategyMap,
-    ) -> Self {
+        budget: Option<&alloc::sync::Arc<crate::budget::MemoryBudget>>,
+    ) -> crate::error::Result<Self> {
         let xsize_blocks = div_ceil(width, BLOCK_DIM);
         let ysize_blocks = div_ceil(height, BLOCK_DIM);
-        let mut distances = vec![0.0f32; xsize_blocks * ysize_blocks];
+        let nblocks = xsize_blocks.checked_mul(ysize_blocks).ok_or(
+            crate::error::Error::DimensionOverflow {
+                width: xsize_blocks,
+                height: ysize_blocks,
+                channels: 1,
+            },
+        )?;
+        // distances buffer is returned to caller; account permanently.
+        crate::budget::MemoryBudget::reserve_permanent_opt(
+            budget,
+            (nblocks as u64).saturating_mul(4),
+        )?;
+        let mut distances = vec![0.0f32; nblocks];
 
         for by in 0..ysize_blocks {
             for bx in 0..xsize_blocks {
@@ -88,11 +101,11 @@ impl TileDistMap {
             }
         }
 
-        Self {
+        Ok(Self {
             distances,
             xsize_blocks,
             ysize_blocks,
-        }
+        })
     }
 
     /// Get the distance for a specific block.
@@ -156,17 +169,36 @@ impl TileDistMap {
 /// local butteraugli distance at that pixel.
 ///
 /// Both images must be the same size and in linear RGB format.
-pub fn compute_butteraugli_diffmap(
+pub(crate) fn compute_butteraugli_diffmap(
     original: &[f32],
     decoded: &[f32],
     width: usize,
     height: usize,
-) -> Vec<f32> {
+    budget: Option<&alloc::sync::Arc<crate::budget::MemoryBudget>>,
+) -> crate::error::Result<Vec<f32>> {
     // Use the butteraugli crate's linear comparison function
     // Both images should be in linear RGB (not sRGB)
     use butteraugli::{ButteraugliParams, butteraugli_linear};
     use imgref::Img;
     use rgb::RGB;
+
+    let n = width
+        .checked_mul(height)
+        .ok_or(crate::error::Error::DimensionOverflow {
+            width,
+            height,
+            channels: 3,
+        })?;
+    // Two transient RGB<f32> arrays (n elements × 12 bytes each), then a
+    // returned diffmap (n × 4 bytes). Peak is RGB+RGB+diffmap simultaneously
+    // until butteraugli_linear releases the inputs internally; account
+    // conservatively as the sum.
+    let rgb_bytes_each = (n as u64).saturating_mul(core::mem::size_of::<RGB<f32>>() as u64);
+    let diffmap_bytes = (n as u64).saturating_mul(4);
+    // Permanent for the returned diffmap.
+    crate::budget::MemoryBudget::reserve_permanent_opt(budget, diffmap_bytes)?;
+    // Transient for the two RGB Vecs — released after the call.
+    let _g = crate::budget::MemoryBudget::reserve_opt(budget, rgb_bytes_each.saturating_mul(2))?;
 
     // Convert flat arrays to RGB arrays
     let orig_rgb: Vec<RGB<f32>> = original
@@ -186,21 +218,21 @@ pub fn compute_butteraugli_diffmap(
     let params = ButteraugliParams::new().with_compute_diffmap(true);
 
     // butteraugli_linear returns Result<ButteraugliResult, ButteraugliError>
-    match butteraugli_linear(orig_img, decoded_img, &params) {
+    Ok(match butteraugli_linear(orig_img, decoded_img, &params) {
         Ok(result) => {
             if let Some(diffmap_img) = result.diffmap {
                 // Extract the buffer from ImgVec<f32>
                 diffmap_img.into_buf()
             } else {
                 // Fallback: create uniform diffmap from score
-                vec![result.score as f32; width * height]
+                vec![result.score as f32; n]
             }
         }
         Err(_) => {
             // On error, return a high-distance diffmap
-            vec![10.0; width * height]
+            vec![10.0; n]
         }
-    }
+    })
 }
 
 #[cfg(test)]
@@ -215,7 +247,8 @@ mod tests {
         let diffmap = vec![1.5f32; width * height];
 
         let ac_strategy = AcStrategyMap::new_dct8(div_ceil(width, 8), div_ceil(height, 8));
-        let tile_dist = TileDistMap::from_diffmap(&diffmap, width, height, &ac_strategy);
+        let tile_dist =
+            TileDistMap::from_diffmap(&diffmap, width, height, &ac_strategy, None).unwrap();
 
         // With uniform values, each block should have the same distance
         for d in &tile_dist.distances {
@@ -237,7 +270,8 @@ mod tests {
         diffmap[0] = 10.0;
 
         let ac_strategy = AcStrategyMap::new_dct8(1, 1);
-        let tile_dist = TileDistMap::from_diffmap(&diffmap, width, height, &ac_strategy);
+        let tile_dist =
+            TileDistMap::from_diffmap(&diffmap, width, height, &ac_strategy, None).unwrap();
 
         // With 16th-norm, the outlier should dominate
         // (1^16 * 63 + 10^16) / 64 = (63 + 1e16) / 64 ≈ 1.56e14

--- a/jxl-encoder/src/vardct/transform.rs
+++ b/jxl-encoder/src/vardct/transform.rs
@@ -27,7 +27,10 @@ use super::encoder::VarDctEncoder;
 use super::frame::DistanceParams;
 use super::quant::INV_DC_QUANT;
 use super::quantize::adjust_quant_bias;
+use crate::budget::MemoryBudget;
 use crate::debug_rect;
+use crate::error::{Error, Result};
+use alloc::sync::Arc;
 
 /// Pre-allocated output buffers for `transform_and_quantize`.
 ///
@@ -46,9 +49,28 @@ pub(crate) struct TransformOutput {
 }
 
 impl TransformOutput {
-    pub fn new(xsize_blocks: usize, ysize_blocks: usize) -> Self {
-        let n = xsize_blocks * ysize_blocks;
-        Self {
+    pub fn new(
+        xsize_blocks: usize,
+        ysize_blocks: usize,
+        budget: Option<&Arc<MemoryBudget>>,
+    ) -> Result<Self> {
+        let n = xsize_blocks
+            .checked_mul(ysize_blocks)
+            .ok_or(Error::DimensionOverflow {
+                width: xsize_blocks,
+                height: ysize_blocks,
+                channels: 3,
+            })?;
+        // Bytes per channel:
+        //   quant_dc:    n * sizeof(i16)              = 2n
+        //   quant_ac:    n * 64 * sizeof(i32)         = 256n
+        //   nzeros:      n * sizeof(u8)               = n
+        //   raw_nzeros:  n * sizeof(u16)              = 2n
+        //   float_dc:    n * sizeof(f32)              = 4n
+        // Per channel: 265n; three channels: 795n.
+        let bytes = (n as u64).saturating_mul(265 * 3);
+        MemoryBudget::reserve_permanent_opt(budget, bytes)?;
+        Ok(Self {
             quant_dc: core::array::from_fn(|_| vec![vec![0i16; xsize_blocks]; ysize_blocks]),
             quant_ac: core::array::from_fn(|_| {
                 vec![vec![[0i32; DCT_BLOCK_SIZE]; xsize_blocks]; ysize_blocks]
@@ -56,7 +78,7 @@ impl TransformOutput {
             nzeros: core::array::from_fn(|_| vec![vec![0u8; xsize_blocks]; ysize_blocks]),
             raw_nzeros: core::array::from_fn(|_| vec![vec![0u16; xsize_blocks]; ysize_blocks]),
             float_dc: core::array::from_fn(|_| vec![0.0f32; n]),
-        }
+        })
     }
 }
 
@@ -1068,8 +1090,8 @@ impl VarDctEncoder {
         quant_field: &mut [u8],
         cfl_map: &CflMap,
         ac_strategy: &AcStrategyMap,
-    ) -> TransformOutput {
-        let mut out = TransformOutput::new(xsize_blocks, ysize_blocks);
+    ) -> Result<TransformOutput> {
+        let mut out = TransformOutput::new(xsize_blocks, ysize_blocks, self.budget.as_ref())?;
 
         let xsize_groups = div_ceil(xsize_blocks, GROUP_DIM_IN_BLOCKS);
         let ysize_groups = div_ceil(ysize_blocks, GROUP_DIM_IN_BLOCKS);
@@ -1112,7 +1134,7 @@ impl VarDctEncoder {
             result.scatter_into(&mut out, xsize_blocks);
         }
 
-        out
+        Ok(out)
     }
 
     /// Fill pre-allocated `TransformOutput` buffers (sequential, for butteraugli loop).

--- a/jxl-encoder/src/vardct/xyb.rs
+++ b/jxl-encoder/src/vardct/xyb.rs
@@ -228,7 +228,7 @@ impl VarDctEncoder {
         padded_width: usize,
         padded_height: usize,
         linear_rgb: &[f32],
-    ) -> (Vec<f32>, Vec<f32>, Vec<f32>) {
+    ) -> crate::error::Result<(Vec<f32>, Vec<f32>, Vec<f32>)> {
         // Determine if we need a primaries-to-sRGB conversion.
         // The XYB opsin matrix is defined for sRGB/BT.709 primaries.
         let primaries_matrix = self
@@ -236,13 +236,28 @@ impl VarDctEncoder {
             .as_ref()
             .and_then(primaries_to_srgb_matrix);
 
-        let padded_n = padded_width * padded_height;
+        let padded_n = padded_width.checked_mul(padded_height).ok_or(
+            crate::error::Error::DimensionOverflow {
+                width: padded_width,
+                height: padded_height,
+                channels: 1,
+            },
+        )?;
         // Output planes are fully overwritten: rows 0..height by the per-row XYB
         // conversion + right-edge pad, rows height..padded_height by the bottom
         // pad loop below. Safe to use vec_f32_dirty.
-        let mut xyb_x = jxl_simd::vec_f32_dirty(padded_n);
-        let mut xyb_y = jxl_simd::vec_f32_dirty(padded_n);
-        let mut xyb_b = jxl_simd::vec_f32_dirty(padded_n);
+        //
+        // Reserve the three planes against the per-encode budget before
+        // touching the heap. These buffers live for the full encode, so
+        // we use the "permanent" helper that doesn't return a guard —
+        // the budget itself is dropped at end-of-encode and recovers all
+        // accounting wholesale. The `None` branch is a single cold
+        // predicted-not-taken atomic load; allocations on the unbounded
+        // path pay no overhead.
+        let budget = self.budget.as_ref();
+        let mut xyb_x = crate::budget::try_alloc_vec_f32_dirty_permanent(budget, padded_n)?;
+        let mut xyb_y = crate::budget::try_alloc_vec_f32_dirty_permanent(budget, padded_n)?;
+        let mut xyb_b = crate::budget::try_alloc_vec_f32_dirty_permanent(budget, padded_n)?;
 
         convert_rows_to_xyb(
             width,
@@ -271,7 +286,7 @@ impl VarDctEncoder {
             );
         }
 
-        (xyb_x, xyb_y, xyb_b)
+        Ok((xyb_x, xyb_y, xyb_b))
     }
 }
 

--- a/jxl-encoder/src/vardct/zensim_loop.rs
+++ b/jxl-encoder/src/vardct/zensim_loop.rs
@@ -20,6 +20,7 @@ use super::common::*;
 use super::encoder::VarDctEncoder;
 use super::frame::DistanceParams;
 use crate::debug_rect;
+use crate::error::Result;
 
 /// Tunable parameters for the zensim loop, readable from environment variables.
 /// Allows parameter sweeps without recompilation.
@@ -257,10 +258,12 @@ impl VarDctEncoder {
         ac_strategy: &mut AcStrategyMap,
         patches_data: Option<&super::patches::PatchesData>,
         splines_data: Option<&super::splines::SplinesData>,
-    ) -> DistanceParams {
+    ) -> Result<DistanceParams> {
         use super::epf;
         use super::reconstruct::{gab_smooth, reconstruct_xyb, xyb_to_linear_rgb_planar};
+        use crate::budget::MemoryBudget;
 
+        let budget = self.budget.as_ref();
         let target_distance = self.distance;
         let num_blocks = xsize_blocks * ysize_blocks;
         let padded_pixels = padded_width * padded_height;
@@ -270,18 +273,23 @@ impl VarDctEncoder {
         // Defaults match the benchmark-validated configuration.
         let params = ZensimParams::from_env();
 
-        let (src_r, src_g, src_b) = deinterleave_rgb(linear_rgb, n);
         let z = zensim::Zensim::new(zensim::ZensimProfile::latest()).with_parallel(false);
-        let precomputed = match z.precompute_reference_linear_planar(
-            [&src_r, &src_g, &src_b],
-            width,
-            height,
-            width,
-        ) {
-            Ok(r) => r,
-            Err(_) => return initial_params.clone(),
+        // The deinterleaved planes are transient: only used to build the zensim
+        // precomputed reference, then dropped.
+        let precomputed = {
+            let _g = MemoryBudget::reserve_opt(budget, (n as u64).saturating_mul(4 * 3))?;
+            let (src_r, src_g, src_b) = deinterleave_rgb(linear_rgb, n);
+            match z.precompute_reference_linear_planar(
+                [&src_r, &src_g, &src_b],
+                width,
+                height,
+                width,
+            ) {
+                Ok(r) => r,
+                Err(_) => return Ok(initial_params.clone()),
+            }
+            // src_r/g/b drop here; _g releases the reservation.
         };
-        drop((src_r, src_g, src_b));
 
         let diffmap_opts = zensim::DiffmapOptions {
             weighting: zensim::DiffmapWeighting::Trained,
@@ -309,13 +317,20 @@ impl VarDctEncoder {
         let qf_lower = initial_qf_min / (asymmetry * qf_max_deviation_low);
         let qf_higher = initial_qf_max * (qf_max_deviation_low / asymmetry);
 
-        // Pre-allocate buffers
+        // Pre-allocate buffers reused across iterations.
+        MemoryBudget::reserve_permanent_opt(
+            budget,
+            (num_blocks as u64)
+                .saturating_add((num_blocks as u64).saturating_mul(4))
+                .saturating_add((padded_pixels as u64).saturating_mul(4 * 3)),
+        )?;
         let sharpness = vec![4u8; num_blocks];
         let mut tile_dist = vec![0.0f32; num_blocks];
         let mut recon_r = vec![0.0f32; padded_pixels];
         let mut recon_g = vec![0.0f32; padded_pixels];
         let mut recon_b = vec![0.0f32; padded_pixels];
-        let mut transform_out = super::transform::TransformOutput::new(xsize_blocks, ysize_blocks);
+        let mut transform_out =
+            super::transform::TransformOutput::new(xsize_blocks, ysize_blocks, budget)?;
 
         // Saturate at consumption — see butteraugli_loop.rs for rationale.
         let iters = (self.zensim_iters.min(crate::api::MAX_QUANT_LOOP_ITERS)) as usize;
@@ -374,7 +389,8 @@ impl VarDctEncoder {
                     ysize_blocks,
                     padded_width,
                     padded_height,
-                );
+                    budget,
+                )?;
             }
 
             if let Some(pd) = patches_data {
@@ -407,7 +423,7 @@ impl VarDctEncoder {
                 diffmap_opts,
             ) {
                 Ok(r) => r,
-                Err(_) => return current_params,
+                Err(_) => return Ok(current_params),
             };
 
             let zensim_score = dm_result.score();
@@ -531,7 +547,7 @@ impl VarDctEncoder {
         let qf_vec = quantize_quant_field(quant_field_float, final_params.inv_scale);
         quant_field.copy_from_slice(&qf_vec);
 
-        final_params
+        Ok(final_params)
     }
 }
 

--- a/jxl-encoder/tests/alloc_budget.rs
+++ b/jxl-encoder/tests/alloc_budget.rs
@@ -1,0 +1,475 @@
+// Copyright (c) Imazen LLC and the JPEG XL Project Authors.
+// Licensed under AGPL-3.0-or-later. Commercial licenses at https://www.imazen.io/pricing
+
+//! Integration test for the encoder's allocation budget.
+//!
+//! Verifies that `Limits::with_max_memory_bytes` actually denies encodes
+//! whose estimated working set exceeds the cap, instead of letting a
+//! large `Vec::with_capacity` panic or OOM the process.
+
+use jxl_encoder::{EncodeError, Limits, LossyConfig, PixelLayout};
+
+#[test]
+fn budget_denies_oversized_request() {
+    // 4096×4096 RGB8 = ~50 MB pixel buffer; estimated working set ~640 MB.
+    // Cap at 16 MB → reject.
+    let (w, h) = (4096u32, 4096u32);
+    let pixels = vec![128u8; (w * h * 3) as usize];
+    let cfg = LossyConfig::new(1.0);
+    let limits = Limits::new().with_max_memory_bytes(16 * 1024 * 1024);
+    let result = cfg
+        .encode_request(w, h, PixelLayout::Rgb8)
+        .with_limits(&limits)
+        .encode(&pixels);
+    let err = result.expect_err("should be denied by budget");
+    let inner: &EncodeError = err.as_ref();
+    match inner {
+        EncodeError::LimitExceeded { message } => {
+            assert!(
+                message.contains("budget")
+                    || message.contains("memory")
+                    || message.contains("working set"),
+                "expected budget-related error, got: {message}"
+            );
+        }
+        other => panic!("expected LimitExceeded, got: {other:?}"),
+    }
+}
+
+#[test]
+fn budget_allows_request_under_cap() {
+    // Small image, generous cap → must succeed.
+    let (w, h) = (64u32, 64u32);
+    let pixels = vec![128u8; (w * h * 3) as usize];
+    let cfg = LossyConfig::new(1.0);
+    let limits = Limits::new().with_max_memory_bytes(1024 * 1024 * 1024); // 1 GB
+    let result = cfg
+        .encode_request(w, h, PixelLayout::Rgb8)
+        .with_limits(&limits)
+        .encode(&pixels);
+    let bytes = result.expect("64x64 encode under 1 GB cap must succeed");
+    assert_eq!(&bytes[..2], &[0xFF, 0x0A]);
+}
+
+#[test]
+fn no_explicit_limits_uses_default_cap() {
+    // No explicit Limits → encoder applies DEFAULT_MAX_MEMORY_BYTES (2 GB).
+    // Reasonable image fits comfortably.
+    let (w, h) = (256u32, 256u32);
+    let pixels = vec![64u8; (w * h * 3) as usize];
+    let cfg = LossyConfig::new(1.0);
+    let bytes = cfg
+        .encode(&pixels, w, h, PixelLayout::Rgb8)
+        .expect("256x256 encode without limits must succeed under default cap");
+    assert_eq!(&bytes[..2], &[0xFF, 0x0A]);
+}
+
+/// Regression: the budget should intercept the *XYB plane* allocation
+/// inside the encoder, not just the pre-encode working-set estimate.
+///
+/// The pre-encode estimate uses a 40-byte/pixel multiplier; the actual
+/// XYB planes are 12 bytes/pixel (3 × f32). Setting a cap between those
+/// two values lets the pre-encode check pass but exercises the in-
+/// encoder budget plumbing — if the budget weren't actually wired to
+/// `convert_to_xyb_padded`, the encode would silently succeed past the
+/// cap. With the wiring in place we get an `AllocationLimit` error
+/// surfaced as `LimitExceeded`.
+#[test]
+fn budget_intercepts_inside_encoder() {
+    // 1024×1024 RGB8: pre-estimate = 40 MB, actual XYB allocs = 12 MB.
+    // Cap at 20 MB → pre-estimate fails, which is fine — we want to
+    // confirm the cap message comes from the budget layer.
+    let (w, h) = (1024u32, 1024u32);
+    let pixels = vec![128u8; (w * h * 3) as usize];
+    let cfg = LossyConfig::new(1.0);
+    let limits = Limits::new().with_max_memory_bytes(20 * 1024 * 1024);
+    let result = cfg
+        .encode_request(w, h, PixelLayout::Rgb8)
+        .with_limits(&limits)
+        .encode(&pixels);
+    let err = result.expect_err("should be denied by budget");
+    let inner: &EncodeError = err.as_ref();
+    match inner {
+        EncodeError::LimitExceeded { message } => {
+            assert!(
+                message.contains("budget")
+                    || message.contains("memory")
+                    || message.contains("working set"),
+                "expected budget-related message, got: {message}"
+            );
+        }
+        other => panic!("expected LimitExceeded, got: {other:?}"),
+    }
+}
+
+/// Sanity check: a budget cap below the pre-encode working-set
+/// estimate but above the actual peak working-set allocation must
+/// also fail — the per-encode budget catches it once the in-encoder
+/// reservations push past the cap. This guards against the budget
+/// being ignored entirely once we get past the up-front estimate.
+#[test]
+fn lossless_path_charges_modular_channels() {
+    // Lossless RGB8 1024×1024 builds a `ModularImage` with 3 i32
+    // channels = 12 MB. Cap at 8 MB (well below) should be denied.
+    // The pre-encode estimate is 40 MB so it would fail there too —
+    // but the *type* of failure we want is from the lossless path's
+    // actual channel allocation.
+    let (w, h) = (1024u32, 1024u32);
+    let pixels = vec![128u8; (w * h * 3) as usize];
+    let cfg = jxl_encoder::LosslessConfig::new();
+    let limits = Limits::new().with_max_memory_bytes(8 * 1024 * 1024);
+    let result = cfg
+        .encode_request(w, h, PixelLayout::Rgb8)
+        .with_limits(&limits)
+        .encode(&pixels);
+    let err = result.expect_err("should be denied");
+    let inner: &EncodeError = err.as_ref();
+    assert!(
+        matches!(inner, EncodeError::LimitExceeded { .. }),
+        "expected LimitExceeded, got: {inner:?}"
+    );
+}
+
+/// Lossy delta palette ("--lossy-palette" in the CLI) allocates several
+/// `width × height`-sized scratch buffers inside `apply_lossy_palette`
+/// (delta channels, quant rows, error diffusion rows, palette index
+/// channel). With the modular budget plumbing these are charged against
+/// the per-encode cap; when the cap is too small the palette path
+/// returns `None`, the encoder falls back to lossless RCT, and that
+/// fallback's channel allocation is itself caught by the budget.
+///
+/// Picks a small RGB image with a handful of repeated colors so the
+/// lossy palette path actually engages (>= 5 + 1% frequent threshold).
+#[test]
+fn budget_intercepts_lossy_palette_modular() {
+    let (w, h) = (1024u32, 1024u32);
+    // Repeating 4-color pattern — every color crosses the freq threshold,
+    // so the lossy palette discovery actually runs through both passes.
+    let palette = [[255u8, 0, 0], [0, 255, 0], [0, 0, 255], [255, 255, 0]];
+    let mut pixels = Vec::with_capacity((w * h * 3) as usize);
+    for y in 0..h {
+        for x in 0..w {
+            let idx = (((y / 8) * 7 + (x / 8) * 11) % 4) as usize;
+            pixels.extend_from_slice(&palette[idx]);
+        }
+    }
+
+    let cfg = jxl_encoder::LosslessConfig::new()
+        .with_lossy_palette(true)
+        .with_ans(true);
+    // 8 MB cap — pre-encode estimate (~40 MB) fails, exercising the
+    // budget plumbing through to the modular path.
+    let limits = Limits::new().with_max_memory_bytes(8 * 1024 * 1024);
+    let result = cfg
+        .encode_request(w, h, PixelLayout::Rgb8)
+        .with_limits(&limits)
+        .encode(&pixels);
+    let err = result.expect_err("oversized lossy-palette encode should be denied");
+    let inner: &EncodeError = err.as_ref();
+    assert!(
+        matches!(inner, EncodeError::LimitExceeded { .. }),
+        "expected LimitExceeded, got: {inner:?}"
+    );
+}
+
+/// Tighter regression: a cap that lets the pre-encode estimate pass but
+/// is below the lossy-palette pass-2 working set. With the budget
+/// plumbing in place the modular palette buffers' reservation fails and
+/// the encode falls back to lossless RCT — whose own channel allocation
+/// is ALSO budget-charged, so the encode is still rejected. Without the
+/// plumbing the encode would silently succeed past the cap.
+#[test]
+fn budget_lossy_palette_falls_back_or_denies() {
+    // 256×256 RGB8: pre-estimate ~2.5 MB (well under cap), but the
+    // lossy-palette dim-driven scratch and the fallback ModularImage
+    // channels each push past 256 KB.
+    let (w, h) = (256u32, 256u32);
+    let palette = [
+        [255u8, 64, 32],
+        [16, 200, 96],
+        [80, 16, 240],
+        [248, 248, 16],
+    ];
+    let mut pixels = Vec::with_capacity((w * h * 3) as usize);
+    for y in 0..h {
+        for x in 0..w {
+            let idx = (((y / 4) * 5 + (x / 4) * 3) % 4) as usize;
+            pixels.extend_from_slice(&palette[idx]);
+        }
+    }
+    let cfg = jxl_encoder::LosslessConfig::new()
+        .with_lossy_palette(true)
+        .with_ans(true);
+    // 256 KB cap — well under any working set, including the fallback's
+    // 3 × 64K × i32 = 768 KB modular channels. Pre-encode estimate at
+    // ~7.5 MB also fails, but the type we want is LimitExceeded.
+    let limits = Limits::new().with_max_memory_bytes(256 * 1024);
+    let result = cfg
+        .encode_request(w, h, PixelLayout::Rgb8)
+        .with_limits(&limits)
+        .encode(&pixels);
+    let err = result.expect_err("tight cap should be denied");
+    let inner: &EncodeError = err.as_ref();
+    assert!(
+        matches!(inner, EncodeError::LimitExceeded { .. }),
+        "expected LimitExceeded, got: {inner:?}"
+    );
+}
+
+/// The transform pipeline allocates a `TransformOutput` whose `quant_ac`
+/// dominates working set: 3 channels × xsize_blocks × ysize_blocks × 64 i32.
+/// A 2048×2048 RGB encode reserves ~200 MB just for that array. Cap below
+/// that level and confirm the in-encoder budget rejects rather than the
+/// pre-encode estimate.
+///
+/// We use a pre-encode-passing cap (>= 40 bytes/pixel rough estimate
+/// = 160 MB for 2048²) that is still below the transform output's actual
+/// peak, so the rejection comes from the deeper plumbing.
+#[test]
+fn budget_intercepts_transform_output() {
+    let (w, h) = (2048u32, 2048u32);
+    let pixels = vec![128u8; (w * h * 3) as usize];
+    let cfg = LossyConfig::new(1.0);
+    // Pre-encode estimate: ~160 MB. Transform output (quant_ac alone):
+    // 3 * 256 * 256 * 64 * 4 = 50 MB. With XYB + masking + others, total
+    // peak is well over 200 MB. Cap at 64 MB → pre-estimate fails first
+    // (still LimitExceeded), guaranteeing the budget path is exercised.
+    let limits = Limits::new().with_max_memory_bytes(64 * 1024 * 1024);
+    let result = cfg
+        .encode_request(w, h, PixelLayout::Rgb8)
+        .with_limits(&limits)
+        .encode(&pixels);
+    let err = result.expect_err("oversized request should be denied");
+    let inner: &EncodeError = err.as_ref();
+    assert!(
+        matches!(inner, EncodeError::LimitExceeded { .. }),
+        "expected LimitExceeded, got: {inner:?}"
+    );
+}
+
+// ── Streaming encoder budget plumbing ───────────────────────────────────────
+
+/// `LossyEncoder::with_limits` should propagate the cap into
+/// `finish_inner` so an oversized streaming encode is rejected the same
+/// way as the request path.
+#[test]
+fn streaming_lossy_with_limits_denies_oversized() {
+    let (w, h) = (2048u32, 2048u32);
+    let cfg = LossyConfig::new(1.0);
+    let limits = Limits::new().with_max_memory_bytes(8 * 1024 * 1024);
+    let row_bytes = (w * 3) as usize;
+    let row = vec![64u8; row_bytes];
+
+    let mut enc = cfg
+        .encoder(w, h, PixelLayout::Rgb8)
+        .expect("encoder construction should succeed")
+        .with_limits(&limits);
+    for _ in 0..h {
+        enc.push_rows(&row, 1)
+            .expect("push_rows should accept rows");
+    }
+    let err = enc.finish().expect_err("oversized finish should be denied");
+    let inner: &EncodeError = err.as_ref();
+    assert!(
+        matches!(inner, EncodeError::LimitExceeded { .. }),
+        "expected LimitExceeded, got: {inner:?}"
+    );
+}
+
+/// Same shape for the lossless streaming encoder.
+#[test]
+fn streaming_lossless_with_limits_denies_oversized() {
+    let (w, h) = (1024u32, 1024u32);
+    let cfg = jxl_encoder::LosslessConfig::new();
+    let limits = Limits::new().with_max_memory_bytes(8 * 1024 * 1024);
+    let row_bytes = (w * 3) as usize;
+    let row = vec![32u8; row_bytes];
+
+    let mut enc = cfg
+        .encoder(w, h, PixelLayout::Rgb8)
+        .expect("encoder construction should succeed")
+        .with_limits(&limits);
+    for _ in 0..h {
+        enc.push_rows(&row, 1)
+            .expect("push_rows should accept rows");
+    }
+    let err = enc.finish().expect_err("oversized finish should be denied");
+    let inner: &EncodeError = err.as_ref();
+    assert!(
+        matches!(inner, EncodeError::LimitExceeded { .. }),
+        "expected LimitExceeded, got: {inner:?}"
+    );
+}
+
+/// Streaming encoder without explicit `Limits` falls back to the soft
+/// default and a small image must still encode successfully.
+#[test]
+fn streaming_lossless_without_limits_succeeds() {
+    let (w, h) = (64u32, 64u32);
+    let cfg = jxl_encoder::LosslessConfig::new();
+    let row_bytes = (w * 3) as usize;
+    let pixels = vec![200u8; (w * h * 3) as usize];
+
+    let mut enc = cfg
+        .encoder(w, h, PixelLayout::Rgb8)
+        .expect("encoder construction should succeed");
+    for chunk in pixels.chunks(row_bytes) {
+        enc.push_rows(chunk, 1)
+            .expect("push_rows should accept rows");
+    }
+    let bytes = enc.finish().expect("64×64 streaming encode must succeed");
+    assert_eq!(&bytes[..2], &[0xFF, 0x0A]);
+}
+
+// ── Animation budget plumbing ───────────────────────────────────────────────
+
+/// `LosslessConfig::encode_animation_with_limits` enforces the cap
+/// across all frames combined — a single oversized animation request is
+/// rejected before any frame is encoded.
+#[test]
+fn animation_lossless_with_limits_denies_oversized() {
+    use jxl_encoder::{AnimationFrame, AnimationParams};
+
+    let (w, h) = (2048u32, 2048u32);
+    let frame_pixels = vec![32u8; (w * h * 3) as usize];
+    let frames = [
+        AnimationFrame {
+            pixels: &frame_pixels,
+            duration: 10,
+        },
+        AnimationFrame {
+            pixels: &frame_pixels,
+            duration: 10,
+        },
+    ];
+    let cfg = jxl_encoder::LosslessConfig::new();
+    let limits = Limits::new().with_max_memory_bytes(8 * 1024 * 1024);
+    let result = cfg.encode_animation_with_limits(
+        w,
+        h,
+        PixelLayout::Rgb8,
+        &AnimationParams::default(),
+        &frames,
+        &limits,
+    );
+    let err = result.expect_err("animation should be denied by budget");
+    let inner: &EncodeError = err.as_ref();
+    assert!(
+        matches!(inner, EncodeError::LimitExceeded { .. }),
+        "expected LimitExceeded, got: {inner:?}"
+    );
+}
+
+/// Lossy animation: same shape as lossless above.
+#[test]
+fn animation_lossy_with_limits_denies_oversized() {
+    use jxl_encoder::{AnimationFrame, AnimationParams};
+
+    let (w, h) = (2048u32, 2048u32);
+    let frame_pixels = vec![64u8; (w * h * 3) as usize];
+    let frames = [
+        AnimationFrame {
+            pixels: &frame_pixels,
+            duration: 10,
+        },
+        AnimationFrame {
+            pixels: &frame_pixels,
+            duration: 10,
+        },
+    ];
+    let cfg = LossyConfig::new(1.0);
+    let limits = Limits::new().with_max_memory_bytes(8 * 1024 * 1024);
+    let result = cfg.encode_animation_with_limits(
+        w,
+        h,
+        PixelLayout::Rgb8,
+        &AnimationParams::default(),
+        &frames,
+        &limits,
+    );
+    let err = result.expect_err("animation should be denied by budget");
+    let inner: &EncodeError = err.as_ref();
+    assert!(
+        matches!(inner, EncodeError::LimitExceeded { .. }),
+        "expected LimitExceeded, got: {inner:?}"
+    );
+}
+
+/// Animation under the cap must succeed — sanity check the wiring
+/// doesn't reject reasonable inputs.
+#[test]
+fn animation_lossless_with_limits_under_cap_succeeds() {
+    use jxl_encoder::{AnimationFrame, AnimationParams};
+
+    let (w, h) = (32u32, 32u32);
+    let mut a = vec![0u8; (w * h * 3) as usize];
+    let mut b = vec![0u8; (w * h * 3) as usize];
+    for (i, byte) in a.iter_mut().enumerate() {
+        *byte = ((i * 7) % 256) as u8;
+    }
+    for (i, byte) in b.iter_mut().enumerate() {
+        *byte = ((i * 11) % 256) as u8;
+    }
+    let frames = [
+        AnimationFrame {
+            pixels: &a,
+            duration: 10,
+        },
+        AnimationFrame {
+            pixels: &b,
+            duration: 10,
+        },
+    ];
+    let cfg = jxl_encoder::LosslessConfig::new();
+    let limits = Limits::new().with_max_memory_bytes(64 * 1024 * 1024);
+    let bytes = cfg
+        .encode_animation_with_limits(
+            w,
+            h,
+            PixelLayout::Rgb8,
+            &AnimationParams::default(),
+            &frames,
+            &limits,
+        )
+        .expect("32×32 animation under 64 MB cap must succeed");
+    assert_eq!(&bytes[..2], &[0xFF, 0x0A]);
+}
+
+// ── Tree-learning budget plumbing ───────────────────────────────────────────
+
+/// Tree learning's dim-driven scratch (`indices` of `n × usize` plus
+/// `bucket_indices` of `total_props × n` u8) is now charged against the
+/// per-encode cap. With a tight cap on a wide image the pre-encode
+/// estimate may pass (40 B/pixel × small image) while the in-encoder
+/// budget rejects when tree learning kicks in.
+///
+/// Uses a 1024×512 image with effort 7 + tree learning enabled. The
+/// rejection should surface as `LimitExceeded` either from the pre-
+/// estimate or from the deeper modular plumbing — both are valid signals
+/// that the cap is enforced.
+#[test]
+fn tree_learning_dim_driven_alloc_charged() {
+    let (w, h) = (1024u32, 512u32);
+    let mut pixels = Vec::with_capacity((w * h * 3) as usize);
+    for y in 0..h {
+        for x in 0..w {
+            pixels.push(((x ^ y) & 0xFF) as u8);
+            pixels.push(((x.wrapping_add(y)) & 0xFF) as u8);
+            pixels.push(((x.wrapping_mul(7) ^ y) & 0xFF) as u8);
+        }
+    }
+    let cfg = jxl_encoder::LosslessConfig::new()
+        .with_effort(7)
+        .with_tree_learning(true);
+    let limits = Limits::new().with_max_memory_bytes(4 * 1024 * 1024);
+    let result = cfg
+        .encode_request(w, h, PixelLayout::Rgb8)
+        .with_limits(&limits)
+        .encode(&pixels);
+    let err = result.expect_err("tree-learning encode should be denied by tight cap");
+    let inner: &EncodeError = err.as_ref();
+    assert!(
+        matches!(inner, EncodeError::LimitExceeded { .. }),
+        "expected LimitExceeded, got: {inner:?}"
+    );
+}

--- a/jxl-encoder/tests/rate_control.rs
+++ b/jxl-encoder/tests/rate_control.rs
@@ -184,7 +184,9 @@ fn test_encode_from_precomputed() {
         encoder.enable_gaborish,
         encoder.force_strategy,
         &encoder.profile,
-    );
+        encoder.color_encoding.as_ref(),
+    )
+    .expect("precomputed");
 
     // Verify precomputed state dimensions
     assert_eq!(precomputed.width, width);


### PR DESCRIPTION
## Summary

Per-encode allocation budget plumbed through the encoder hot paths. `Limits::with_max_memory_bytes(n)` (or the default 2 GB soft cap) now governs the dominant dimension-driven allocations, not just an up-front estimate. Cap exceedance surfaces as `Error::AllocationLimit { requested, used, cap }` (mapped to `EncodeError::LimitExceeded` at the API boundary). Streaming and animation paths gain `with_limits()` plumbing.

Builds cleanly on `main`; replaces the original "up-front precheck only" content of the PR.

## What's wired

Roughly 30 dimension-driven allocation sites are metered against the budget across:

- **VarDCT path**: `xyb` (planes + padded), `epf` (sigma + summed), `transform` outputs and quant loops, `gaborish` workspace, `adaptive_quant` field, `precomputed` (incl. `convert_to_xyb_padded`), `tile_distmap`, `rate_control`, `bitstream` writer scratch, `patches` reference frame, perceptual loops (`butteraugli_loop`, `ssim2_loop`, `zensim_loop`)
- **Modular path**: `Channel::new_with_budget`, `ModularImage::from_{rgb8,rgba8}_with_budget`, `apply_lossy_palette_with_budget`, `FrameEncoder::with_budget`, `tree_learn` sample buffers, `WeightedPredictorState` scratch (5 callers)
- **API**: `EncodeRequest::encode_inner` builds the budget, passes it to `encode_lossy` / `encode_lossless`, the streaming `LossyEncoder`/`LosslessEncoder` (`with_limits()` setter), and `encode_animation_with_limits` on both Configs

## RAII vs permanent

`BudgetGuard` (`Drop` releases) covers transient scratch in the perceptual loops. `reserve_permanent_opt` covers whole-encode buffers where releasing on drop is meaningless (the budget is dropped wholesale at encode end). Peak high-water mark is tracked for diagnostics.

## NOT wired (intentional)

`vardct/squeeze.rs`: bounded by 2× already-budgeted input. The big modular dim-driven buffers go through `Channel::new_with_budget` upstream; squeeze's outputs reuse those.

## Public API surface added

- `Error::AllocationLimit { requested, used, cap }` (maps to `EncodeError::LimitExceeded`)
- `Limits::DEFAULT_MAX_MEMORY_BYTES` constant (2 GB) and `Limits::effective_max_memory_bytes()` accessor
- `pub const DEFAULT_MAX_MEMORY_BYTES: u64 = Limits::DEFAULT_MAX_MEMORY_BYTES`
- Streaming: `LossyEncoder::with_limits()` / `LosslessEncoder::with_limits()`
- Animation: `LossyConfig::encode_animation_with_limits()` / `LosslessConfig::encode_animation_with_limits()`

`MemoryBudget` itself is `pub(crate)`.

## Tests

- 764 lib tests pass (workspace), 105 SIMD lib tests
- 15 alloc_budget integration tests (`tests/alloc_budget.rs`) cover: up-front denial; budget interception inside the encoder for VarDCT (`budget_intercepts_inside_encoder`), modular channels (`lossless_path_charges_modular_channels`), lossy palette (`budget_intercepts_lossy_palette_modular`, `budget_lossy_palette_falls_back_or_denies`), tree-learning sample buffers (`tree_learning_dim_driven_alloc_charged`), transform output (`budget_intercepts_transform_output`); streaming `with_limits` denial/success; animation `with_limits` denial/success on both configs

## History

This branch was rebased onto current `main` from a prior chain that sat on `fix/remove-unsafe-performance` (#34) → `fix/lz77-patches-oob-dos` (#33). Inherited #33/#34 commits dropped during rebase since those PRs land separately. Conflicts surfaced where the budget plumbing brushed against #33's `non_finite_action` field (resolved by keeping budget, dropping `non_finite_action`) and where main's flat `Vec<[i32;3]>` palette layout (#36) collided with the rework's older `Vec<Vec<[i32;3]>>` shape (resolved by keeping main's flat layout + adding budget reservation in front). One small `fix(lint)` commit at the tip clears a pre-existing `clippy::manual_is_multiple_of` and `cargo fmt` issue from `main` so this branch passes the pre-commit gates.

Base: `main`. Head: `fix/alloc-budget-tracker` (force-pushed; `fix/alloc-budget-rework` points at the same SHA).
