### PR TITLE
fix(security): post-#30 follow-ups (silent defenses → errors, NaN sanitization, iter caps, headroom checks)

### DIFF
--- a/benchmarks/rd_regression_2026-05-06_security_branch.log
+++ b/benchmarks/rd_regression_2026-05-06_security_branch.log
@@ -1,0 +1,103 @@
+cargo test -p jxl-encoder --test clic2025 test_rd_regression -- --ignored --nocapture
+   Compiling jxl-encoder v0.3.1 (/home/lilith/work/zen/jxl-encoder/jxl-encoder)
+    Finished `test` profile [optimized + debuginfo] target(s) in 20.71s
+     Running tests/clic2025.rs (target/debug/deps/clic2025-aef5b65ed2bd96a7)
+
+running 2 tests
+
+=== RD Regression Test ===
+
+--- Distance 0.25 ---
+
+Image          Size     Base      %     Bfly   Base      B%    SSIM2   Base
+----------------------------------------------------------------------------------
+
+=== High-Distance RD Regression Test ===
+
+--- Distance 2.0 ---
+
+Image          Size     Base      %     Bfly   Base      B%    SSIM2   Base
+----------------------------------------------------------------------------------
+frymire     1185985  1186449  -0.0%   1.546  1.546  -0.0%   93.32  93.47
+frymire      463724   463859  -0.0%   3.111  3.111  +0.0%   77.96  77.96
+1001682      120385   120481  -0.1%   0.472  0.472  -0.1%   92.97  92.98
+1001682       33841    33843  -0.0%   2.512  2.512  -0.0%   75.82  75.84
+1028637       92439    92631  -0.2%   0.437  0.437  +0.1%!   93.63  93.66
+1028637       29077    29082  -0.0%   2.227  2.227  -0.0%   75.31  75.30
+1029604      158708   158782  -0.0%   0.412  0.412  -0.1%   94.82  94.81
+1029604       42907    43500  -1.4%   2.283  2.283  -0.0%   79.22  79.24
+106399       115574   115785  -0.2%   0.654  0.654  -0.0%   93.66  93.68
+106399        31200    31482  -0.9%   2.065  2.065  -0.0%   77.65  77.65
+1080721      105039   105269  -0.2%   0.470  0.470  -0.1%   93.36  93.30
+
+--- Distance 0.50 ---
+
+Image          Size     Base      %     Bfly   Base      B%    SSIM2   Base
+----------------------------------------------------------------------------------
+1080721       28367    28638  -0.9%   2.087  2.087  -0.0%   82.32  82.28
+
+--- Distance 3.0 ---
+
+Image          Size     Base      %     Bfly   Base      B%    SSIM2   Base
+----------------------------------------------------------------------------------
+frymire      902200   902610  -0.0%   1.550  1.550  +0.0%   91.07  91.12
+frymire      370926   370935  -0.0%   4.028  4.028  +0.0%   70.91  70.90
+1001682       83815    83833  -0.0%   0.662  0.662  +0.1%!   90.64  90.61
+1001682       22283    22674  -1.7%   3.279  3.279  -0.0%   65.66  65.67
+1028637       64226    64354  -0.2%   0.885  0.885  -0.0%   90.40  90.41
+1028637       22250    22288  -0.2%   3.095  3.095  -0.0%   68.61  68.61
+1029604      109984   110085  -0.1%   0.708  0.708  +0.0%   92.11  92.07
+1029604       29967    31237  -4.1%   3.276  3.276  -0.0%   72.40  72.40
+106399        76047    76180  -0.2%   0.713  0.713  +0.1%!   91.16  91.11
+106399        23413    23507  -0.4%   2.821  2.821  +0.0%   71.08  71.08
+1080721       22192    22304  -0.5%   2.771  2.771  +0.0%   77.01  77.04
+
+=== Summary ===
+
+All images within quality thresholds.
+  Butteraugli floor: < 8.0 (catches broken transforms)
+  SSIM2 floor: > 40.0 (catches broken transforms)
+test test_rd_regression_high_distance ... ok
+1080721       67071    67249  -0.3%   0.762  0.762  +0.1%!   91.51  91.50
+
+--- Distance 1.00 ---
+
+Image          Size     Base      %     Bfly   Base      B%    SSIM2   Base
+----------------------------------------------------------------------------------
+frymire      661152   661495  -0.1%   1.570  1.570  -0.0%   86.50  86.48
+1001682       54575    54766  -0.3%   1.265  1.265  -0.0%   85.85  85.87
+1028637       44087    44176  -0.2%   1.371  1.371  +0.0%   84.57  84.56
+1029604       70554    70607  -0.1%   1.431  1.431  -0.0%   87.28  87.31
+106399        49998    50059  -0.1%   1.417  1.417  -0.0%   86.23  86.24
+1080721       43727    43795  -0.2%   1.335  1.335  -0.0%   88.03  88.03
+
+=== Summary ===
+
+Improvements vs baseline:
+  + frymire d=0.25: size 0.0% smaller
+  + 1001682 d=0.25: size 0.1% smaller
+  + 1028637 d=0.25: size 0.2% smaller
+  + 1029604 d=0.25: size 0.0% smaller
+  + 106399 d=0.25: size 0.2% smaller
+  + 1080721 d=0.25: size 0.2% smaller
+  + frymire d=0.5: size 0.0% smaller
+  + 1001682 d=0.5: size 0.0% smaller
+  + 1028637 d=0.5: size 0.2% smaller
+  + 1029604 d=0.5: size 0.1% smaller
+  + 106399 d=0.5: size 0.2% smaller
+  + 1080721 d=0.5: size 0.3% smaller
+  + frymire d=1: size 0.1% smaller
+  + 1001682 d=1: size 0.3% smaller
+  + 1028637 d=1: size 0.2% smaller
+  + 1029604 d=1: size 0.1% smaller
+  + 106399 d=1: size 0.1% smaller
+  + 1080721 d=1: size 0.2% smaller
+
+All images within regression thresholds.
+  Size: < baseline * 103%
+  Butteraugli: < baseline * 105%
+  SSIM2: > baseline - 1.0
+test test_rd_regression ... ok
+
+test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 69 filtered out; finished in 22.91s
+

--- a/jxl-encoder-cli/Cargo.toml
+++ b/jxl-encoder-cli/Cargo.toml
@@ -19,7 +19,16 @@ name = "cjxl-rs"
 path = "src/main.rs"
 
 [features]
-default = ["jxl_encoder/std", "butteraugli-loop", "unsafe-performance", "parallel"]
+# SECURITY: `unsafe-performance` is NOT in the default set. It eliminates
+# memset zero-fills on hot-path scratch buffers via MaybeUninit and
+# get_unchecked, but every misuse becomes UB rather than a panic. The
+# v09/v11 production sweep crashes (0x40000000-prefix indices in patches.rs
+# and lz77 chain arrays) are consistent with one such misuse leaking into
+# adjacent heap memory — the defensive bounds added in commit 1498053
+# block the symptom but the underlying UB is still possible. Run
+# `cjxl-rs` with `--features unsafe-performance` only when the input is
+# trusted; do not use it on a public-facing image proxy.
+default = ["jxl_encoder/std", "butteraugli-loop", "parallel"]
 debug-tokens = ["jxl_encoder/debug-tokens"]
 debug-ac-strategy = ["jxl_encoder/debug-ac-strategy"]
 debug-rect = ["jxl_encoder/debug-rect"]

--- a/jxl-encoder-simd/src/lib.rs
+++ b/jxl-encoder-simd/src/lib.rs
@@ -317,7 +317,7 @@ pub use mask1x1::compute_mask1x1;
 pub use noise::denoise_channel;
 pub use pixel_loss::pixel_domain_loss;
 pub use quantize::{quantize_block_dct8, quantize_block_large};
-pub use sanitize::sanitize_finite;
+pub use sanitize::{is_finite_plane, sanitize_finite};
 pub use transpose::transpose_8x8;
 pub use xyb::{linear_rgb_to_xyb_batch, xyb_to_linear_rgb_batch, xyb_to_linear_rgb_planar};
 
@@ -348,7 +348,7 @@ pub use mask1x1::compute_mask1x1_scalar;
 pub use noise::denoise_channel_scalar;
 pub use pixel_loss::pixel_domain_loss_scalar;
 pub use quantize::{quantize_dct8_scalar, quantize_large_scalar};
-pub use sanitize::sanitize_finite_scalar;
+pub use sanitize::{is_finite_plane_scalar, sanitize_finite_scalar};
 // transpose has no separate scalar — the dispatching fn IS the scalar fallback
 pub use xyb::{forward_xyb_scalar, inverse_xyb_planar_scalar, inverse_xyb_scalar};
 
@@ -400,7 +400,7 @@ pub use pixel_loss::pixel_domain_loss_avx2;
 #[cfg(target_arch = "x86_64")]
 pub use quantize::{quantize_dct8_avx2, quantize_large_avx2};
 #[cfg(target_arch = "x86_64")]
-pub use sanitize::sanitize_finite_avx2;
+pub use sanitize::{is_finite_plane_avx2, sanitize_finite_avx2};
 #[cfg(target_arch = "x86_64")]
 pub use transpose::transpose_8x8_avx2;
 #[cfg(target_arch = "x86_64")]
@@ -439,7 +439,7 @@ pub use pixel_loss::pixel_domain_loss_neon;
 #[cfg(target_arch = "aarch64")]
 pub use quantize::{quantize_dct8_neon, quantize_large_neon};
 #[cfg(target_arch = "aarch64")]
-pub use sanitize::sanitize_finite_neon;
+pub use sanitize::{is_finite_plane_neon, sanitize_finite_neon};
 #[cfg(target_arch = "aarch64")]
 pub use transpose::transpose_8x8_neon;
 #[cfg(target_arch = "aarch64")]

--- a/jxl-encoder-simd/src/lib.rs
+++ b/jxl-encoder-simd/src/lib.rs
@@ -274,6 +274,7 @@ mod mask1x1;
 mod noise;
 mod pixel_loss;
 mod quantize;
+mod sanitize;
 mod transpose;
 mod xyb;
 
@@ -316,6 +317,7 @@ pub use mask1x1::compute_mask1x1;
 pub use noise::denoise_channel;
 pub use pixel_loss::pixel_domain_loss;
 pub use quantize::{quantize_block_dct8, quantize_block_large};
+pub use sanitize::sanitize_finite;
 pub use transpose::transpose_8x8;
 pub use xyb::{linear_rgb_to_xyb_batch, xyb_to_linear_rgb_batch, xyb_to_linear_rgb_planar};
 
@@ -346,6 +348,7 @@ pub use mask1x1::compute_mask1x1_scalar;
 pub use noise::denoise_channel_scalar;
 pub use pixel_loss::pixel_domain_loss_scalar;
 pub use quantize::{quantize_dct8_scalar, quantize_large_scalar};
+pub use sanitize::sanitize_finite_scalar;
 // transpose has no separate scalar — the dispatching fn IS the scalar fallback
 pub use xyb::{forward_xyb_scalar, inverse_xyb_planar_scalar, inverse_xyb_scalar};
 
@@ -397,6 +400,8 @@ pub use pixel_loss::pixel_domain_loss_avx2;
 #[cfg(target_arch = "x86_64")]
 pub use quantize::{quantize_dct8_avx2, quantize_large_avx2};
 #[cfg(target_arch = "x86_64")]
+pub use sanitize::sanitize_finite_avx2;
+#[cfg(target_arch = "x86_64")]
 pub use transpose::transpose_8x8_avx2;
 #[cfg(target_arch = "x86_64")]
 pub use xyb::{forward_xyb_avx2, inverse_xyb_avx2, inverse_xyb_planar_avx2};
@@ -433,6 +438,8 @@ pub use noise::denoise_channel_neon;
 pub use pixel_loss::pixel_domain_loss_neon;
 #[cfg(target_arch = "aarch64")]
 pub use quantize::{quantize_dct8_neon, quantize_large_neon};
+#[cfg(target_arch = "aarch64")]
+pub use sanitize::sanitize_finite_neon;
 #[cfg(target_arch = "aarch64")]
 pub use transpose::transpose_8x8_neon;
 #[cfg(target_arch = "aarch64")]

--- a/jxl-encoder-simd/src/sanitize.rs
+++ b/jxl-encoder-simd/src/sanitize.rs
@@ -2,7 +2,7 @@
 // Algorithms and constants derived from libjxl (BSD-3-Clause).
 // Licensed under AGPL-3.0-or-later. Commercial licenses at https://www.imazen.io/pricing
 
-//! Replace non-finite f32 values (NaN / ±Inf) with 0.0 in-place.
+//! Detect / replace non-finite f32 values (NaN / ±Inf) in pixel planes.
 //!
 //! Used at the XYB→downstream-pipeline boundary in the encoder. NaN
 //! comparisons are always false, which silently bypasses clamps in the
@@ -11,15 +11,117 @@
 //! rendering — the suspected upstream of the `0x40000000`-prefix index
 //! corruption observed in production sweeps.
 //!
-//! Detection trick: `v * 0.0` evaluates to:
+//! Two entry points:
+//!
+//! - [`is_finite_plane`] — read-only check. Returns `true` if every
+//!   value in the plane is finite. Memory-bandwidth-bound; touches each
+//!   byte once. Use when the caller wants to fail-fast with an error.
+//!
+//! - [`sanitize_finite`] — read-modify-write. Replaces non-finite
+//!   values with `0.0` and returns whether any replacement happened.
+//!   Memory-bandwidth-bound; touches each byte twice (load + store) on
+//!   chunks where any replacement is needed. Use when the caller wants
+//!   defense-in-depth on hostile input.
+//!
+//! Detection trick (shared between both kernels): `v * 0.0` evaluates to:
 //! - `0.0` (or `-0.0`) for finite `v` — both compare equal to `0.0`
 //! - `NaN` for ±Inf or NaN inputs — does not compare equal to anything,
 //!   including `0.0`
 //!
 //! So `(v * 0.0).simd_eq(splat(0.0))` is the SIMD finite-mask. Blend
-//! with `0.0` and store. Returns whether any replacement happened so
-//! the caller can `debug_assert!` against legitimate inputs producing
-//! non-finite XYB (which means upstream invariants regressed).
+//! with `0.0` for sanitize; sum and check finite for the read-only check.
+
+/// Read-only check: returns `true` if every value in `plane` is finite
+/// (no NaN, no ±Inf). Faster than [`sanitize_finite`] — no buffer writes,
+/// just a load + accumulate + reduce.
+///
+/// Dispatches to the best available SIMD at runtime.
+#[inline]
+pub fn is_finite_plane(plane: &[f32]) -> bool {
+    #[cfg(target_arch = "x86_64")]
+    {
+        use archmage::SimdToken;
+        if let Some(token) = archmage::X64V3Token::summon() {
+            return is_finite_plane_avx2(token, plane);
+        }
+    }
+    #[cfg(target_arch = "aarch64")]
+    {
+        use archmage::SimdToken;
+        if let Some(token) = archmage::NeonToken::summon() {
+            return is_finite_plane_neon(token, plane);
+        }
+    }
+    is_finite_plane_scalar(plane)
+}
+
+#[inline]
+pub fn is_finite_plane_scalar(plane: &[f32]) -> bool {
+    plane.iter().all(|v| v.is_finite())
+}
+
+#[cfg(target_arch = "x86_64")]
+#[inline]
+#[archmage::arcane]
+pub fn is_finite_plane_avx2(token: archmage::X64V3Token, plane: &[f32]) -> bool {
+    use magetypes::simd::f32x8;
+    let zero = f32x8::splat(token, 0.0);
+
+    let n = plane.len();
+    let chunks = n / 8;
+    let tail_start = chunks * 8;
+
+    // Accumulator: `v * 0` is 0 for finite v, NaN for ±Inf or NaN.
+    // Sum across chunks — NaN propagates through addition. At the end,
+    // if any lane is non-zero or non-finite, some input lane was
+    // non-finite.
+    let mut acc = f32x8::splat(token, 0.0);
+
+    for c in 0..chunks {
+        let off = c * 8;
+        let arr: &[f32; 8] = (&plane[off..off + 8]).try_into().unwrap();
+        let v = f32x8::load(token, arr);
+        acc += v * zero;
+    }
+
+    let mut a = [0.0f32; 8];
+    acc.store(&mut a);
+    if a.iter().any(|&x| x != 0.0 || !x.is_finite()) {
+        return false;
+    }
+
+    // Tail
+    plane[tail_start..].iter().all(|v| v.is_finite())
+}
+
+#[cfg(target_arch = "aarch64")]
+#[inline]
+#[archmage::arcane]
+pub fn is_finite_plane_neon(token: archmage::NeonToken, plane: &[f32]) -> bool {
+    use magetypes::simd::f32x4;
+    let zero = f32x4::splat(token, 0.0);
+
+    let n = plane.len();
+    let chunks = n / 4;
+    let tail_start = chunks * 4;
+
+    let mut acc = f32x4::splat(token, 0.0);
+
+    for c in 0..chunks {
+        let off = c * 4;
+        let arr: &[f32; 4] = (&plane[off..off + 4]).try_into().unwrap();
+        let v = f32x4::load(token, arr);
+        acc += v * zero;
+    }
+
+    let mut a = [0.0f32; 4];
+    acc.store(&mut a);
+    if a.iter().any(|&x| x != 0.0 || !x.is_finite()) {
+        return false;
+    }
+
+    plane[tail_start..].iter().all(|v| v.is_finite())
+}
 
 /// Replace any NaN or ±Inf in `plane` with `0.0`. Returns `true` if any
 /// replacement happened.
@@ -227,5 +329,74 @@ mod tests {
         let replaced = sanitize_finite(&mut v);
         assert!(replaced);
         assert!(v.iter().all(|&x| x == 0.0));
+    }
+
+    #[test]
+    fn is_finite_plane_scalar_all_finite() {
+        let v: Vec<f32> = (0..256).map(|i| i as f32 * 0.1).collect();
+        assert!(is_finite_plane_scalar(&v));
+    }
+
+    #[test]
+    fn is_finite_plane_scalar_detects_nan() {
+        let mut v: Vec<f32> = (0..256).map(|i| i as f32 * 0.1).collect();
+        v[100] = f32::NAN;
+        assert!(!is_finite_plane_scalar(&v));
+    }
+
+    #[test]
+    fn is_finite_plane_scalar_detects_inf() {
+        let mut v: Vec<f32> = (0..256).map(|i| i as f32 * 0.1).collect();
+        v[200] = f32::INFINITY;
+        assert!(!is_finite_plane_scalar(&v));
+        v[200] = 0.0;
+        v[200] = f32::NEG_INFINITY;
+        assert!(!is_finite_plane_scalar(&v));
+    }
+
+    #[cfg(target_arch = "x86_64")]
+    #[test]
+    fn is_finite_plane_avx2_matches_scalar() {
+        use archmage::SimdToken;
+        let Some(token) = archmage::X64V3Token::summon() else {
+            return;
+        };
+        let cases: &[Vec<f32>] = &[
+            (0..15).map(|i| i as f32).collect(),
+            vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0],
+            {
+                let mut v: Vec<f32> = (0..1000).map(|i| i as f32 * 0.001).collect();
+                v[500] = f32::NAN;
+                v
+            },
+            {
+                let mut v: Vec<f32> = (0..1000).map(|i| i as f32 * 0.001).collect();
+                v[7] = f32::INFINITY; // first chunk
+                v
+            },
+            {
+                let mut v: Vec<f32> = (0..1000).map(|i| i as f32 * 0.001).collect();
+                v[999] = f32::NEG_INFINITY; // tail
+                v
+            },
+            vec![f32::NAN; 17], // all NaN, tail
+            vec![],             // empty
+        ];
+        for (i, v) in cases.iter().enumerate() {
+            assert_eq!(
+                is_finite_plane_scalar(v),
+                is_finite_plane_avx2(token, v),
+                "mismatch on case {i}"
+            );
+        }
+    }
+
+    #[test]
+    fn is_finite_plane_dispatch() {
+        let v: Vec<f32> = (0..1000).map(|i| i as f32 * 0.001).collect();
+        assert!(is_finite_plane(&v));
+        let mut v_bad = v.clone();
+        v_bad[500] = f32::NAN;
+        assert!(!is_finite_plane(&v_bad));
     }
 }

--- a/jxl-encoder-simd/src/sanitize.rs
+++ b/jxl-encoder-simd/src/sanitize.rs
@@ -1,0 +1,231 @@
+// Copyright (c) Imazen LLC and the JPEG XL Project Authors.
+// Algorithms and constants derived from libjxl (BSD-3-Clause).
+// Licensed under AGPL-3.0-or-later. Commercial licenses at https://www.imazen.io/pricing
+
+//! Replace non-finite f32 values (NaN / ±Inf) with 0.0 in-place.
+//!
+//! Used at the XYB→downstream-pipeline boundary in the encoder. NaN
+//! comparisons are always false, which silently bypasses clamps in the
+//! butteraugli iteration loop and propagates non-finite values into
+//! `f32 as i32` / `as usize` casts in patch detection and spline
+//! rendering — the suspected upstream of the `0x40000000`-prefix index
+//! corruption observed in production sweeps.
+//!
+//! Detection trick: `v * 0.0` evaluates to:
+//! - `0.0` (or `-0.0`) for finite `v` — both compare equal to `0.0`
+//! - `NaN` for ±Inf or NaN inputs — does not compare equal to anything,
+//!   including `0.0`
+//!
+//! So `(v * 0.0).simd_eq(splat(0.0))` is the SIMD finite-mask. Blend
+//! with `0.0` and store. Returns whether any replacement happened so
+//! the caller can `debug_assert!` against legitimate inputs producing
+//! non-finite XYB (which means upstream invariants regressed).
+
+/// Replace any NaN or ±Inf in `plane` with `0.0`. Returns `true` if any
+/// replacement happened.
+///
+/// Dispatches to the best available SIMD at runtime.
+#[inline]
+pub fn sanitize_finite(plane: &mut [f32]) -> bool {
+    #[cfg(target_arch = "x86_64")]
+    {
+        use archmage::SimdToken;
+        if let Some(token) = archmage::X64V3Token::summon() {
+            return sanitize_finite_avx2(token, plane);
+        }
+    }
+    #[cfg(target_arch = "aarch64")]
+    {
+        use archmage::SimdToken;
+        if let Some(token) = archmage::NeonToken::summon() {
+            return sanitize_finite_neon(token, plane);
+        }
+    }
+    sanitize_finite_scalar(plane)
+}
+
+#[inline]
+pub fn sanitize_finite_scalar(plane: &mut [f32]) -> bool {
+    let mut replaced = false;
+    for v in plane.iter_mut() {
+        if !v.is_finite() {
+            *v = 0.0;
+            replaced = true;
+        }
+    }
+    replaced
+}
+
+#[cfg(target_arch = "x86_64")]
+#[inline]
+#[archmage::arcane]
+pub fn sanitize_finite_avx2(token: archmage::X64V3Token, plane: &mut [f32]) -> bool {
+    use magetypes::simd::f32x8;
+    let zero = f32x8::splat(token, 0.0);
+
+    let n = plane.len();
+    let chunks = n / 8;
+    let tail_start = chunks * 8;
+
+    // Accumulator for "any non-finite seen" — we propagate non-finite
+    // values through via floating-point addition (NaN + x = NaN, Inf + x
+    // = Inf for finite x). At the end any non-zero or non-finite lane in
+    // the accumulator signals a replacement.
+    let mut nonfinite_acc = f32x8::splat(token, 0.0);
+
+    for c in 0..chunks {
+        let off = c * 8;
+        let arr: &mut [f32; 8] = (&mut plane[off..off + 8]).try_into().unwrap();
+        let v = f32x8::load(token, arr);
+        // `v * 0` is `0.0` for finite v, `NaN` for ±Inf or NaN. Comparing
+        // to `0.0` with `simd_eq` (which uses `_CMP_EQ_OQ` — *ordered*
+        // equality) returns:
+        //   - true  for finite v (0 == 0)
+        //   - false for non-finite (NaN comparisons are unordered → false)
+        // So this is the FINITE mask. Use it to keep finite lanes and
+        // replace non-finite with zero.
+        let finite_mask = (v * zero).simd_eq(zero);
+        let cleaned = f32x8::blend(finite_mask, v, zero);
+        cleaned.store(arr);
+        // `v - cleaned`: 0 for finite (cleaned == v), NaN/Inf for
+        // non-finite (cleaned == 0). Add to accumulator — any non-finite
+        // propagates because NaN + finite = NaN, ±Inf + finite = ±Inf.
+        nonfinite_acc += v - cleaned;
+    }
+
+    let mut acc = [0.0f32; 8];
+    nonfinite_acc.store(&mut acc);
+    let mut replaced = acc.iter().any(|&x| x != 0.0 || !x.is_finite());
+
+    // Tail
+    for v in plane[tail_start..].iter_mut() {
+        if !v.is_finite() {
+            *v = 0.0;
+            replaced = true;
+        }
+    }
+    replaced
+}
+
+#[cfg(target_arch = "aarch64")]
+#[inline]
+#[archmage::arcane]
+pub fn sanitize_finite_neon(token: archmage::NeonToken, plane: &mut [f32]) -> bool {
+    use magetypes::simd::f32x4;
+    let zero = f32x4::splat(token, 0.0);
+
+    let n = plane.len();
+    let chunks = n / 4;
+    let tail_start = chunks * 4;
+
+    let mut nonfinite_acc = f32x4::splat(token, 0.0);
+
+    for c in 0..chunks {
+        let off = c * 4;
+        let arr: &mut [f32; 4] = (&mut plane[off..off + 4]).try_into().unwrap();
+        let v = f32x4::load(token, arr);
+        // See AVX2 path for the finite-mask trick.
+        let finite_mask = (v * zero).simd_eq(zero);
+        let cleaned = f32x4::blend(finite_mask, v, zero);
+        cleaned.store(arr);
+        nonfinite_acc += v - cleaned;
+    }
+
+    let mut acc = [0.0f32; 4];
+    nonfinite_acc.store(&mut acc);
+    let mut replaced = acc.iter().any(|&x| x != 0.0 || !x.is_finite());
+
+    for v in plane[tail_start..].iter_mut() {
+        if !v.is_finite() {
+            *v = 0.0;
+            replaced = true;
+        }
+    }
+    replaced
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloc::vec;
+    use alloc::vec::Vec;
+
+    #[test]
+    fn scalar_replaces_nan_inf() {
+        let mut v = vec![
+            1.0,
+            f32::NAN,
+            3.0,
+            f32::INFINITY,
+            -1.0,
+            f32::NEG_INFINITY,
+            0.0,
+            5.0,
+        ];
+        let replaced = sanitize_finite_scalar(&mut v);
+        assert!(replaced);
+        assert_eq!(v, vec![1.0, 0.0, 3.0, 0.0, -1.0, 0.0, 0.0, 5.0]);
+    }
+
+    #[test]
+    fn scalar_preserves_finite() {
+        let mut v = vec![1.0, -2.0, 3.5, -0.0, 1e30, -1e-30];
+        let original = v.clone();
+        let replaced = sanitize_finite_scalar(&mut v);
+        assert!(!replaced);
+        assert_eq!(v, original);
+    }
+
+    #[cfg(target_arch = "x86_64")]
+    #[test]
+    fn avx2_matches_scalar() {
+        use archmage::SimdToken;
+        let Some(token) = archmage::X64V3Token::summon() else {
+            return; // CPU without AVX2 — skip
+        };
+        // Mix of all categories, length not a multiple of 8 to exercise tail.
+        let original: Vec<f32> = vec![
+            1.0,
+            f32::NAN,
+            f32::INFINITY,
+            -2.0,
+            0.0,
+            f32::NEG_INFINITY,
+            -0.0,
+            7.0,
+            f32::NAN,
+            8.5,
+            -1e30,
+            1e-30,
+            13.0,
+            14.0,
+            15.0,
+        ];
+        let mut a = original.clone();
+        let mut b = original.clone();
+        let r_scalar = sanitize_finite_scalar(&mut a);
+        let r_avx2 = sanitize_finite_avx2(token, &mut b);
+        assert_eq!(r_scalar, r_avx2);
+        assert_eq!(a, b);
+    }
+
+    #[cfg(target_arch = "x86_64")]
+    #[test]
+    fn avx2_clean_input_returns_false() {
+        use archmage::SimdToken;
+        let Some(token) = archmage::X64V3Token::summon() else {
+            return;
+        };
+        let mut v: Vec<f32> = (0..256).map(|i| i as f32 * 0.1).collect();
+        let replaced = sanitize_finite_avx2(token, &mut v);
+        assert!(!replaced, "no NaN in input — should not report replacement");
+    }
+
+    #[test]
+    fn dispatch_returns_replaced_flag() {
+        let mut v = vec![f32::NAN; 100];
+        let replaced = sanitize_finite(&mut v);
+        assert!(replaced);
+        assert!(v.iter().all(|&x| x == 0.0));
+    }
+}

--- a/jxl-encoder/Cargo.toml
+++ b/jxl-encoder/Cargo.toml
@@ -80,6 +80,12 @@ __expert = []
 # jxl-encoder-gpu's forks::* tests). Off by default; not part of the
 # stable API surface — items here may move or change at any time.
 __internals = []
+# Corpus-dependent tests. When enabled, tests under
+# `#[cfg_attr(not(feature = "corpus-tests"), ignore = "...")]` run; otherwise
+# they're marked as #[ignore] so the skip decision is visible at the test
+# attribute level (caller-controlled), not buried inside the test body.
+# CI must enable this feature explicitly when corpus is staged.
+corpus-tests = []
 default = ["std", "butteraugli-loop"]
 
 [dev-dependencies]

--- a/jxl-encoder/Cargo.toml
+++ b/jxl-encoder/Cargo.toml
@@ -99,6 +99,11 @@ imgref = "1.12"
 rgb = "0.8"
 walkdir = "2.5"
 sha2 = "0.11.0"
+# archmage is already a regular dep (`default-features = false, features = ["macros"]`);
+# the test suite needs `std` for `archmage::testing::for_each_token_permutation`
+# (used by `tests/nonfinite_xyb_repro.rs` to exercise scalar / SSE / AVX2 / etc.
+# fallback paths on the trigger fixtures).
+archmage = { version = "0.9.15", default-features = false, features = ["macros", "std"] }
 
 # codec-corpus uses fd-lock which doesn't compile on WASM
 [target.'cfg(not(target_family = "wasm"))'.dev-dependencies]

--- a/jxl-encoder/src/api.rs
+++ b/jxl-encoder/src/api.rs
@@ -1168,10 +1168,13 @@ pub enum NonFiniteAction {
     /// DoS exposure because the encode never touches the bad data.
     #[default]
     Error,
-    /// Read-modify-write SIMD scan; replace any non-finite value with
-    /// `0.0` and continue encoding. Use for image-proxy deployments
-    /// that prefer best-effort encoding over fail-fast on hostile
-    /// input. Costs ~2 passes through cache hierarchy.
+    /// Read-modify-write SIMD scrub on the linear-RGB input plane (and
+    /// defense-in-depth on XYB output): replace any non-finite value
+    /// with `0.0` and continue encoding. Use for image-proxy
+    /// deployments that prefer best-effort encoding over fail-fast on
+    /// hostile input. Costs an extra owned-buffer copy + one
+    /// read-modify-write SIMD pass (~12.5 GB/s) over the linear-RGB
+    /// plane vs. the read-only [`Error`](Self::Error) path.
     Sanitize,
 }
 

--- a/jxl-encoder/src/api.rs
+++ b/jxl-encoder/src/api.rs
@@ -124,6 +124,24 @@ impl From<enough::StopReason> for EncodeError {
 /// production-safe error tracking without debuginfo or backtraces.
 pub type Result<T> = core::result::Result<T, At<EncodeError>>;
 
+// ── Public limit constants ──────────────────────────────────────────────────
+
+/// Maximum iterations for any quantization-loop knob (butteraugli, ssim2,
+/// zensim). Each iteration runs a full perceptual-metric pass over the image
+/// and is *expensive* — capping this prevents a malicious caller from passing
+/// `u32::MAX` and DoS-ing the encoder. At default usage the encoder picks
+/// 0–4 iterations based on effort; values beyond ~16 produce diminishing
+/// returns even for legitimate use.
+pub const MAX_QUANT_LOOP_ITERS: u32 = 64;
+
+/// Default soft cap on encoder working-set memory when the caller passes no
+/// explicit [`Limits`]. Computed conservatively as ~40 bytes/pixel
+/// (XYB f32, quant fields, strategy maps, entropy buffers). Encoders that
+/// expect larger workloads should set [`Limits::max_memory_bytes`]
+/// explicitly. Encoders embedded in real-time image proxies should keep
+/// this bounded — see [`Limits`].
+pub const DEFAULT_MAX_MEMORY_BYTES: u64 = 2 * 1024 * 1024 * 1024;
+
 // ── EncodeResult / EncodeStats ──────────────────────────────────────────────
 
 /// Result of an encode operation. Holds encoded data and metrics.
@@ -1310,10 +1328,12 @@ impl LossyConfig {
     /// Set butteraugli quantization loop iterations explicitly.
     ///
     /// Overrides the automatic effort-based default (effort 7: 0, effort 8: 2, effort 9+: 4).
+    /// Saturated to [`MAX_QUANT_LOOP_ITERS`] to bound worst-case CPU on
+    /// untrusted callers — each iteration runs a full butteraugli pipeline.
     /// Requires the `butteraugli-loop` feature.
     #[cfg(feature = "butteraugli-loop")]
     pub fn with_butteraugli_iters(mut self, n: u32) -> Self {
-        self.butteraugli_iters = n;
+        self.butteraugli_iters = n.min(MAX_QUANT_LOOP_ITERS);
         self.butteraugli_iters_explicit = true;
         self
     }
@@ -1321,10 +1341,11 @@ impl LossyConfig {
     /// Set SSIM2 quantization loop iterations.
     ///
     /// Alternative to butteraugli loop: uses per-block linear RGB RMSE + full-image SSIM2.
+    /// Saturated to [`MAX_QUANT_LOOP_ITERS`].
     /// Requires the `ssim2-loop` feature.
     #[cfg(feature = "ssim2-loop")]
     pub fn with_ssim2_iters(mut self, n: u32) -> Self {
-        self.ssim2_iters = n;
+        self.ssim2_iters = n.min(MAX_QUANT_LOOP_ITERS);
         self
     }
 
@@ -1337,7 +1358,7 @@ impl LossyConfig {
     /// Requires the `zensim-loop` feature.
     #[cfg(feature = "zensim-loop")]
     pub fn with_zensim_iters(mut self, n: u32) -> Self {
-        self.zensim_iters = n;
+        self.zensim_iters = n.min(MAX_QUANT_LOOP_ITERS);
         self
     }
 
@@ -1648,6 +1669,29 @@ impl<'a> EncodeRequest<'a> {
     fn encode_inner(&self, pixels: &[u8]) -> core::result::Result<EncodeResult, EncodeError> {
         self.validate_pixels(pixels)?;
         self.check_limits()?;
+        if let Some(ref ce) = self.color_encoding {
+            crate::vardct::xyb::validate_color_encoding(ce).map_err(EncodeError::from)?;
+        }
+        if let Some(meta) = self.metadata
+            && let Some(icc) = meta.icc_profile
+        {
+            // Surface ICC issues here rather than letting predict_icc/write_icc
+            // panic deep in the bitstream-writing path.
+            const ICC_SIZE_LIMIT: usize = u32::MAX as usize >> 2;
+            if icc.is_empty() {
+                return Err(EncodeError::InvalidInput {
+                    message: "ICC profile must not be empty".into(),
+                });
+            }
+            if icc.len() > ICC_SIZE_LIMIT {
+                return Err(EncodeError::InvalidInput {
+                    message: format!(
+                        "ICC profile too large: {} bytes (max {ICC_SIZE_LIMIT})",
+                        icc.len()
+                    ),
+                });
+            }
+        }
 
         let threads = match self.config {
             ConfigRef::Lossless(cfg) => cfg.threads,

--- a/jxl-encoder/src/api.rs
+++ b/jxl-encoder/src/api.rs
@@ -1142,10 +1142,37 @@ pub struct LossyConfig {
     #[cfg(feature = "zensim-loop")]
     zensim_iters: u32,
     threads: usize,
+    non_finite_action: NonFiniteAction,
     /// Sweep / picker hook: when set, replaces the effort+mode-derived
     /// `EffortProfile` everywhere the encoder asks for one. See
     /// [`Self::with_effort_profile_override`].
     profile_override: Option<crate::effort::EffortProfile>,
+}
+
+/// Policy for what to do if the encoder finds non-finite (NaN / ±Inf)
+/// f32 values in the XYB pixel planes at the conversion→pipeline
+/// boundary.
+///
+/// The opsin XYB transform (`cbrt(mixed + bias) - cbrt(bias)`) is
+/// finite for any finite linear-RGB input — non-finite XYB indicates
+/// an upstream bug (caller passed non-finite linear-RGB, internal
+/// arithmetic leaked NaN, or memory corruption). The encoder runs a
+/// SIMD scan at the boundary either way; this enum picks what happens
+/// when the scan reports non-finite.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub enum NonFiniteAction {
+    /// **Default.** Read-only SIMD scan; return
+    /// [`EncodeError::InvalidInput`] on first non-finite value.
+    /// ~4× faster than [`Sanitize`](Self::Sanitize) (no buffer writes
+    /// — single pass through cache hierarchy). Fail-fast surface, no
+    /// DoS exposure because the encode never touches the bad data.
+    #[default]
+    Error,
+    /// Read-modify-write SIMD scan; replace any non-finite value with
+    /// `0.0` and continue encoding. Use for image-proxy deployments
+    /// that prefer best-effort encoding over fail-fast on hostile
+    /// input. Costs ~2 passes through cache hierarchy.
+    Sanitize,
 }
 
 impl LossyConfig {
@@ -1183,6 +1210,7 @@ impl LossyConfig {
             #[cfg(feature = "zensim-loop")]
             zensim_iters: 0,
             threads: 0,
+            non_finite_action: NonFiniteAction::default(),
             profile_override: None,
         }
     }
@@ -1409,6 +1437,20 @@ impl LossyConfig {
         self.butteraugli_iters = n;
         self.butteraugli_iters_explicit = true;
         self
+    }
+
+    /// Set the policy for non-finite XYB values at the
+    /// conversion→pipeline boundary. See [`NonFiniteAction`] for the
+    /// trade-off between fail-fast (default, `Error`) and best-effort
+    /// (`Sanitize`).
+    pub fn with_non_finite_action(mut self, action: NonFiniteAction) -> Self {
+        self.non_finite_action = action;
+        self
+    }
+
+    /// The currently-configured [`NonFiniteAction`] policy.
+    pub fn non_finite_action(&self) -> NonFiniteAction {
+        self.non_finite_action
     }
 
     /// Set SSIM2 quantization loop iterations.
@@ -2297,6 +2339,7 @@ impl<'a> EncodeRequest<'a> {
         enc.bit_depth_16 = bit_depth_16;
         enc.source_gamma = self.source_gamma;
         enc.color_encoding = self.color_encoding.clone();
+        enc.non_finite_action = cfg.non_finite_action;
 
         // Tone mapping and intrinsic size from metadata
         if let Some(meta) = self.metadata {
@@ -2742,6 +2785,7 @@ impl LossyEncoder {
             enc.intensity_target = self.intensity_target;
             enc.min_nits = self.min_nits;
             enc.intrinsic_size = self.intrinsic_size;
+            enc.non_finite_action = self.cfg.non_finite_action;
             if let Some(ref icc) = self.icc_profile {
                 enc.icc_profile = Some(icc.clone());
             }
@@ -3708,6 +3752,7 @@ fn encode_animation_lossy(
     {
         enc.zensim_iters = cfg.zensim_iters;
     }
+    enc.non_finite_action = cfg.non_finite_action;
 
     // Detect alpha and 16-bit from layout
     let has_alpha = layout.has_alpha();

--- a/jxl-encoder/src/api.rs
+++ b/jxl-encoder/src/api.rs
@@ -1729,6 +1729,25 @@ impl<'a> EncodeRequest<'a> {
         let expected = w
             .checked_mul(h)
             .and_then(|n| n.checked_mul(self.layout.bytes_per_pixel()));
+        // Internal allocations are sized as `width * height * N` for N up
+        // to 8 (4 channels × f32 = 16 bytes/px would also fit since
+        // `usize` can absorb a 4× multiplier on top of `bpp` ≤ 4 within
+        // the same budget). Enforce a single up-front check that
+        // `width * height * 16` fits in `usize` so the encoder never has
+        // to re-validate inside hot loops. This bounds the per-pixel
+        // working-set scaling factor for all downstream callers.
+        const MAX_INTERNAL_SCALE: usize = 16;
+        if w.checked_mul(h)
+            .and_then(|n| n.checked_mul(MAX_INTERNAL_SCALE))
+            .is_none()
+        {
+            return Err(EncodeError::LimitExceeded {
+                message: format!(
+                    "image {w}x{h} too large for encoder working buffers \
+                     (width × height × {MAX_INTERNAL_SCALE} overflows usize)"
+                ),
+            });
+        }
         match expected {
             Some(expected) if pixels.len() == expected => Ok(()),
             Some(expected) => Err(EncodeError::InvalidInput {
@@ -3317,6 +3336,17 @@ fn validate_animation_input(
         .ok_or_else(|| EncodeError::InvalidInput {
             message: "image dimensions overflow".into(),
         })?;
+    // Match the still-image working-buffer headroom check (validate_pixels).
+    const MAX_INTERNAL_SCALE: usize = 16;
+    if (width as usize)
+        .checked_mul(height as usize)
+        .and_then(|n| n.checked_mul(MAX_INTERNAL_SCALE))
+        .is_none()
+    {
+        return Err(EncodeError::LimitExceeded {
+            message: format!("image {width}x{height} too large for encoder working buffers"),
+        });
+    }
     for (i, frame) in frames.iter().enumerate() {
         if frame.pixels.len() != expected_size {
             return Err(EncodeError::InvalidInput {

--- a/jxl-encoder/src/api.rs
+++ b/jxl-encoder/src/api.rs
@@ -130,9 +130,12 @@ pub type Result<T> = core::result::Result<T, At<EncodeError>>;
 /// zensim). Each iteration runs a full perceptual-metric pass over the image
 /// and is *expensive* — capping this prevents a malicious caller from passing
 /// `u32::MAX` and DoS-ing the encoder. At default usage the encoder picks
-/// 0–4 iterations based on effort; values beyond ~16 produce diminishing
-/// returns even for legitimate use.
-pub const MAX_QUANT_LOOP_ITERS: u32 = 64;
+/// 0–4 iterations based on effort.
+///
+/// Matches [`crate::validation::ITER_MAX`] so callers see consistent
+/// behavior whether they validate the config explicitly or rely on the
+/// encoder's automatic clamping.
+pub const MAX_QUANT_LOOP_ITERS: u32 = crate::validation::ITER_MAX;
 
 /// Default soft cap on encoder working-set memory when the caller passes no
 /// explicit [`Limits`]. Computed conservatively as ~40 bytes/pixel
@@ -1328,12 +1331,15 @@ impl LossyConfig {
     /// Set butteraugli quantization loop iterations explicitly.
     ///
     /// Overrides the automatic effort-based default (effort 7: 0, effort 8: 2, effort 9+: 4).
-    /// Saturated to [`MAX_QUANT_LOOP_ITERS`] to bound worst-case CPU on
-    /// untrusted callers — each iteration runs a full butteraugli pipeline.
+    /// Stores the value as-given for [`Self::validate`] to surface as
+    /// [`crate::ValidationError::IterCountOutOfRange`] if it exceeds
+    /// [`MAX_QUANT_LOOP_ITERS`]. The encoder additionally saturates at
+    /// consumption time so callers that skip `validate()` still cannot
+    /// DoS the encoder by passing a huge value.
     /// Requires the `butteraugli-loop` feature.
     #[cfg(feature = "butteraugli-loop")]
     pub fn with_butteraugli_iters(mut self, n: u32) -> Self {
-        self.butteraugli_iters = n.min(MAX_QUANT_LOOP_ITERS);
+        self.butteraugli_iters = n;
         self.butteraugli_iters_explicit = true;
         self
     }
@@ -1341,11 +1347,12 @@ impl LossyConfig {
     /// Set SSIM2 quantization loop iterations.
     ///
     /// Alternative to butteraugli loop: uses per-block linear RGB RMSE + full-image SSIM2.
-    /// Saturated to [`MAX_QUANT_LOOP_ITERS`].
+    /// See [`Self::with_butteraugli_iters`] for how out-of-range values
+    /// are handled.
     /// Requires the `ssim2-loop` feature.
     #[cfg(feature = "ssim2-loop")]
     pub fn with_ssim2_iters(mut self, n: u32) -> Self {
-        self.ssim2_iters = n.min(MAX_QUANT_LOOP_ITERS);
+        self.ssim2_iters = n;
         self
     }
 
@@ -1358,7 +1365,7 @@ impl LossyConfig {
     /// Requires the `zensim-loop` feature.
     #[cfg(feature = "zensim-loop")]
     pub fn with_zensim_iters(mut self, n: u32) -> Self {
-        self.zensim_iters = n.min(MAX_QUANT_LOOP_ITERS);
+        self.zensim_iters = n;
         self
     }
 

--- a/jxl-encoder/src/api.rs
+++ b/jxl-encoder/src/api.rs
@@ -124,26 +124,19 @@ impl From<enough::StopReason> for EncodeError {
 /// production-safe error tracking without debuginfo or backtraces.
 pub type Result<T> = core::result::Result<T, At<EncodeError>>;
 
-// ── Public limit constants ──────────────────────────────────────────────────
+// ── Limit aliases ──────────────────────────────────────────────────────────
 
-/// Maximum iterations for any quantization-loop knob (butteraugli, ssim2,
-/// zensim). Each iteration runs a full perceptual-metric pass over the image
-/// and is *expensive* — capping this prevents a malicious caller from passing
-/// `u32::MAX` and DoS-ing the encoder. At default usage the encoder picks
-/// 0–4 iterations based on effort.
-///
-/// Matches [`crate::validation::ITER_MAX`] so callers see consistent
-/// behavior whether they validate the config explicitly or rely on the
-/// encoder's automatic clamping.
-pub const MAX_QUANT_LOOP_ITERS: u32 = crate::validation::ITER_MAX;
+/// Hard upper bound for quantization-loop iterations. Alias of
+/// [`Limits::DEFAULT_MAX_QUANT_LOOP_ITERS`] — preserved for callers that
+/// referenced the bare const before per-encode limits became
+/// configurable. Prefer setting [`Limits::with_max_quant_loop_iters`]
+/// (or letting the default apply) over hard-coding this constant.
+pub const MAX_QUANT_LOOP_ITERS: u32 = Limits::DEFAULT_MAX_QUANT_LOOP_ITERS;
 
-/// Default soft cap on encoder working-set memory when the caller passes no
-/// explicit [`Limits`]. Computed conservatively as ~40 bytes/pixel
-/// (XYB f32, quant fields, strategy maps, entropy buffers). Encoders that
-/// expect larger workloads should set [`Limits::max_memory_bytes`]
-/// explicitly. Encoders embedded in real-time image proxies should keep
-/// this bounded — see [`Limits`].
-pub const DEFAULT_MAX_MEMORY_BYTES: u64 = 2 * 1024 * 1024 * 1024;
+/// Default soft cap on encoder working-set memory when no explicit
+/// [`Limits::max_memory_bytes`] is set. Alias of
+/// [`Limits::DEFAULT_MAX_MEMORY_BYTES`].
+pub const DEFAULT_MAX_MEMORY_BYTES: u64 = Limits::DEFAULT_MAX_MEMORY_BYTES;
 
 // ── EncodeResult / EncodeStats ──────────────────────────────────────────────
 
@@ -580,15 +573,51 @@ impl<'a> ImageMetadata<'a> {
 }
 
 /// Resource limits for encoding.
+///
+/// Every field is `Option<…>`; `None` means "unlimited" (or "use the
+/// validator-side default", for fields that have one). Callers wire a
+/// [`Limits`] onto an [`EncodeRequest`] via
+/// [`EncodeRequest::with_limits`]; the encoder consults it before any
+/// dimension-driven allocation and before each per-encode CPU budget
+/// check.
+///
+/// Two policy fields are intentionally NOT bare `pub const`s:
+///
+/// - [`Self::max_quant_loop_iters`] — the cap on
+///   butteraugli/ssim2/zensim quantization-loop iterations. The
+///   validator's hard upper bound is [`Self::DEFAULT_MAX_QUANT_LOOP_ITERS`]
+///   (= [`crate::validation::ITER_MAX`]); a caller may set a lower limit
+///   here, but never a higher one. The encoder saturates at the lower of
+///   `Limits.max_quant_loop_iters` (or its default) and the validator
+///   max.
+/// - [`Self::max_memory_bytes`] — when `None`, the encoder applies
+///   [`Self::DEFAULT_MAX_MEMORY_BYTES`] (≈ 2 GB) as a soft cap so that an
+///   image proxy without explicit `Limits` configuration still has a
+///   working-set ceiling. Set to `Some(u64::MAX)` to opt out of the soft
+///   cap explicitly (this surfaces in logs as "user explicitly disabled
+///   memory limit").
 #[derive(Clone, Debug, Default)]
 pub struct Limits {
     max_width: Option<u64>,
     max_height: Option<u64>,
     max_pixels: Option<u64>,
     max_memory_bytes: Option<u64>,
+    max_quant_loop_iters: Option<u32>,
 }
 
 impl Limits {
+    /// Hard upper bound for quantization-loop iterations. Mirrors
+    /// [`crate::validation::ITER_MAX`] so the validator and the encoder
+    /// agree on what counts as "too many iters".
+    pub const DEFAULT_MAX_QUANT_LOOP_ITERS: u32 = crate::validation::ITER_MAX;
+
+    /// Default soft cap on encoder working-set memory when no explicit
+    /// `max_memory_bytes` is set. ~40 bytes/pixel × 50 megapixels is
+    /// roughly 2 GB; encoders embedded in real-time image proxies should
+    /// keep this bounded — set a tighter cap explicitly via
+    /// [`Self::with_max_memory_bytes`] for hostile-input scenarios.
+    pub const DEFAULT_MAX_MEMORY_BYTES: u64 = 2 * 1024 * 1024 * 1024;
+
     /// Create limits with no restrictions (all `None`).
     pub fn new() -> Self {
         Self::default()
@@ -613,8 +642,23 @@ impl Limits {
     }
 
     /// Set maximum memory bytes the encoder may allocate.
+    ///
+    /// When unset, the encoder applies
+    /// [`Self::DEFAULT_MAX_MEMORY_BYTES`] (~2 GB) as a soft cap. Pass
+    /// `u64::MAX` explicitly to disable the cap (with the understanding
+    /// that an unbounded working set on a hostile input can OOM the
+    /// process).
     pub fn with_max_memory_bytes(mut self, bytes: u64) -> Self {
         self.max_memory_bytes = Some(bytes);
+        self
+    }
+
+    /// Set maximum quantization-loop iterations (butteraugli / ssim2 /
+    /// zensim). Saturated at [`Self::DEFAULT_MAX_QUANT_LOOP_ITERS`] —
+    /// passing a higher value silently lowers it to the validator-side
+    /// hard limit. Use a lower value to bound CPU on untrusted callers.
+    pub fn with_max_quant_loop_iters(mut self, n: u32) -> Self {
+        self.max_quant_loop_iters = Some(n.min(Self::DEFAULT_MAX_QUANT_LOOP_ITERS));
         self
     }
 
@@ -633,9 +677,32 @@ impl Limits {
         self.max_pixels
     }
 
-    /// Get maximum memory bytes, if set.
+    /// Get maximum memory bytes, if set. When `None`,
+    /// [`Self::effective_max_memory_bytes`] gives the soft default the
+    /// encoder will actually enforce.
     pub fn max_memory_bytes(&self) -> Option<u64> {
         self.max_memory_bytes
+    }
+
+    /// The cap the encoder will actually apply: explicit
+    /// `max_memory_bytes` if set, else
+    /// [`Self::DEFAULT_MAX_MEMORY_BYTES`].
+    pub fn effective_max_memory_bytes(&self) -> u64 {
+        self.max_memory_bytes
+            .unwrap_or(Self::DEFAULT_MAX_MEMORY_BYTES)
+    }
+
+    /// Get maximum quantization-loop iterations.
+    pub fn max_quant_loop_iters(&self) -> Option<u32> {
+        self.max_quant_loop_iters
+    }
+
+    /// The cap the encoder will actually apply: explicit
+    /// `max_quant_loop_iters` if set, else
+    /// [`Self::DEFAULT_MAX_QUANT_LOOP_ITERS`].
+    pub fn effective_max_quant_loop_iters(&self) -> u32 {
+        self.max_quant_loop_iters
+            .unwrap_or(Self::DEFAULT_MAX_QUANT_LOOP_ITERS)
     }
 }
 
@@ -1810,7 +1877,59 @@ impl<'a> EncodeRequest<'a> {
                 });
             }
         }
+        // If the caller set an explicit max_quant_loop_iters and the
+        // resolved config is asking for more, reject. The encoder still
+        // saturates at the validator hard cap (`Limits::DEFAULT_MAX_QUANT_LOOP_ITERS`)
+        // at consumption sites — this lets a caller set a *tighter* cap
+        // and have it surface as an error rather than a silent saturation.
+        if let Some(max_iters) = limits.max_quant_loop_iters {
+            let configured = match self.config {
+                ConfigRef::Lossy(cfg) => self.lossy_max_iter_value(cfg),
+                ConfigRef::Lossless(_) => 0,
+            };
+            if configured > max_iters {
+                return Err(EncodeError::LimitExceeded {
+                    message: format!(
+                        "quantization-loop iterations ({configured}) exceed \
+                         Limits::max_quant_loop_iters ({max_iters})"
+                    ),
+                });
+            }
+        }
         Ok(())
+    }
+
+    /// Maximum of butteraugli/ssim2/zensim iters across the loop knobs
+    /// available on this config — used by `check_limits` to surface a
+    /// caller-set per-encode iter cap.
+    #[cfg(any(
+        feature = "butteraugli-loop",
+        feature = "ssim2-loop",
+        feature = "zensim-loop"
+    ))]
+    fn lossy_max_iter_value(&self, cfg: &LossyConfig) -> u32 {
+        let mut m = 0u32;
+        #[cfg(feature = "butteraugli-loop")]
+        {
+            m = m.max(cfg.butteraugli_iters);
+        }
+        #[cfg(feature = "ssim2-loop")]
+        {
+            m = m.max(cfg.ssim2_iters);
+        }
+        #[cfg(feature = "zensim-loop")]
+        {
+            m = m.max(cfg.zensim_iters);
+        }
+        m
+    }
+    #[cfg(not(any(
+        feature = "butteraugli-loop",
+        feature = "ssim2-loop",
+        feature = "zensim-loop"
+    )))]
+    fn lossy_max_iter_value(&self, _cfg: &LossyConfig) -> u32 {
+        0
     }
 
     // ── Lossless path ───────────────────────────────────────────────────

--- a/jxl-encoder/src/api.rs
+++ b/jxl-encoder/src/api.rs
@@ -1788,6 +1788,24 @@ impl<'a> EncodeRequest<'a> {
     fn encode_inner(&self, pixels: &[u8]) -> core::result::Result<EncodeResult, EncodeError> {
         self.validate_pixels(pixels)?;
         self.check_limits()?;
+        // Reject distances outside the libjxl-documented `[0.0, 25.0]` band
+        // here (lossy only). The `validate()` API is opt-in and only the
+        // belt-and-suspenders harness ever calls it; the encode path used to
+        // accept e.g. distance=50 and silently clamp internally, producing a
+        // ~25 bitstream while the caller saw no error. Surface explicitly.
+        if let ConfigRef::Lossy(cfg) = self.config
+            && (!cfg.distance.is_finite()
+                || cfg.distance <= 0.0
+                || cfg.distance > crate::validation::DISTANCE_MAX)
+        {
+            return Err(EncodeError::InvalidInput {
+                message: format!(
+                    "lossy distance {} out of range (0.0, {}]",
+                    cfg.distance,
+                    crate::validation::DISTANCE_MAX
+                ),
+            });
+        }
         if let Some(ref ce) = self.color_encoding {
             crate::vardct::xyb::validate_color_encoding(ce).map_err(EncodeError::from)?;
         }

--- a/jxl-encoder/src/api_tests.rs
+++ b/jxl-encoder/src/api_tests.rs
@@ -467,6 +467,7 @@ mod corpus_tests {
     }
 
     #[test]
+    #[cfg_attr(not(feature = "corpus-tests"), ignore = "requires codec corpus; enable `corpus-tests` feature")]
     fn test_pngsuite_gray() {
         crate::skip_without_corpus!();
         // 8-bit grayscale from PNG suite
@@ -486,6 +487,7 @@ mod corpus_tests {
     }
 
     #[test]
+    #[cfg_attr(not(feature = "corpus-tests"), ignore = "requires codec corpus; enable `corpus-tests` feature")]
     fn test_pngsuite_rgb() {
         crate::skip_without_corpus!();
         // 8-bit RGB from PNG suite
@@ -508,6 +510,7 @@ mod corpus_tests {
     }
 
     #[test]
+    #[cfg_attr(not(feature = "corpus-tests"), ignore = "requires codec corpus; enable `corpus-tests` feature")]
     fn test_kodak_01() {
         crate::skip_without_corpus!();
         let path = format!(
@@ -534,6 +537,7 @@ mod corpus_tests {
     }
 
     #[test]
+    #[cfg_attr(not(feature = "corpus-tests"), ignore = "requires codec corpus; enable `corpus-tests` feature")]
     fn test_corpus_batch() {
         crate::skip_without_corpus!();
         // Test multiple images from the corpus
@@ -1550,6 +1554,7 @@ mod decoder_validation {
 
     /// Test that pngsuite RGB images can be decoded by jxl-oxide
     #[test]
+    #[cfg_attr(not(feature = "corpus-tests"), ignore = "requires codec corpus; enable `corpus-tests` feature")]
     fn test_decode_pngsuite_rgb() {
         crate::skip_without_corpus!();
         // (corpus path resolved via crate::test_helpers::corpus_dir)
@@ -2360,6 +2365,7 @@ mod decoder_validation {
 
     /// Dual-decoder validation for corpus images
     #[test]
+    #[cfg_attr(not(feature = "corpus-tests"), ignore = "requires codec corpus; enable `corpus-tests` feature")]
     fn test_dual_decode_corpus_images() {
         crate::skip_without_corpus!();
         // (corpus path resolved via crate::test_helpers::corpus_dir)
@@ -2608,6 +2614,7 @@ mod decoder_validation {
 
     /// Test lossless roundtrip for corpus image (pngsuite)
     #[test]
+    #[cfg_attr(not(feature = "corpus-tests"), ignore = "requires codec corpus; enable `corpus-tests` feature")]
     fn test_roundtrip_lossless_corpus_rgb() {
         crate::skip_without_corpus!();
         // (corpus path resolved via crate::test_helpers::corpus_dir)
@@ -2628,6 +2635,7 @@ mod decoder_validation {
 
     /// Test lossless roundtrip for corpus grayscale (pngsuite)
     #[test]
+    #[cfg_attr(not(feature = "corpus-tests"), ignore = "requires codec corpus; enable `corpus-tests` feature")]
     fn test_roundtrip_lossless_corpus_gray() {
         crate::skip_without_corpus!();
         // (corpus path resolved via crate::test_helpers::corpus_dir)
@@ -2855,6 +2863,7 @@ mod quality_comparison_tests {
     }
 
     #[test]
+    #[cfg_attr(not(feature = "corpus-tests"), ignore = "requires codec corpus; enable `corpus-tests` feature")]
     fn test_quality_comparison_kodak01() {
         crate::skip_without_corpus!();
         let path = format!(

--- a/jxl-encoder/src/api_tests.rs
+++ b/jxl-encoder/src/api_tests.rs
@@ -467,7 +467,10 @@ mod corpus_tests {
     }
 
     #[test]
-    #[cfg_attr(not(feature = "corpus-tests"), ignore = "requires codec corpus; enable `corpus-tests` feature")]
+    #[cfg_attr(
+        not(feature = "corpus-tests"),
+        ignore = "requires codec corpus; enable `corpus-tests` feature"
+    )]
     fn test_pngsuite_gray() {
         crate::skip_without_corpus!();
         // 8-bit grayscale from PNG suite
@@ -487,7 +490,10 @@ mod corpus_tests {
     }
 
     #[test]
-    #[cfg_attr(not(feature = "corpus-tests"), ignore = "requires codec corpus; enable `corpus-tests` feature")]
+    #[cfg_attr(
+        not(feature = "corpus-tests"),
+        ignore = "requires codec corpus; enable `corpus-tests` feature"
+    )]
     fn test_pngsuite_rgb() {
         crate::skip_without_corpus!();
         // 8-bit RGB from PNG suite
@@ -510,7 +516,10 @@ mod corpus_tests {
     }
 
     #[test]
-    #[cfg_attr(not(feature = "corpus-tests"), ignore = "requires codec corpus; enable `corpus-tests` feature")]
+    #[cfg_attr(
+        not(feature = "corpus-tests"),
+        ignore = "requires codec corpus; enable `corpus-tests` feature"
+    )]
     fn test_kodak_01() {
         crate::skip_without_corpus!();
         let path = format!(
@@ -537,7 +546,10 @@ mod corpus_tests {
     }
 
     #[test]
-    #[cfg_attr(not(feature = "corpus-tests"), ignore = "requires codec corpus; enable `corpus-tests` feature")]
+    #[cfg_attr(
+        not(feature = "corpus-tests"),
+        ignore = "requires codec corpus; enable `corpus-tests` feature"
+    )]
     fn test_corpus_batch() {
         crate::skip_without_corpus!();
         // Test multiple images from the corpus
@@ -1554,7 +1566,10 @@ mod decoder_validation {
 
     /// Test that pngsuite RGB images can be decoded by jxl-oxide
     #[test]
-    #[cfg_attr(not(feature = "corpus-tests"), ignore = "requires codec corpus; enable `corpus-tests` feature")]
+    #[cfg_attr(
+        not(feature = "corpus-tests"),
+        ignore = "requires codec corpus; enable `corpus-tests` feature"
+    )]
     fn test_decode_pngsuite_rgb() {
         crate::skip_without_corpus!();
         // (corpus path resolved via crate::test_helpers::corpus_dir)
@@ -2365,7 +2380,10 @@ mod decoder_validation {
 
     /// Dual-decoder validation for corpus images
     #[test]
-    #[cfg_attr(not(feature = "corpus-tests"), ignore = "requires codec corpus; enable `corpus-tests` feature")]
+    #[cfg_attr(
+        not(feature = "corpus-tests"),
+        ignore = "requires codec corpus; enable `corpus-tests` feature"
+    )]
     fn test_dual_decode_corpus_images() {
         crate::skip_without_corpus!();
         // (corpus path resolved via crate::test_helpers::corpus_dir)
@@ -2614,7 +2632,10 @@ mod decoder_validation {
 
     /// Test lossless roundtrip for corpus image (pngsuite)
     #[test]
-    #[cfg_attr(not(feature = "corpus-tests"), ignore = "requires codec corpus; enable `corpus-tests` feature")]
+    #[cfg_attr(
+        not(feature = "corpus-tests"),
+        ignore = "requires codec corpus; enable `corpus-tests` feature"
+    )]
     fn test_roundtrip_lossless_corpus_rgb() {
         crate::skip_without_corpus!();
         // (corpus path resolved via crate::test_helpers::corpus_dir)
@@ -2635,7 +2656,10 @@ mod decoder_validation {
 
     /// Test lossless roundtrip for corpus grayscale (pngsuite)
     #[test]
-    #[cfg_attr(not(feature = "corpus-tests"), ignore = "requires codec corpus; enable `corpus-tests` feature")]
+    #[cfg_attr(
+        not(feature = "corpus-tests"),
+        ignore = "requires codec corpus; enable `corpus-tests` feature"
+    )]
     fn test_roundtrip_lossless_corpus_gray() {
         crate::skip_without_corpus!();
         // (corpus path resolved via crate::test_helpers::corpus_dir)
@@ -2863,7 +2887,10 @@ mod quality_comparison_tests {
     }
 
     #[test]
-    #[cfg_attr(not(feature = "corpus-tests"), ignore = "requires codec corpus; enable `corpus-tests` feature")]
+    #[cfg_attr(
+        not(feature = "corpus-tests"),
+        ignore = "requires codec corpus; enable `corpus-tests` feature"
+    )]
     fn test_quality_comparison_kodak01() {
         crate::skip_without_corpus!();
         let path = format!(

--- a/jxl-encoder/src/entropy_coding/encode_ans.rs
+++ b/jxl-encoder/src/entropy_coding/encode_ans.rs
@@ -867,24 +867,26 @@ pub fn write_tokens_ans(
         let config = code.uint_configs.get(dist_idx).copied().unwrap_or_default();
         let (encoded, sym) = encode_token_value_with_config(token, lz77, &config);
 
-        // Get the distribution for this context
-        let dist = code.distributions.get(dist_idx).unwrap_or_else(|| {
-            panic!(
-                "ANS: missing distribution at index {} for context {}",
-                dist_idx, ctx
-            )
-        });
+        // Get the distribution for this context. Out-of-range here is an
+        // internal-consistency bug, not user-recoverable, but we still
+        // surface it as a Result rather than panicking — a panic in this
+        // code path would be a DoS vector if a malformed Lz77Params or
+        // tokenization-bug ever produced a sym/ctx outside the distribution.
+        let dist = code.distributions.get(dist_idx).ok_or_else(|| {
+            crate::error::Error::InvalidInput(format!(
+                "ANS internal: missing distribution at index {dist_idx} for context {ctx}"
+            ))
+        })?;
 
         // Push extra bits first (they come after the symbol in forward order)
         encoder.push_bits(encoded.bits, encoded.nbits as u8);
 
         // Push the ANS symbol
-        let info = dist.get(sym as usize).unwrap_or_else(|| {
-            panic!(
-                "ANS: symbol {} not in distribution (ctx={}, dist_idx={})",
-                sym, ctx, dist_idx
-            )
-        });
+        let info = dist.get(sym as usize).ok_or_else(|| {
+            crate::error::Error::InvalidInput(format!(
+                "ANS internal: symbol {sym} not in distribution (ctx={ctx}, dist_idx={dist_idx})"
+            ))
+        })?;
 
         #[cfg(feature = "debug-tokens")]
         if _i < 5 || _i >= tokens.len() - 3 {

--- a/jxl-encoder/src/entropy_coding/encode_huffman.rs
+++ b/jxl-encoder/src/entropy_coding/encode_huffman.rs
@@ -43,8 +43,11 @@ pub fn convert_bit_depths_to_symbols(depth: &[u8], bits: &mut [u16]) {
     const MAX_BITS: usize = 16;
     let mut bl_count = [0u16; MAX_BITS];
 
+    // See encode_huffman tree: defensively clamp d to MAX_BITS-1 in case
+    // a caller bypasses create_huffman_tree's depth-limit retry loop.
     for &d in depth.iter() {
-        bl_count[d as usize] += 1;
+        let di = (d as usize).min(MAX_BITS - 1);
+        bl_count[di] += 1;
     }
     bl_count[0] = 0;
 
@@ -57,8 +60,9 @@ pub fn convert_bit_depths_to_symbols(depth: &[u8], bits: &mut [u16]) {
 
     for (i, &d) in depth.iter().enumerate() {
         if d > 0 {
-            bits[i] = reverse_bits(d as u32, next_code[d as usize]);
-            next_code[d as usize] += 1;
+            let di = (d as usize).min(MAX_BITS - 1);
+            bits[i] = reverse_bits(di as u32, next_code[di]);
+            next_code[di] += 1;
         }
     }
 }

--- a/jxl-encoder/src/entropy_coding/huffman_tree.rs
+++ b/jxl-encoder/src/entropy_coding/huffman_tree.rs
@@ -255,6 +255,18 @@ pub fn create_huffman_tree(histogram: &[u32], tree_limit: u8) -> Vec<u8> {
         };
     }
 
+    // Defensive clamp: if the retry loop bailed via overflow without ever
+    // fitting in `tree_limit`, depths can exceed MAX_BITS=16 and panic
+    // downstream when convert_bit_depths_to_symbols indexes
+    // `bl_count[d as usize]`. Clamp here so the panic site is unreachable
+    // — the resulting Huffman code may be slightly suboptimal but is still
+    // valid (decoder accepts any depth ≤ 15).
+    for d in depth.iter_mut() {
+        if *d > tree_limit {
+            *d = tree_limit;
+        }
+    }
+
     depth
 }
 
@@ -330,10 +342,14 @@ pub fn convert_bit_depths_to_symbols(depth: &[u8]) -> Vec<u16> {
     let len = depth.len();
     let mut bits = vec![0u16; len];
 
-    // Count symbols at each depth
+    // Count symbols at each depth. `create_huffman_tree` clamps depths to
+    // tree_limit (≤15) before returning, but defensively saturate here as
+    // well so any future caller that passes an unclamped depth array
+    // doesn't OOB-panic on `bl_count[d as usize]`.
     let mut bl_count = [0u16; MAX_BITS];
     for &d in depth {
-        bl_count[d as usize] += 1;
+        let di = (d as usize).min(MAX_BITS - 1);
+        bl_count[di] += 1;
     }
     bl_count[0] = 0; // Depth 0 means symbol doesn't exist
 

--- a/jxl-encoder/src/entropy_coding/lz77.rs
+++ b/jxl-encoder/src/entropy_coding/lz77.rs
@@ -693,7 +693,12 @@ pub fn apply_lz77_backref(
 
     let max_distance = tokens.len();
     let min_length = lz77.min_length as usize;
-    let max_length = tokens.len();
+    // SECURITY: same hard cap as the optimal path — see lz77_optimal for
+    // rationale. Greedy already has MAX_LAZY_MATCH_LEN=256 capping `lazy`
+    // matches, but find_matches itself can extend up to `max_length` per
+    // chain step, and that's the dimension we need to bound.
+    const LZ77_GREEDY_MAX_MATCH_LEN: usize = 1024;
+    let max_length = tokens.len().min(LZ77_GREEDY_MAX_MATCH_LEN);
 
     // Use next power of two as window size
     let mut window_size = 1usize;
@@ -1012,7 +1017,18 @@ pub fn apply_lz77_optimal(
     // Step 4: Forward DP pass.
     let max_distance = tokens.len();
     let min_length = lz77.min_length as usize;
-    let max_length = tokens.len();
+    // SECURITY: cap match length to a hard ceiling. Without this, the optimal
+    // LZ77 DP is O(n × chain_length × max_match_extend) where max_match_extend
+    // can reach `tokens.len()` on periodic adversarial input (e.g., a tight
+    // checker pattern at effort 9) — that's the e9 hang regression observed
+    // in the wild. Capping max_length bounds both the per-position
+    // find_matches work and the size of the dist_symbols accumulator that's
+    // re-iterated for each outer index. 1024 covers essentially every real
+    // long match (LZ77 RD benefit drops to noise past a few hundred symbols)
+    // while keeping worst-case work to O(n × 1024 × 256) ≈ a few seconds at
+    // n=4M tokens instead of indefinite hang.
+    const LZ77_OPTIMAL_MAX_MATCH_LEN: usize = 1024;
+    let max_length = tokens.len().min(LZ77_OPTIMAL_MAX_MATCH_LEN);
 
     let mut window_size = 1usize;
     while window_size < max_distance && window_size < WINDOW_SIZE {

--- a/jxl-encoder/src/icc.rs
+++ b/jxl-encoder/src/icc.rs
@@ -344,9 +344,13 @@ fn predict_flags(order: i32, width: usize, stride: usize) -> u8 {
 ///
 /// The output is a varint-encoded size, followed by commands, followed by data.
 /// This matches libjxl's `PredictICC()`.
-fn predict_icc(icc: &[u8]) -> Vec<u8> {
+fn predict_icc(icc: &[u8]) -> Result<Vec<u8>> {
     let size = icc.len();
-    assert!(size <= SIZE_LIMIT, "ICC profile too large");
+    if size > SIZE_LIMIT {
+        return Err(crate::error::Error::InvalidInput(format!(
+            "ICC profile too large: {size} bytes (max {SIZE_LIMIT})"
+        )));
+    }
 
     let mut result = Vec::new();
     let mut commands = Vec::new();
@@ -364,7 +368,7 @@ fn predict_icc(icc: &[u8]) -> Vec<u8> {
     if size <= ICC_HEADER_SIZE {
         encode_var_int(0, &mut result); // 0 commands
         result.extend_from_slice(&data);
-        return result;
+        return Ok(result);
     }
 
     // Parse tag table
@@ -694,7 +698,7 @@ fn predict_icc(icc: &[u8]) -> Vec<u8> {
     encode_var_int(commands.len() as u64, &mut result);
     result.extend_from_slice(&commands);
     result.extend_from_slice(&data);
-    result
+    Ok(result)
 }
 
 // ── U64 Coder ───────────────────────────────────────────────────────────────
@@ -738,9 +742,13 @@ fn write_u64(value: u64, writer: &mut BitWriter) -> Result<()> {
 /// The ICC data is transformed via PredictICC for better compressibility, then
 /// entropy-coded using Huffman with 41 contexts (matching libjxl's force_huffman=true).
 pub fn write_icc(icc: &[u8], writer: &mut BitWriter) -> Result<()> {
-    assert!(!icc.is_empty(), "ICC profile must not be empty");
+    if icc.is_empty() {
+        return Err(crate::error::Error::InvalidInput(
+            "ICC profile must not be empty".into(),
+        ));
+    }
 
-    let enc = predict_icc(icc);
+    let enc = predict_icc(icc)?;
 
     // Write predicted size as U64
     write_u64(enc.len() as u64, writer)?;
@@ -804,7 +812,7 @@ mod tests {
         let size_bytes = 128u32.to_be_bytes();
         icc[..4].copy_from_slice(&size_bytes);
 
-        let predicted = predict_icc(&icc);
+        let predicted = predict_icc(&icc).unwrap();
         assert!(!predicted.is_empty());
     }
 
@@ -824,7 +832,7 @@ mod tests {
         icc[140..144].copy_from_slice(&12u32.to_be_bytes());
         icc[144..148].copy_from_slice(b"text");
 
-        let predicted = predict_icc(&icc);
+        let predicted = predict_icc(&icc).unwrap();
         assert!(!predicted.is_empty());
     }
 

--- a/jxl-encoder/src/jpeg/encode.rs
+++ b/jxl-encoder/src/jpeg/encode.rs
@@ -790,6 +790,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(not(feature = "corpus-tests"), ignore = "requires codec corpus; enable `corpus-tests` feature")]
     fn test_encode_real_jpeg() {
         crate::skip_without_corpus!();
         let path = format!(

--- a/jxl-encoder/src/jpeg/encode.rs
+++ b/jxl-encoder/src/jpeg/encode.rs
@@ -790,7 +790,10 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(not(feature = "corpus-tests"), ignore = "requires codec corpus; enable `corpus-tests` feature")]
+    #[cfg_attr(
+        not(feature = "corpus-tests"),
+        ignore = "requires codec corpus; enable `corpus-tests` feature"
+    )]
     fn test_encode_real_jpeg() {
         crate::skip_without_corpus!();
         let path = format!(

--- a/jxl-encoder/src/jpeg/parse.rs
+++ b/jxl-encoder/src/jpeg/parse.rs
@@ -646,7 +646,10 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(not(feature = "corpus-tests"), ignore = "requires codec corpus; enable `corpus-tests` feature")]
+    #[cfg_attr(
+        not(feature = "corpus-tests"),
+        ignore = "requires codec corpus; enable `corpus-tests` feature"
+    )]
     fn test_parse_real_jpeg() {
         crate::skip_without_corpus!();
         let path = format!(

--- a/jxl-encoder/src/jpeg/parse.rs
+++ b/jxl-encoder/src/jpeg/parse.rs
@@ -646,6 +646,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(not(feature = "corpus-tests"), ignore = "requires codec corpus; enable `corpus-tests` feature")]
     fn test_parse_real_jpeg() {
         crate::skip_without_corpus!();
         let path = format!(

--- a/jxl-encoder/src/lib.rs
+++ b/jxl-encoder/src/lib.rs
@@ -109,7 +109,7 @@ pub mod test_helpers;
 #[doc(hidden)]
 pub mod __internals {
     // Pub re-exports of already-pub items in private/pub(crate) modules.
-    pub use crate::vardct::chroma_from_luma::{ytox_ratio, ytob_ratio};
+    pub use crate::vardct::chroma_from_luma::{ytob_ratio, ytox_ratio};
     pub use crate::vardct::quant::INV_DC_QUANT;
     // Wrappers around pub(crate) helpers and pub(crate) impl methods that
     // can't be `pub use`d directly.

--- a/jxl-encoder/src/lib.rs
+++ b/jxl-encoder/src/lib.rs
@@ -47,8 +47,8 @@ pub mod convenience;
 pub use api::{
     AnimationFrame, AnimationParams, At, EncodeError, EncodeMode, EncodeRequest, EncodeResult,
     EncodeStats, EncoderMode, ImageMetadata, Limits, LosslessConfig, LosslessEncoder, LossyConfig,
-    LossyEncoder, Lz77Method, PixelLayout, ProgressiveMode, Quality, ResultAtExt, Stop,
-    Unstoppable, at, calibrated_jxl_quality, quality_to_distance,
+    LossyEncoder, Lz77Method, NonFiniteAction, PixelLayout, ProgressiveMode, Quality, ResultAtExt,
+    Stop, Unstoppable, at, calibrated_jxl_quality, quality_to_distance,
 };
 // `EffortProfile` was re-exported at the crate root in 0.3.0; it is now an
 // **internal** type that drives the encoder's effort-derived decisions.

--- a/jxl-encoder/src/modular/tree_learn.rs
+++ b/jxl-encoder/src/modular/tree_learn.rs
@@ -181,6 +181,22 @@ impl TreeLearningParams {
             // (enc_modular.cc:546-549). This is our typical single-group case.
             PROP_ORDER_NO_SQUEEZE_NO_GID
         };
+        // Surface caller misconfiguration loudly. The `__expert` setter on
+        // LosslessConfig accepts any u8; previously the over-bound case
+        // silently clamped here. Runtime validation lives in
+        // `validate()` (opt-in); this debug_assert catches misconfigured
+        // sweep harnesses early during testing without panicking release
+        // builds (the `.min(order.len())` clamp below remains as a safety
+        // net so we never panic on out-of-bounds slice access).
+        debug_assert!(
+            (profile.tree_num_properties as usize) <= order.len(),
+            "tree_num_properties = {} exceeds property-order length {} \
+             for {}; clamp here is hiding a misconfigured \
+             LosslessInternalParams. Validate via LosslessConfig::validate().",
+            profile.tree_num_properties,
+            order.len(),
+            if is_squeeze { "squeeze" } else { "no-squeeze" },
+        );
         let num_props = (profile.tree_num_properties as usize).min(order.len());
 
         Self {

--- a/jxl-encoder/src/test_helpers.rs
+++ b/jxl-encoder/src/test_helpers.rs
@@ -38,17 +38,26 @@ pub fn corpus_dir() -> std::path::PathBuf {
     })
 }
 
-/// Skip the current test if the codec corpus is not available.
+/// Require the codec corpus directory; panic loudly if it isn't available.
 ///
-/// Use at the top of any test that requires external corpus files.
-/// In CI (no corpus), the test will pass silently instead of failing.
+/// Use at the top of any test that requires external corpus files. The
+/// caller is expected to gate the *test itself* with
+/// `#[cfg_attr(not(feature = "corpus-tests"), ignore = "...")]` (or the
+/// equivalent at the harness level) so the skip decision is visible as a
+/// `#[ignore]` attribute rather than a silent in-body return.
+///
+/// CLAUDE.md "NO GRACEFUL SKIPS IN TESTS": this macro intentionally does
+/// NOT swallow missing-corpus into an `eprintln!("SKIPPED ..."); return;`.
+/// If a corpus-using test runs (i.e. the `corpus-tests` feature is on)
+/// and the corpus path can't be found, that's a CI configuration bug —
+/// the test panics so the failure is loud.
 #[macro_export]
 macro_rules! skip_without_corpus {
     () => {
-        if $crate::test_helpers::try_corpus_dir().is_none() {
-            eprintln!("SKIPPED: codec corpus not available");
-            return;
-        }
+        // Resolves to the corpus dir or panics with a clear actionable
+        // message. Kept under the same name for callsite churn-free
+        // migration; consider renaming to `require_corpus!` in a follow-up.
+        let _ = $crate::test_helpers::corpus_dir();
     };
 }
 

--- a/jxl-encoder/src/validation.rs
+++ b/jxl-encoder/src/validation.rs
@@ -152,7 +152,10 @@ pub(crate) const NB_RCTS_RANGE: RangeInclusive<u8> = 0..=19;
 #[cfg(feature = "__expert")]
 pub(crate) const WP_NUM_PARAM_SETS_RANGE: RangeInclusive<u8> = 0..=5;
 /// `PROP_ORDER_NO_SQUEEZE` / `PROP_ORDER_SQUEEZE` are 16 entries; values
-/// above are silently clamped by `from_profile_impl`.
+/// above are clamped by `from_profile_impl`. A `debug_assert!` in
+/// `from_profile_impl` fires if a misconfigured sweep harness pushes a
+/// value past the bound; release builds still clamp (as a safety net so
+/// the encoder never panics on out-of-bounds slice access).
 #[cfg(feature = "__expert")]
 pub(crate) const TREE_NUM_PROPERTIES_RANGE: RangeInclusive<u8> = 0..=16;
 #[cfg(feature = "__expert")]

--- a/jxl-encoder/src/validation.rs
+++ b/jxl-encoder/src/validation.rs
@@ -137,11 +137,8 @@ pub(crate) const DISTANCE_MAX: f32 = 25.0;
 pub(crate) const EFFORT_RANGE: RangeInclusive<u8> = 1..=10;
 /// Cap on quality-loop iter counts. libjxl's kTortoise butteraugli runs 4
 /// passes; 16 leaves room for sweep harnesses without inviting absurd values.
-#[cfg(any(
-    feature = "butteraugli-loop",
-    feature = "ssim2-loop",
-    feature = "zensim-loop"
-))]
+/// Referenced unconditionally by `Limits::DEFAULT_MAX_QUANT_LOOP_ITERS`, so
+/// not feature-gated even though the loops themselves are.
 pub(crate) const ITER_MAX: u32 = 16;
 #[cfg(feature = "__expert")]
 pub(crate) const FINE_GRAINED_STEP_RANGE: RangeInclusive<u8> = 1..=8;

--- a/jxl-encoder/src/validation_tests.rs
+++ b/jxl-encoder/src/validation_tests.rs
@@ -539,18 +539,49 @@ mod expert {
         ));
     }
 
-    // ─── Existing encode behaviour is unchanged ──
+}
 
-    #[test]
-    fn validate_does_not_alter_encode_path() {
-        // A "bad" distance > 25 is silently accepted by the encode path
-        // (clamped internally). validate() rejects it but the Config still
-        // works for callers that don't validate.
-        let cfg = LossyConfig::new(50.0);
-        assert!(cfg.validate().is_err());
-        // Don't actually encode here — that path is exercised by the rest
-        // of the test suite. We just confirm `validate()` is purely
-        // observational and does not mutate state.
-        assert_eq!(cfg.distance(), 50.0);
+// ─── Existing encode behaviour is unchanged ──
+
+#[test]
+fn validate_does_not_alter_encode_path() {
+    // `validate()` is observational: it doesn't mutate `LossyConfig`
+    // state. The Config still holds the as-set distance.
+    let cfg = LossyConfig::new(50.0);
+    assert!(cfg.validate().is_err());
+    assert_eq!(cfg.distance(), 50.0);
+}
+
+#[test]
+fn encode_rejects_distance_above_max() {
+    // The encode path itself MUST reject distance > DISTANCE_MAX
+    // (= 25.0). Previously the encoder silently clamped internally
+    // and produced a ~25 bitstream while the caller saw no error.
+    // Now distance=50 fails fast at encode_inner.
+    let cfg = LossyConfig::new(50.0);
+    let pixels = vec![0u8; 4 * 4 * 3];
+    let err = cfg
+        .encode(&pixels, 4, 4, crate::api::PixelLayout::Rgb8)
+        .unwrap_err();
+    let msg = format!("{err}");
+    assert!(
+        msg.contains("distance") && msg.contains("out of range"),
+        "expected out-of-range error, got: {msg}"
+    );
+}
+
+#[test]
+fn encode_rejects_distance_zero_and_below() {
+    // Lossy distance must be > 0 (libjxl convention; d = 0 is lossless,
+    // accessible via `LosslessConfig`). Negative / zero / non-finite
+    // distance must not silently produce a bitstream.
+    let pixels = vec![0u8; 4 * 4 * 3];
+    for &d in &[0.0_f32, -1.0, f32::NAN, f32::INFINITY] {
+        let cfg = LossyConfig::new(d);
+        assert!(
+            cfg.encode(&pixels, 4, 4, crate::api::PixelLayout::Rgb8)
+                .is_err(),
+            "encode unexpectedly succeeded for distance = {d}"
+        );
     }
 }

--- a/jxl-encoder/src/validation_tests.rs
+++ b/jxl-encoder/src/validation_tests.rs
@@ -538,7 +538,6 @@ mod expert {
             ValidationError::TreeMaxBucketsZero
         ));
     }
-
 }
 
 // ─── Existing encode behaviour is unchanged ──

--- a/jxl-encoder/src/vardct/ac_strategy.rs
+++ b/jxl-encoder/src/vardct/ac_strategy.rs
@@ -453,10 +453,7 @@ pub(crate) fn compute_scaled_constants(distance: f32, bases: (f32, f32, f32)) ->
 /// `__internals` cargo feature's downstream parity testing.
 #[cfg(feature = "__internals")]
 #[doc(hidden)]
-pub fn compute_scaled_constants_free(
-    distance: f32,
-    bases: (f32, f32, f32),
-) -> (f32, f32, f32) {
+pub fn compute_scaled_constants_free(distance: f32, bases: (f32, f32, f32)) -> (f32, f32, f32) {
     compute_scaled_constants(distance, bases)
 }
 

--- a/jxl-encoder/src/vardct/butteraugli_loop.rs
+++ b/jxl-encoder/src/vardct/butteraugli_loop.rs
@@ -361,45 +361,27 @@ impl VarDctEncoder {
                 // Only adjust bad blocks (diff > 1.0)
                 // (libjxl enc_adaptive_quantization.cc:1066-1086)
                 for bi in 0..num_blocks {
-                    // SECURITY: defensively replace non-finite tile_dist or
-                    // quant_field values with finite fallbacks. NaN
-                    // (e.g., 0/0 when both tile_dist and target_distance are
-                    // zero, or when butteraugli returns NaN on a degenerate
-                    // input) propagates through these arithmetic ops and
-                    // bypasses the clamps below (every NaN comparison is
-                    // false), leaking non-finite quant_field values into
-                    // downstream `f32 as i32` casts.
-                    //
-                    // butteraugli's ButteraugliReference is supposed to
-                    // produce finite per-tile distances on legitimate
-                    // input. A `debug_assert` catches any test regression
-                    // where the upstream returns NaN; release builds
-                    // continue with the fallback to keep DoS protection
-                    // intact.
-                    debug_assert!(
+                    // butteraugli's ButteraugliReference is finite by
+                    // construction on any finite XYB input — non-finite
+                    // here is always an upstream bug. The 270-encode
+                    // trigger-fixture sweep + the math (XYB transform is
+                    // total on ℝ via cbrt + bias) prove these never fire
+                    // on legitimate input.
+                    assert!(
                         tile_dist[bi].is_finite(),
                         "butteraugli loop: non-finite tile_dist[{bi}] = {} \
                          (upstream butteraugli should never produce non-finite)",
                         tile_dist[bi]
                     );
-                    debug_assert!(
+                    assert!(
                         quant_field_float[bi].is_finite(),
                         "butteraugli loop: non-finite quant_field_float[{bi}] = {} \
                          (clamps should keep this finite every iter)",
                         quant_field_float[bi]
                     );
-                    let td = if tile_dist[bi].is_finite() {
-                        tile_dist[bi]
-                    } else {
-                        target_distance
-                    };
-                    let diff = td / target_distance;
+                    let diff = tile_dist[bi] / target_distance;
                     if diff > 1.0 {
-                        let old = if quant_field_float[bi].is_finite() {
-                            quant_field_float[bi]
-                        } else {
-                            qf_lower
-                        };
+                        let old = quant_field_float[bi];
                         quant_field_float[bi] = old * diff;
                         // Minimum step check: if rounding to integer quant produces
                         // the same value, bump by one quantizer step
@@ -411,47 +393,36 @@ impl VarDctEncoder {
                             quant_field_float[bi] = old + quantizer_scale;
                         }
                     }
-                    // .clamp() is NaN-safe (returns lo for NaN); explicit
-                    // is_finite check above keeps this as a belt-and-braces.
-                    if !quant_field_float[bi].is_finite() {
-                        quant_field_float[bi] = qf_lower;
-                    }
                     quant_field_float[bi] = quant_field_float[bi].clamp(qf_lower, qf_higher);
                 }
             } else {
                 // Adjust both directions (libjxl enc_adaptive_quantization.cc:1087-1110)
                 for bi in 0..num_blocks {
-                    debug_assert!(
+                    assert!(
                         tile_dist[bi].is_finite(),
                         "butteraugli loop: non-finite tile_dist[{bi}] = {}",
                         tile_dist[bi]
                     );
-                    debug_assert!(
+                    assert!(
                         quant_field_float[bi].is_finite(),
                         "butteraugli loop: non-finite quant_field_float[{bi}] = {}",
                         quant_field_float[bi]
                     );
-                    let td = if tile_dist[bi].is_finite() {
-                        tile_dist[bi]
-                    } else {
-                        target_distance
-                    };
-                    let diff = td / target_distance;
+                    let diff = tile_dist[bi] / target_distance;
                     if diff <= 1.0 {
                         // Good quality: reduce precision to save bits.
                         // diff < 0.0 (negative) would produce NaN through
-                        // powf for non-integer cur_pow — guard.
+                        // powf for non-integer cur_pow — guard via max(0).
                         let safe_diff = diff.max(0.0) as f64;
                         let factor = safe_diff.powf(cur_pow) as f32;
-                        let factor = if factor.is_finite() { factor } else { 1.0 };
+                        assert!(
+                            factor.is_finite(),
+                            "butteraugli loop: non-finite powf factor diff={diff} pow={cur_pow}"
+                        );
                         quant_field_float[bi] *= factor;
                     } else {
                         // Bad quality: increase precision
-                        let old = if quant_field_float[bi].is_finite() {
-                            quant_field_float[bi]
-                        } else {
-                            qf_lower
-                        };
+                        let old = quant_field_float[bi];
                         quant_field_float[bi] = old * diff;
                         // Minimum step check
                         let qf_old = (old * inv_global_scale + 0.5).floor() as i32;
@@ -460,9 +431,6 @@ impl VarDctEncoder {
                         if qf_old == qf_new {
                             quant_field_float[bi] = old + quantizer_scale;
                         }
-                    }
-                    if !quant_field_float[bi].is_finite() {
-                        quant_field_float[bi] = qf_lower;
                     }
                     quant_field_float[bi] = quant_field_float[bi].clamp(qf_lower, qf_higher);
                 }

--- a/jxl-encoder/src/vardct/butteraugli_loop.rs
+++ b/jxl-encoder/src/vardct/butteraugli_loop.rs
@@ -369,6 +369,25 @@ impl VarDctEncoder {
                     // bypasses the clamps below (every NaN comparison is
                     // false), leaking non-finite quant_field values into
                     // downstream `f32 as i32` casts.
+                    //
+                    // butteraugli's ButteraugliReference is supposed to
+                    // produce finite per-tile distances on legitimate
+                    // input. A `debug_assert` catches any test regression
+                    // where the upstream returns NaN; release builds
+                    // continue with the fallback to keep DoS protection
+                    // intact.
+                    debug_assert!(
+                        tile_dist[bi].is_finite(),
+                        "butteraugli loop: non-finite tile_dist[{bi}] = {} \
+                         (upstream butteraugli should never produce non-finite)",
+                        tile_dist[bi]
+                    );
+                    debug_assert!(
+                        quant_field_float[bi].is_finite(),
+                        "butteraugli loop: non-finite quant_field_float[{bi}] = {} \
+                         (clamps should keep this finite every iter)",
+                        quant_field_float[bi]
+                    );
                     let td = if tile_dist[bi].is_finite() {
                         tile_dist[bi]
                     } else {
@@ -402,6 +421,16 @@ impl VarDctEncoder {
             } else {
                 // Adjust both directions (libjxl enc_adaptive_quantization.cc:1087-1110)
                 for bi in 0..num_blocks {
+                    debug_assert!(
+                        tile_dist[bi].is_finite(),
+                        "butteraugli loop: non-finite tile_dist[{bi}] = {}",
+                        tile_dist[bi]
+                    );
+                    debug_assert!(
+                        quant_field_float[bi].is_finite(),
+                        "butteraugli loop: non-finite quant_field_float[{bi}] = {}",
+                        quant_field_float[bi]
+                    );
                     let td = if tile_dist[bi].is_finite() {
                         tile_dist[bi]
                     } else {

--- a/jxl-encoder/src/vardct/butteraugli_loop.rs
+++ b/jxl-encoder/src/vardct/butteraugli_loop.rs
@@ -356,9 +356,26 @@ impl VarDctEncoder {
                 // Only adjust bad blocks (diff > 1.0)
                 // (libjxl enc_adaptive_quantization.cc:1066-1086)
                 for bi in 0..num_blocks {
-                    let diff = tile_dist[bi] / target_distance;
+                    // SECURITY: defensively replace non-finite tile_dist or
+                    // quant_field values with finite fallbacks. NaN
+                    // (e.g., 0/0 when both tile_dist and target_distance are
+                    // zero, or when butteraugli returns NaN on a degenerate
+                    // input) propagates through these arithmetic ops and
+                    // bypasses the clamps below (every NaN comparison is
+                    // false), leaking non-finite quant_field values into
+                    // downstream `f32 as i32` casts.
+                    let td = if tile_dist[bi].is_finite() {
+                        tile_dist[bi]
+                    } else {
+                        target_distance
+                    };
+                    let diff = td / target_distance;
                     if diff > 1.0 {
-                        let old = quant_field_float[bi];
+                        let old = if quant_field_float[bi].is_finite() {
+                            quant_field_float[bi]
+                        } else {
+                            qf_lower
+                        };
                         quant_field_float[bi] = old * diff;
                         // Minimum step check: if rounding to integer quant produces
                         // the same value, bump by one quantizer step
@@ -370,23 +387,37 @@ impl VarDctEncoder {
                             quant_field_float[bi] = old + quantizer_scale;
                         }
                     }
-                    if quant_field_float[bi] > qf_higher {
-                        quant_field_float[bi] = qf_higher;
-                    }
-                    if quant_field_float[bi] < qf_lower {
+                    // .clamp() is NaN-safe (returns lo for NaN); explicit
+                    // is_finite check above keeps this as a belt-and-braces.
+                    if !quant_field_float[bi].is_finite() {
                         quant_field_float[bi] = qf_lower;
                     }
+                    quant_field_float[bi] = quant_field_float[bi].clamp(qf_lower, qf_higher);
                 }
             } else {
                 // Adjust both directions (libjxl enc_adaptive_quantization.cc:1087-1110)
                 for bi in 0..num_blocks {
-                    let diff = tile_dist[bi] / target_distance;
+                    let td = if tile_dist[bi].is_finite() {
+                        tile_dist[bi]
+                    } else {
+                        target_distance
+                    };
+                    let diff = td / target_distance;
                     if diff <= 1.0 {
-                        // Good quality: reduce precision to save bits
-                        quant_field_float[bi] *= (diff as f64).powf(cur_pow) as f32;
+                        // Good quality: reduce precision to save bits.
+                        // diff < 0.0 (negative) would produce NaN through
+                        // powf for non-integer cur_pow — guard.
+                        let safe_diff = diff.max(0.0) as f64;
+                        let factor = safe_diff.powf(cur_pow) as f32;
+                        let factor = if factor.is_finite() { factor } else { 1.0 };
+                        quant_field_float[bi] *= factor;
                     } else {
                         // Bad quality: increase precision
-                        let old = quant_field_float[bi];
+                        let old = if quant_field_float[bi].is_finite() {
+                            quant_field_float[bi]
+                        } else {
+                            qf_lower
+                        };
                         quant_field_float[bi] = old * diff;
                         // Minimum step check
                         let qf_old = (old * inv_global_scale + 0.5).floor() as i32;
@@ -396,12 +427,10 @@ impl VarDctEncoder {
                             quant_field_float[bi] = old + quantizer_scale;
                         }
                     }
-                    if quant_field_float[bi] > qf_higher {
-                        quant_field_float[bi] = qf_higher;
-                    }
-                    if quant_field_float[bi] < qf_lower {
+                    if !quant_field_float[bi].is_finite() {
                         quant_field_float[bi] = qf_lower;
                     }
+                    quant_field_float[bi] = quant_field_float[bi].clamp(qf_lower, qf_higher);
                 }
             }
         }

--- a/jxl-encoder/src/vardct/butteraugli_loop.rs
+++ b/jxl-encoder/src/vardct/butteraugli_loop.rs
@@ -411,8 +411,20 @@ impl VarDctEncoder {
                     let diff = tile_dist[bi] / target_distance;
                     if diff <= 1.0 {
                         // Good quality: reduce precision to save bits.
-                        // diff < 0.0 (negative) would produce NaN through
-                        // powf for non-integer cur_pow — guard via max(0).
+                        // `diff` must be finite — NaN here indicates a real bug
+                        // (target_distance == 0, or polluted reconstruction from
+                        // a previous butteraugli iteration). Surface loudly rather
+                        // than silently coercing to 0 via .max() (IEEE-754 ordered
+                        // max returns the non-NaN operand, and 0.0.powf(x) = 0.0
+                        // is finite, so the downstream assert can't catch it).
+                        assert!(
+                            diff.is_finite(),
+                            "butteraugli loop: non-finite diff = {diff} \
+                             (tile_dist={}, target_distance={target_distance})",
+                            tile_dist[bi]
+                        );
+                        // Negative diff would produce NaN through powf for
+                        // non-integer cur_pow — guard via max(0).
                         let safe_diff = diff.max(0.0) as f64;
                         let factor = safe_diff.powf(cur_pow) as f32;
                         assert!(

--- a/jxl-encoder/src/vardct/butteraugli_loop.rs
+++ b/jxl-encoder/src/vardct/butteraugli_loop.rs
@@ -129,7 +129,12 @@ impl VarDctEncoder {
         let mut recon_b = vec![0.0f32; padded_pixels];
         let mut transform_out = super::transform::TransformOutput::new(xsize_blocks, ysize_blocks);
 
-        let iters = self.butteraugli_iters as usize;
+        // Saturate at consumption to bound worst-case CPU even when the
+        // caller skipped LossyConfig::validate (which would have rejected
+        // values > MAX_QUANT_LOOP_ITERS with IterCountOutOfRange). Each
+        // iteration runs a full butteraugli pipeline; capping prevents
+        // a malicious or buggy caller from DoS-ing the encoder.
+        let iters = (self.butteraugli_iters.min(crate::api::MAX_QUANT_LOOP_ITERS)) as usize;
         let mut current_params;
 
         // Loop runs iters+1 times (matching libjxl: last iteration is compare-only).

--- a/jxl-encoder/src/vardct/encoder.rs
+++ b/jxl-encoder/src/vardct/encoder.rs
@@ -25,6 +25,23 @@ use crate::headers::frame_header::FrameHeader;
 // Re-export types from entropy_code sub-module.
 pub(crate) use super::entropy_code::{BuiltEntropyCode, force_strategy_map};
 
+/// Replace any NaN or non-finite f32 in the three XYB planes with 0.0.
+///
+/// Called once at the boundary between XYB conversion and the downstream
+/// pipeline (patches, splines, gaborish, adaptive quant, butteraugli loop).
+/// NaN comparisons are always false, which would bypass clamps in the
+/// butteraugli iteration loop and propagate non-finite values into
+/// `f32 as i32` / `as usize` casts in patch detection and spline rendering
+/// — the suspected upstream of the 0x40000000-prefix index corruption
+/// observed in production sweeps.
+fn sanitize_xyb_planes(x: &mut [f32], y: &mut [f32], b: &mut [f32]) {
+    for v in x.iter_mut().chain(y.iter_mut()).chain(b.iter_mut()) {
+        if !v.is_finite() {
+            *v = 0.0;
+        }
+    }
+}
+
 /// Output of a VarDCT encode operation.
 pub struct VarDctOutput {
     /// Encoded JXL codestream bytes.
@@ -358,6 +375,19 @@ impl VarDctEncoder {
         // This allows SIMD to process full blocks without bounds checking.
         let (mut xyb_x, mut xyb_y, mut xyb_b) =
             self.convert_to_xyb_padded(width, height, padded_width, padded_height, linear_rgb);
+
+        // SECURITY: sanitize XYB at the boundary before any downstream
+        // consumer (patches, splines, gaborish, adaptive quant). NaN/Inf in
+        // XYB has been observed to leak through after butteraugli quant-loop
+        // numeric blowups (`diff = tile_dist / target_distance` where
+        // both are zero, then `pow(diff, cur_pow)` returns NaN, then NaN
+        // bypasses the qf clamp because all NaN comparisons are false).
+        // NaN that reaches `f32 as i32`/`as usize` casts in patches /
+        // splines / quantization is the suspected upstream of the
+        // 0x40000000-prefix corruption pattern. Replacing non-finite with
+        // 0.0 is correctness-safe (XYB 0.0 is a valid mid-gray) and
+        // bounded.
+        sanitize_xyb_planes(&mut xyb_x, &mut xyb_y, &mut xyb_b);
 
         // Estimate noise parameters (if enabled).
         // The decoder adds noise during rendering; the encoder just encodes the params.

--- a/jxl-encoder/src/vardct/encoder.rs
+++ b/jxl-encoder/src/vardct/encoder.rs
@@ -419,29 +419,51 @@ impl VarDctEncoder {
         let padded_width = xsize_blocks * BLOCK_DIM;
         let padded_height = ysize_blocks * BLOCK_DIM;
 
-        // Validate linear-RGB at intake (Error mode only). The
-        // `forward_xyb` SIMD kernel uses `mixed.max(0.0)` per channel,
-        // which silently coerces NaN to `0.0` (IEEE-754 ordered max
-        // returns the non-NaN operand). That means a caller-supplied
-        // NaN linear-RGB never reaches the XYB output — the post-XYB
-        // check would not fire. To surface caller bugs we have to check
-        // here, before forward_xyb runs. For 8-bit / 16-bit pixel
-        // layouts the linear-RGB conversion is total (no non-finite
-        // possible) and this check is a fast read-only no-op.
+        // Validate linear-RGB at intake. The `forward_xyb` SIMD kernel
+        // uses `mixed.max(0.0)` per channel, which silently coerces NaN
+        // to `0.0` (IEEE-754 ordered max returns the non-NaN operand).
+        // That means a caller-supplied NaN linear-RGB never reaches the
+        // XYB output — the post-XYB check would not fire either. To
+        // surface caller bugs (Error mode) or actively scrub them
+        // (Sanitize mode), we must check / fix here, before forward_xyb
+        // runs. For 8-bit / 16-bit pixel layouts the linear-RGB
+        // conversion is total (no non-finite possible) and the
+        // is_finite_plane scan is a fast read-only no-op (~55 GB/s).
         //
-        // Sanitize mode skips this check on the assumption that the
-        // XYB transform's silent NaN→0 clamp is the desired behavior
-        // for image-proxy use cases.
-        if matches!(self.non_finite_action, crate::api::NonFiniteAction::Error)
-            && !jxl_simd::is_finite_plane(linear_rgb)
-        {
-            return Err(crate::error::Error::InvalidInput(
-                "non-finite (NaN / ±Inf) value detected in linear-RGB input. \
-                 Use LossyConfig::with_non_finite_action(NonFiniteAction::Sanitize) \
-                 to silently clamp at the XYB transform instead."
-                    .into(),
-            ));
-        }
+        // Sanitize mode used to skip the input check entirely, relying
+        // on forward_xyb's silent NaN→0 max to mask non-finite values.
+        // That left the advertised "SIMD scrub" never running on the
+        // linear-RGB plane and made Error/Sanitize behavior diverge.
+        // Now Sanitize actively rewrites non-finite values to 0.0
+        // (~12.5 GB/s), then runs the rest of the pipeline on a clean
+        // buffer; the downstream XYB scan stays as defense-in-depth.
+        let sanitized_linear_rgb_storage: Option<alloc::vec::Vec<f32>> =
+            match self.non_finite_action {
+                crate::api::NonFiniteAction::Error => {
+                    if !jxl_simd::is_finite_plane(linear_rgb) {
+                        return Err(crate::error::Error::InvalidInput(
+                            "non-finite (NaN / ±Inf) value detected in linear-RGB input. \
+                             Use LossyConfig::with_non_finite_action(NonFiniteAction::Sanitize) \
+                             to silently scrub non-finite values to 0.0 instead."
+                                .into(),
+                        ));
+                    }
+                    None
+                }
+                crate::api::NonFiniteAction::Sanitize => {
+                    // sanitize_finite needs &mut, but the caller-supplied
+                    // buffer is borrowed. Clone-and-sanitize when (and
+                    // only when) Sanitize mode is selected. For 8-bit /
+                    // 16-bit pixel layouts there are never non-finite
+                    // values, so most callers stay on the Error fast path.
+                    let mut owned: alloc::vec::Vec<f32> = linear_rgb.to_vec();
+                    let _ = jxl_simd::sanitize_finite(&mut owned);
+                    Some(owned)
+                }
+            };
+        let linear_rgb: &[f32] = sanitized_linear_rgb_storage
+            .as_deref()
+            .unwrap_or(linear_rgb);
 
         // Convert to XYB with edge-replicated padding to block boundaries.
         // This allows SIMD to process full blocks without bounds checking.

--- a/jxl-encoder/src/vardct/encoder.rs
+++ b/jxl-encoder/src/vardct/encoder.rs
@@ -25,44 +25,64 @@ use crate::headers::frame_header::FrameHeader;
 // Re-export types from entropy_code sub-module.
 pub(crate) use super::entropy_code::{BuiltEntropyCode, force_strategy_map};
 
-/// Replace any NaN or non-finite f32 in the three XYB planes with 0.0,
-/// and panic if any replacement happened.
+/// Validate the three XYB planes against caller-configured policy at
+/// the conversion→pipeline boundary.
 ///
-/// Called once at the boundary between XYB conversion and the downstream
-/// pipeline. **Non-finite XYB is always an upstream bug:** the opsin
-/// transform (`color::xyb::linear_rgb_to_xyb`) is `cbrt(mixed + bias) -
-/// cbrt(bias)` per channel — bias is positive, so the cube-root argument
-/// is always strictly positive for any finite linear-RGB input, and the
-/// output is finite.
+/// The opsin transform (`color::xyb::linear_rgb_to_xyb`) is
+/// `cbrt(mixed + bias) - cbrt(bias)` per channel — bias is positive, so
+/// the cube-root argument is always strictly positive for any finite
+/// linear-RGB input, and the output is finite. Non-finite XYB at this
+/// boundary indicates an upstream bug:
 ///
-/// The only ways non-finite XYB can reach this boundary are:
-///
-/// 1. The caller passed non-finite linear-RGB (a caller bug — the
-///    `LinearF32` pixel layouts allow this; we should validate at
-///    intake but currently don't).
-/// 2. An upstream computation (butteraugli loop reconstruction, EPF,
+/// 1. The caller passed non-finite linear-RGB (the `LinearF32` pixel
+///    layouts allow this; we should validate at intake but currently
+///    don't).
+/// 2. An upstream computation (butteraugli-loop reconstruction, EPF,
 ///    gaborish) leaked NaN into XYB — fix-the-upstream bug.
 /// 3. Memory corruption (the original v09/v11 sweep cause, mitigated
 ///    by removing `unsafe-performance` in PR #34).
 ///
-/// All three are real bugs we want to surface as panics, not silently
-/// sanitize. The 270-encode trigger-fixture sweep on every image
-/// known to crash the v09/v11 production sweep showed zero non-finite
-/// values, so this assertion does not fire on legitimate input.
+/// Behavior:
 ///
-/// Backed by the SIMD `sanitize_finite` kernel in jxl-encoder-simd.
-fn sanitize_xyb_planes(x: &mut [f32], y: &mut [f32], b: &mut [f32]) {
-    let rx = jxl_simd::sanitize_finite(x);
-    let ry = jxl_simd::sanitize_finite(y);
-    let rb = jxl_simd::sanitize_finite(b);
-    assert!(
-        !(rx | ry | rb),
-        "sanitize_xyb_planes: non-finite XYB values found at the \
-         conversion→pipeline boundary. This is always an upstream bug. \
-         Check: (1) non-finite linear-RGB input from caller, \
-         (2) butteraugli-loop reconstruction polluting XYB, \
-         (3) memory corruption. See vardct/encoder.rs:48 for context."
-    );
+/// - [`NonFiniteAction::Error`] (default): runs the **read-only**
+///   `is_finite_plane` SIMD scan (~55 GB/s) and returns
+///   [`crate::error::Error::InvalidInput`] on first non-finite plane.
+///   Nothing downstream ever sees the bad data.
+/// - [`NonFiniteAction::Sanitize`]: runs the read-modify-write
+///   `sanitize_finite` SIMD kernel (~12.5 GB/s) and replaces non-finite
+///   values with `0.0`. Encoding continues.
+fn validate_xyb_planes(
+    action: crate::api::NonFiniteAction,
+    x: &mut [f32],
+    y: &mut [f32],
+    b: &mut [f32],
+) -> crate::error::Result<()> {
+    match action {
+        crate::api::NonFiniteAction::Error => {
+            if !(jxl_simd::is_finite_plane(x)
+                && jxl_simd::is_finite_plane(y)
+                && jxl_simd::is_finite_plane(b))
+            {
+                return Err(crate::error::Error::InvalidInput(
+                    "non-finite (NaN / ±Inf) value detected in XYB pixel planes. \
+                     This is an upstream bug. Common causes: caller passed \
+                     non-finite linear-RGB, butteraugli-loop reconstruction \
+                     polluted XYB, memory corruption. To accept and silently \
+                     replace with 0.0 instead of erroring, use \
+                     LossyConfig::with_non_finite_action(NonFiniteAction::Sanitize)."
+                        .into(),
+                ));
+            }
+        }
+        crate::api::NonFiniteAction::Sanitize => {
+            // Always run all three so each plane gets cleaned even if
+            // an earlier one was clean.
+            let _ = jxl_simd::sanitize_finite(x);
+            let _ = jxl_simd::sanitize_finite(y);
+            let _ = jxl_simd::sanitize_finite(b);
+        }
+    }
+    Ok(())
 }
 
 /// Output of a VarDCT encode operation.
@@ -241,6 +261,9 @@ pub struct VarDctEncoder {
     pub min_nits: f32,
     /// Intrinsic display size `(width, height)`, if different from coded dimensions.
     pub intrinsic_size: Option<(u32, u32)>,
+    /// Policy for non-finite XYB values at the conversion→pipeline
+    /// boundary. See [`crate::api::NonFiniteAction`].
+    pub non_finite_action: crate::api::NonFiniteAction,
 }
 
 impl Default for VarDctEncoder {
@@ -283,6 +306,7 @@ impl Default for VarDctEncoder {
             intensity_target: 255.0,
             min_nits: 0.0,
             intrinsic_size: None,
+            non_finite_action: crate::api::NonFiniteAction::default(),
         }
     }
 }
@@ -328,6 +352,7 @@ impl VarDctEncoder {
             intensity_target: 255.0,
             min_nits: 0.0,
             intrinsic_size: None,
+            non_finite_action: crate::api::NonFiniteAction::default(),
         }
     }
 
@@ -394,25 +419,40 @@ impl VarDctEncoder {
         let padded_width = xsize_blocks * BLOCK_DIM;
         let padded_height = ysize_blocks * BLOCK_DIM;
 
+        // Validate linear-RGB at intake (Error mode only). The
+        // `forward_xyb` SIMD kernel uses `mixed.max(0.0)` per channel,
+        // which silently coerces NaN to `0.0` (IEEE-754 ordered max
+        // returns the non-NaN operand). That means a caller-supplied
+        // NaN linear-RGB never reaches the XYB output — the post-XYB
+        // check would not fire. To surface caller bugs we have to check
+        // here, before forward_xyb runs. For 8-bit / 16-bit pixel
+        // layouts the linear-RGB conversion is total (no non-finite
+        // possible) and this check is a fast read-only no-op.
+        //
+        // Sanitize mode skips this check on the assumption that the
+        // XYB transform's silent NaN→0 clamp is the desired behavior
+        // for image-proxy use cases.
+        if matches!(self.non_finite_action, crate::api::NonFiniteAction::Error)
+            && !jxl_simd::is_finite_plane(linear_rgb)
+        {
+            return Err(crate::error::Error::InvalidInput(
+                "non-finite (NaN / ±Inf) value detected in linear-RGB input. \
+                 Use LossyConfig::with_non_finite_action(NonFiniteAction::Sanitize) \
+                 to silently clamp at the XYB transform instead."
+                    .into(),
+            ));
+        }
+
         // Convert to XYB with edge-replicated padding to block boundaries.
         // This allows SIMD to process full blocks without bounds checking.
         let (mut xyb_x, mut xyb_y, mut xyb_b) =
             self.convert_to_xyb_padded(width, height, padded_width, padded_height, linear_rgb);
 
-        // SECURITY: sanitize XYB at the boundary before any downstream
-        // consumer (patches, splines, gaborish, adaptive quant). NaN/Inf in
-        // XYB has been observed to leak through after butteraugli quant-loop
-        // numeric blowups (`diff = tile_dist / target_distance` where
-        // both are zero, then `pow(diff, cur_pow)` returns NaN, then NaN
-        // bypasses the qf clamp because all NaN comparisons are false).
-        // NaN that reaches `f32 as i32`/`as usize` casts in patches /
-        // splines / quantization is the suspected upstream of the
-        // 0x40000000-prefix corruption pattern. Replacing non-finite with
-        // 0.0 is correctness-safe (XYB 0.0 is a valid mid-gray) and
-        // bounded.
-        // Panics if any non-finite XYB value reaches this boundary —
-        // that's always an upstream bug (see fn doc).
-        sanitize_xyb_planes(&mut xyb_x, &mut xyb_y, &mut xyb_b);
+        // Defense-in-depth XYB scan. Catches downstream-bug non-finite
+        // (memory corruption, butteraugli-loop reconstruction polluting
+        // XYB) — should never fire on the encode-fresh path because
+        // forward_xyb is finite-output-for-finite-input.
+        validate_xyb_planes(self.non_finite_action, &mut xyb_x, &mut xyb_y, &mut xyb_b)?;
 
         // Estimate noise parameters (if enabled).
         // The decoder adds noise during rendering; the encoder just encodes the params.

--- a/jxl-encoder/src/vardct/encoder.rs
+++ b/jxl-encoder/src/vardct/encoder.rs
@@ -35,21 +35,37 @@ pub(crate) use super::entropy_code::{BuiltEntropyCode, force_strategy_map};
 /// — the suspected upstream of the 0x40000000-prefix index corruption
 /// observed in production sweeps.
 ///
-/// Legitimate inputs *can* produce non-finite XYB values (e.g.,
-/// all-zero RGB → log(0) = -Inf in the XYB opsin transform). The
-/// replacement to 0.0 (mid-gray, valid XYB origin) is correct for that
-/// case, so this function never fails or panics in release. Returns
-/// `true` if any replacement occurred — callers in tests can assert
-/// `false` against synthetic-content invariants to catch upstream
-/// regressions.
+/// **Non-finite XYB is always an upstream bug.** The opsin transform
+/// (`color::xyb::linear_rgb_to_xyb`) is `cbrt(mixed + bias) - cbrt(bias)`
+/// per channel — bias is positive, so the cube-root argument is always
+/// strictly positive for any finite linear-RGB input, and the output is
+/// finite. The only way non-finite XYB reaches this boundary is:
 ///
-/// Backed by the SIMD `sanitize_finite` kernel in jxl-encoder-simd
-/// (see `sanitize.rs` for the `(v * 0).simd_eq(0)` finite-mask trick).
+/// 1. The caller passed non-finite linear-RGB (a caller bug — the
+///    `LinearF32` pixel layouts allow this; we should validate at
+///    intake but currently don't).
+/// 2. An upstream computation (butteraugli loop reconstruction, EPF,
+///    gaborish) leaked NaN into XYB — that's a fix-the-upstream bug.
+/// 3. Memory corruption (the original v09/v11 sweep cause).
+///
+/// Release builds replace with 0.0 (DoS protection — keeps the encoder
+/// from panicking on hostile input), but a `debug_assert!` surfaces the
+/// regression in test builds so it isn't silently absorbed. Backed by
+/// the SIMD `sanitize_finite` kernel in jxl-encoder-simd.
 fn sanitize_xyb_planes(x: &mut [f32], y: &mut [f32], b: &mut [f32]) -> bool {
     let rx = jxl_simd::sanitize_finite(x);
     let ry = jxl_simd::sanitize_finite(y);
     let rb = jxl_simd::sanitize_finite(b);
-    rx | ry | rb
+    let replaced = rx | ry | rb;
+    debug_assert!(
+        !replaced,
+        "sanitize_xyb_planes: replaced non-finite XYB values — \
+         this indicates an upstream NaN/Inf source that should be fixed at \
+         the source. Check: (1) non-finite linear-RGB input from caller, \
+         (2) butteraugli-loop reconstruction polluting XYB, \
+         (3) memory corruption. See vardct/encoder.rs:48 for context."
+    );
+    replaced
 }
 
 /// Output of a VarDCT encode operation.
@@ -397,19 +413,15 @@ impl VarDctEncoder {
         // 0x40000000-prefix corruption pattern. Replacing non-finite with
         // 0.0 is correctness-safe (XYB 0.0 is a valid mid-gray) and
         // bounded.
+        // Returns true (with a debug_assert! firing in test builds) if any
+        // non-finite XYB value was found and zeroed. Release builds keep
+        // running with the cleaned planes — that's the DoS protection.
         let _xyb_had_nonfinite = sanitize_xyb_planes(&mut xyb_x, &mut xyb_y, &mut xyb_b);
-        // The scalar fallback in `sanitize_finite` will catch any tail bytes;
-        // legitimate input can produce non-finite XYB (e.g. all-zero RGB →
-        // log(0) = -Inf), so we don't assert against `_xyb_had_nonfinite`
-        // here. Tests that exercise non-degenerate content can `debug_assert`
-        // on the encoder's behavior end-to-end via the patches/lz77 OOB
-        // regression suites — those would re-trip if the upstream invariant
-        // breaks again.
         #[cfg(feature = "debug-tokens")]
         if _xyb_had_nonfinite {
             eprintln!(
-                "sanitize_xyb_planes: replaced non-finite values \
-                 (degenerate input — see vardct/encoder.rs:48)"
+                "sanitize_xyb_planes: replaced non-finite values — \
+                 upstream bug (see vardct/encoder.rs:48 for diagnosis paths)"
             );
         }
 

--- a/jxl-encoder/src/vardct/encoder.rs
+++ b/jxl-encoder/src/vardct/encoder.rs
@@ -36,17 +36,20 @@ pub(crate) use super::entropy_code::{BuiltEntropyCode, force_strategy_map};
 /// observed in production sweeps.
 ///
 /// Legitimate inputs *can* produce non-finite XYB values (e.g.,
-/// all-zero RGB → log(0) = -Inf in the XYB opsin transform). This is
-/// not a bug; it's a numerical edge case the rest of the encoder
-/// handled by accident-bypass before NaN propagation became visible.
-/// Replace with 0.0 (mid-gray, valid XYB origin); a tiny number of
-/// non-finite values per encode is expected on degenerate input.
-fn sanitize_xyb_planes(x: &mut [f32], y: &mut [f32], b: &mut [f32]) {
-    for v in x.iter_mut().chain(y.iter_mut()).chain(b.iter_mut()) {
-        if !v.is_finite() {
-            *v = 0.0;
-        }
-    }
+/// all-zero RGB → log(0) = -Inf in the XYB opsin transform). The
+/// replacement to 0.0 (mid-gray, valid XYB origin) is correct for that
+/// case, so this function never fails or panics in release. Returns
+/// `true` if any replacement occurred — callers in tests can assert
+/// `false` against synthetic-content invariants to catch upstream
+/// regressions.
+///
+/// Backed by the SIMD `sanitize_finite` kernel in jxl-encoder-simd
+/// (see `sanitize.rs` for the `(v * 0).simd_eq(0)` finite-mask trick).
+fn sanitize_xyb_planes(x: &mut [f32], y: &mut [f32], b: &mut [f32]) -> bool {
+    let rx = jxl_simd::sanitize_finite(x);
+    let ry = jxl_simd::sanitize_finite(y);
+    let rb = jxl_simd::sanitize_finite(b);
+    rx | ry | rb
 }
 
 /// Output of a VarDCT encode operation.
@@ -394,7 +397,21 @@ impl VarDctEncoder {
         // 0x40000000-prefix corruption pattern. Replacing non-finite with
         // 0.0 is correctness-safe (XYB 0.0 is a valid mid-gray) and
         // bounded.
-        sanitize_xyb_planes(&mut xyb_x, &mut xyb_y, &mut xyb_b);
+        let _xyb_had_nonfinite = sanitize_xyb_planes(&mut xyb_x, &mut xyb_y, &mut xyb_b);
+        // The scalar fallback in `sanitize_finite` will catch any tail bytes;
+        // legitimate input can produce non-finite XYB (e.g. all-zero RGB →
+        // log(0) = -Inf), so we don't assert against `_xyb_had_nonfinite`
+        // here. Tests that exercise non-degenerate content can `debug_assert`
+        // on the encoder's behavior end-to-end via the patches/lz77 OOB
+        // regression suites — those would re-trip if the upstream invariant
+        // breaks again.
+        #[cfg(feature = "debug-tokens")]
+        if _xyb_had_nonfinite {
+            eprintln!(
+                "sanitize_xyb_planes: replaced non-finite values \
+                 (degenerate input — see vardct/encoder.rs:48)"
+            );
+        }
 
         // Estimate noise parameters (if enabled).
         // The decoder adds noise during rendering; the encoder just encodes the params.

--- a/jxl-encoder/src/vardct/encoder.rs
+++ b/jxl-encoder/src/vardct/encoder.rs
@@ -34,6 +34,13 @@ pub(crate) use super::entropy_code::{BuiltEntropyCode, force_strategy_map};
 /// `f32 as i32` / `as usize` casts in patch detection and spline rendering
 /// — the suspected upstream of the 0x40000000-prefix index corruption
 /// observed in production sweeps.
+///
+/// Legitimate inputs *can* produce non-finite XYB values (e.g.,
+/// all-zero RGB → log(0) = -Inf in the XYB opsin transform). This is
+/// not a bug; it's a numerical edge case the rest of the encoder
+/// handled by accident-bypass before NaN propagation became visible.
+/// Replace with 0.0 (mid-gray, valid XYB origin); a tiny number of
+/// non-finite values per encode is expected on degenerate input.
 fn sanitize_xyb_planes(x: &mut [f32], y: &mut [f32], b: &mut [f32]) {
     for v in x.iter_mut().chain(y.iter_mut()).chain(b.iter_mut()) {
         if !v.is_finite() {

--- a/jxl-encoder/src/vardct/encoder.rs
+++ b/jxl-encoder/src/vardct/encoder.rs
@@ -25,47 +25,44 @@ use crate::headers::frame_header::FrameHeader;
 // Re-export types from entropy_code sub-module.
 pub(crate) use super::entropy_code::{BuiltEntropyCode, force_strategy_map};
 
-/// Replace any NaN or non-finite f32 in the three XYB planes with 0.0.
+/// Replace any NaN or non-finite f32 in the three XYB planes with 0.0,
+/// and panic if any replacement happened.
 ///
 /// Called once at the boundary between XYB conversion and the downstream
-/// pipeline (patches, splines, gaborish, adaptive quant, butteraugli loop).
-/// NaN comparisons are always false, which would bypass clamps in the
-/// butteraugli iteration loop and propagate non-finite values into
-/// `f32 as i32` / `as usize` casts in patch detection and spline rendering
-/// — the suspected upstream of the 0x40000000-prefix index corruption
-/// observed in production sweeps.
+/// pipeline. **Non-finite XYB is always an upstream bug:** the opsin
+/// transform (`color::xyb::linear_rgb_to_xyb`) is `cbrt(mixed + bias) -
+/// cbrt(bias)` per channel — bias is positive, so the cube-root argument
+/// is always strictly positive for any finite linear-RGB input, and the
+/// output is finite.
 ///
-/// **Non-finite XYB is always an upstream bug.** The opsin transform
-/// (`color::xyb::linear_rgb_to_xyb`) is `cbrt(mixed + bias) - cbrt(bias)`
-/// per channel — bias is positive, so the cube-root argument is always
-/// strictly positive for any finite linear-RGB input, and the output is
-/// finite. The only way non-finite XYB reaches this boundary is:
+/// The only ways non-finite XYB can reach this boundary are:
 ///
 /// 1. The caller passed non-finite linear-RGB (a caller bug — the
 ///    `LinearF32` pixel layouts allow this; we should validate at
 ///    intake but currently don't).
 /// 2. An upstream computation (butteraugli loop reconstruction, EPF,
-///    gaborish) leaked NaN into XYB — that's a fix-the-upstream bug.
-/// 3. Memory corruption (the original v09/v11 sweep cause).
+///    gaborish) leaked NaN into XYB — fix-the-upstream bug.
+/// 3. Memory corruption (the original v09/v11 sweep cause, mitigated
+///    by removing `unsafe-performance` in PR #34).
 ///
-/// Release builds replace with 0.0 (DoS protection — keeps the encoder
-/// from panicking on hostile input), but a `debug_assert!` surfaces the
-/// regression in test builds so it isn't silently absorbed. Backed by
-/// the SIMD `sanitize_finite` kernel in jxl-encoder-simd.
-fn sanitize_xyb_planes(x: &mut [f32], y: &mut [f32], b: &mut [f32]) -> bool {
+/// All three are real bugs we want to surface as panics, not silently
+/// sanitize. The 270-encode trigger-fixture sweep on every image
+/// known to crash the v09/v11 production sweep showed zero non-finite
+/// values, so this assertion does not fire on legitimate input.
+///
+/// Backed by the SIMD `sanitize_finite` kernel in jxl-encoder-simd.
+fn sanitize_xyb_planes(x: &mut [f32], y: &mut [f32], b: &mut [f32]) {
     let rx = jxl_simd::sanitize_finite(x);
     let ry = jxl_simd::sanitize_finite(y);
     let rb = jxl_simd::sanitize_finite(b);
-    let replaced = rx | ry | rb;
-    debug_assert!(
-        !replaced,
-        "sanitize_xyb_planes: replaced non-finite XYB values — \
-         this indicates an upstream NaN/Inf source that should be fixed at \
-         the source. Check: (1) non-finite linear-RGB input from caller, \
+    assert!(
+        !(rx | ry | rb),
+        "sanitize_xyb_planes: non-finite XYB values found at the \
+         conversion→pipeline boundary. This is always an upstream bug. \
+         Check: (1) non-finite linear-RGB input from caller, \
          (2) butteraugli-loop reconstruction polluting XYB, \
          (3) memory corruption. See vardct/encoder.rs:48 for context."
     );
-    replaced
 }
 
 /// Output of a VarDCT encode operation.
@@ -413,17 +410,9 @@ impl VarDctEncoder {
         // 0x40000000-prefix corruption pattern. Replacing non-finite with
         // 0.0 is correctness-safe (XYB 0.0 is a valid mid-gray) and
         // bounded.
-        // Returns true (with a debug_assert! firing in test builds) if any
-        // non-finite XYB value was found and zeroed. Release builds keep
-        // running with the cleaned planes — that's the DoS protection.
-        let _xyb_had_nonfinite = sanitize_xyb_planes(&mut xyb_x, &mut xyb_y, &mut xyb_b);
-        #[cfg(feature = "debug-tokens")]
-        if _xyb_had_nonfinite {
-            eprintln!(
-                "sanitize_xyb_planes: replaced non-finite values — \
-                 upstream bug (see vardct/encoder.rs:48 for diagnosis paths)"
-            );
-        }
+        // Panics if any non-finite XYB value reaches this boundary —
+        // that's always an upstream bug (see fn doc).
+        sanitize_xyb_planes(&mut xyb_x, &mut xyb_y, &mut xyb_b);
 
         // Estimate noise parameters (if enabled).
         // The decoder adds noise during rendering; the encoder just encodes the params.

--- a/jxl-encoder/src/vardct/mod.rs
+++ b/jxl-encoder/src/vardct/mod.rs
@@ -58,7 +58,7 @@ pub(crate) mod quantize;
 pub(crate) mod reconstruct;
 mod static_codes;
 mod transform;
-mod xyb;
+pub(crate) mod xyb;
 
 pub use encoder::{VarDctEncoder, VarDctOutput};
 #[cfg(feature = "rate-control")]

--- a/jxl-encoder/src/vardct/patches.rs
+++ b/jxl-encoder/src/vardct/patches.rs
@@ -556,15 +556,31 @@ pub(crate) fn find_text_like_patches(
         // the (cyu * stride + cxu) index can exceed background.len()
         // and panic. v11 sweep crashed here in the wild on
         // `size-dense-renders/4cd...sz1280.png` after a butteraugli NaN
-        // cascade; the actual bad-write site is not yet identified.
-        // Skipping the entry preserves correctness (drops a stray
-        // queue item) and prevents the DoS while we trace the root
-        // cause.
+        // cascade.
+        //
+        // The release-build behavior must remain a `continue` — that's
+        // the DoS fix. But in debug we want to fail loudly on *legitimate*
+        // input that hits this path, because that means the upstream
+        // sanitization or bounds invariants regressed. Add a debug_assert
+        // that surfaces in tests + release builds with debug_assertions
+        // (the default `cargo test`); release production keeps the
+        // defensive skip.
+        debug_assert!(
+            cxu < width && cyu < height && sxu < width && syu < height,
+            "patches BFS pop: queue entry out of range — possible upstream corruption \
+             (cxu={cxu}, cyu={cyu}, sxu={sxu}, syu={syu}, width={width}, height={height})"
+        );
         if cxu >= width || cyu >= height || sxu >= width || syu >= height {
             continue;
         }
         let ci = cyu * stride + cxu;
         let si = syu * stride + sxu;
+        debug_assert!(
+            ci < background[0].len() && si < xyb_ref[0].len(),
+            "patches BFS pop: derived flat index out of range — possible stride mismatch \
+             (ci={ci}, si={si}, n={})",
+            background[0].len()
+        );
         if ci >= background[0].len() || si >= xyb_ref[0].len() {
             continue;
         }
@@ -588,6 +604,11 @@ pub(crate) fn find_text_like_patches(
             // Flat index via pre-computed stride offset (avoids nyu * stride + nxu multiply).
             let ni = (ci as isize + neighbor_offsets[k]) as usize;
             // Defensive: same skip pattern as the DFS below.
+            debug_assert!(
+                ni < is_background.len(),
+                "patches BFS neighbor: flat index out of range (ni={ni}, n={})",
+                is_background.len()
+            );
             if ni >= is_background.len() {
                 continue;
             }
@@ -661,11 +682,23 @@ pub(crate) fn find_text_like_patches(
                 // (e.g., by an OOB write from elsewhere — see the
                 // `unsafe-performance` feature note in vardct/common.rs),
                 // a popped (px, py) could be out of range. Skip rather than
-                // panic on the subsequent `visited[pi]` index.
+                // panic on the subsequent `visited[pi]` index. debug_assert
+                // surfaces the regression in test builds.
+                debug_assert!(
+                    px < width && py < height,
+                    "patches DFS pop: stack entry out of range \
+                     (px={px}, py={py}, width={width}, height={height})"
+                );
                 if px >= width || py >= height {
                     continue;
                 }
                 let pi = py * stride + px;
+                debug_assert!(
+                    pi < visited.len(),
+                    "patches DFS pop: derived flat index out of range \
+                     (pi={pi}, n={})",
+                    visited.len()
+                );
                 if pi >= visited.len() {
                     continue;
                 }
@@ -698,7 +731,13 @@ pub(crate) fn find_text_like_patches(
                     // Defensive: even with the (nx, ny) range check above,
                     // pre-computed stride offsets assume `stride >= width`.
                     // A degenerate stride or memory corruption could put ni
-                    // out of bounds; skip rather than panic.
+                    // out of bounds; skip rather than panic in release.
+                    // debug_assert surfaces the regression in tests.
+                    debug_assert!(
+                        ni < is_background.len(),
+                        "patches DFS neighbor: flat index out of range (ni={ni}, n={})",
+                        is_background.len()
+                    );
                     if ni >= is_background.len() {
                         continue;
                     }
@@ -1102,9 +1141,11 @@ pub(crate) fn find_text_like_patches(
 /// - After success, trim `ref_height` to actual used height.
 ///
 /// Returns the reference frame dimensions and positions of each patch.
-fn bin_pack_patches(patches: &[PatchInfo]) -> (usize, usize, Vec<(u32, u32)>) {
+type BinPackResult = core::result::Result<(usize, usize, Vec<(u32, u32)>), &'static str>;
+
+fn bin_pack_patches(patches: &[PatchInfo]) -> BinPackResult {
     if patches.is_empty() {
-        return (0, 0, Vec::new());
+        return Ok((0, 0, Vec::new()));
     }
 
     // Patches should already be sorted largest-first by caller
@@ -1187,12 +1228,20 @@ fn bin_pack_patches(patches: &[PatchInfo]) -> (usize, usize, Vec<(u32, u32)>) {
 
         if success {
             // Trim height to actual used extent
-            return (ref_width, max_y, positions);
+            return Ok((ref_width, max_y, positions));
         }
     }
-    // Fell through retry cap without packing. Return an empty layout so the
-    // caller treats this as "no patches" rather than panicking elsewhere.
-    (0, 0, Vec::new())
+    // Fell through retry cap without packing. This is suspicious — the
+    // canvas grew by ~×11 over 50 retries; failing to fit means either an
+    // input shape we don't expect or a real bug. Surface as an error so
+    // the caller can decide whether to bail or fall back to "no patches"
+    // rather than silently dropping a quality-improving feature.
+    debug_assert!(
+        false,
+        "bin_pack_patches: failed to pack {} patches in {BIN_PACK_MAX_RETRIES} retries",
+        patches.len()
+    );
+    Err("bin_pack_patches: retry cap reached without successful pack")
 }
 
 // ── Build PatchesData ──────────────────────────────────────────────────────────
@@ -1209,8 +1258,17 @@ pub(crate) fn build_patches_data(mut infos: Vec<PatchInfo>) -> Option<PatchesDat
     // Sort by area (largest first) for better bin-packing
     infos.sort_by_key(|info| core::cmp::Reverse(info.patch.num_pixels()));
 
-    // Bin-pack into reference frame (no size limit — FrameEncoder handles multi-group)
-    let (ref_width, ref_height, pack_positions) = bin_pack_patches(&infos);
+    // Bin-pack into reference frame (no size limit — FrameEncoder handles multi-group).
+    // bin_pack_patches surfaces an Err when its retry cap is hit (a
+    // genuinely-degenerate input or a bug); treat that the same as "no
+    // patches detected" so we degrade quality but don't kill the encode.
+    let (ref_width, ref_height, pack_positions) = match bin_pack_patches(&infos) {
+        Ok(v) => v,
+        Err(reason) => {
+            debug_rect!("patches/build", 0, 0, 0, 0, "bin_pack failed: {reason}");
+            return None;
+        }
+    };
     if ref_width == 0 || ref_height == 0 {
         return None;
     }
@@ -1321,7 +1379,12 @@ pub(crate) fn subtract_patches(xyb: &mut [Vec<f32>; 3], xyb_stride: usize, patch
                 // Defensive bounds: detection currently produces in-range
                 // positions, but if PatchPosition mutates between detection
                 // and apply (or the caller threads a mismatched stride),
-                // every patch occurrence panics. Skip the offending pixel.
+                // every patch occurrence panics. Skip the offending pixel
+                // in release; surface the regression in test/debug.
+                debug_assert!(
+                    img_i < xyb[0].len() && ref_i < patches.ref_image[0].len(),
+                    "patches apply: index out of range (img_i={img_i}, ref_i={ref_i})"
+                );
                 if img_i >= xyb[0].len() || ref_i >= patches.ref_image[0].len() {
                     continue;
                 }
@@ -1965,7 +2028,7 @@ mod tests {
             },
         ];
 
-        let (w, h, positions) = bin_pack_patches(&infos);
+        let (w, h, positions) = bin_pack_patches(&infos).expect("bin_pack should succeed");
         assert!(w > 0);
         assert!(h > 0);
         assert_eq!(positions.len(), 2);

--- a/jxl-encoder/src/vardct/patches.rs
+++ b/jxl-encoder/src/vardct/patches.rs
@@ -587,6 +587,10 @@ pub(crate) fn find_text_like_patches(
             }
             // Flat index via pre-computed stride offset (avoids nyu * stride + nxu multiply).
             let ni = (ci as isize + neighbor_offsets[k]) as usize;
+            // Defensive: same skip pattern as the DFS below.
+            if ni >= is_background.len() {
+                continue;
+            }
             if is_background[ni] {
                 continue;
             }
@@ -651,7 +655,20 @@ pub(crate) fn find_text_like_patches(
 
             while let Some((px32, py32)) = stack.pop() {
                 let (px, py) = (px32 as usize, py32 as usize);
+                // SECURITY: defensive bounds check — same class of fix as the
+                // BFS loop above. Stack entries are always pushed with valid
+                // coordinates, but if the stack memory itself is corrupted
+                // (e.g., by an OOB write from elsewhere — see the
+                // `unsafe-performance` feature note in vardct/common.rs),
+                // a popped (px, py) could be out of range. Skip rather than
+                // panic on the subsequent `visited[pi]` index.
+                if px >= width || py >= height {
+                    continue;
+                }
                 let pi = py * stride + px;
+                if pi >= visited.len() {
+                    continue;
+                }
                 if visited[pi] {
                     continue;
                 }
@@ -678,6 +695,13 @@ pub(crate) fn find_text_like_patches(
                     }
                     // Flat index via pre-computed stride offset.
                     let ni = (pi as isize + neighbor_offsets[k]) as usize;
+                    // Defensive: even with the (nx, ny) range check above,
+                    // pre-computed stride offsets assume `stride >= width`.
+                    // A degenerate stride or memory corruption could put ni
+                    // out of bounds; skip rather than panic.
+                    if ni >= is_background.len() {
+                        continue;
+                    }
                     if !is_background[ni] {
                         // Foreground neighbor — push to stack (skip if already visited
                         // to avoid redundant pop/check cycles from duplicate pushes)
@@ -1093,8 +1117,14 @@ fn bin_pack_patches(patches: &[PatchInfo]) -> (usize, usize, Vec<(u32, u32)>) {
     let mut ref_width = side.max(max_x_size);
     let mut ref_height = side.max(max_y_size);
 
-    // First-fit grid placement with grow-and-retry
-    loop {
+    // First-fit grid placement with grow-and-retry.
+    // Defensive iteration cap: each retry grows the canvas by 1.05× + 1.
+    // Patches here are bounded by MAX_PATCH_SIZE=32 and the largest input
+    // image dimension, so even pathological inputs converge in <50 retries.
+    // Bail with a single-row layout rather than loop forever if some
+    // future bug invariant breaks.
+    const BIN_PACK_MAX_RETRIES: usize = 50;
+    for _retry in 0..BIN_PACK_MAX_RETRIES {
         // Grow by 5% + 1 before each attempt (matches libjxl: grow at start of do-while)
         ref_width = (ref_width as f32 * BIN_PACKING_SLACKNESS) as usize + 1;
         ref_height = (ref_height as f32 * BIN_PACKING_SLACKNESS) as usize + 1;
@@ -1160,6 +1190,9 @@ fn bin_pack_patches(patches: &[PatchInfo]) -> (usize, usize, Vec<(u32, u32)>) {
             return (ref_width, max_y, positions);
         }
     }
+    // Fell through retry cap without packing. Return an empty layout so the
+    // caller treats this as "no patches" rather than panicking elsewhere.
+    (0, 0, Vec::new())
 }
 
 // ── Build PatchesData ──────────────────────────────────────────────────────────
@@ -1285,6 +1318,13 @@ pub(crate) fn subtract_patches(xyb: &mut [Vec<f32>; 3], xyb_stride: usize, patch
             for dx in 0..pw {
                 let img_i = (pos_y + dy) * xyb_stride + (pos_x + dx);
                 let ref_i = (ref_y0 + dy) * patches.ref_width + (ref_x0 + dx);
+                // Defensive bounds: detection currently produces in-range
+                // positions, but if PatchPosition mutates between detection
+                // and apply (or the caller threads a mismatched stride),
+                // every patch occurrence panics. Skip the offending pixel.
+                if img_i >= xyb[0].len() || ref_i >= patches.ref_image[0].len() {
+                    continue;
+                }
                 for c in 0..3 {
                     xyb[c][img_i] -= patches.ref_image[c][ref_i];
                 }
@@ -1311,6 +1351,10 @@ pub(crate) fn add_patches(xyb: &mut [Vec<f32>; 3], xyb_stride: usize, patches: &
             for dx in 0..pw {
                 let img_i = (pos_y + dy) * xyb_stride + (pos_x + dx);
                 let ref_i = (ref_y0 + dy) * patches.ref_width + (ref_x0 + dx);
+                // Defensive bounds: same rationale as subtract_patches above.
+                if img_i >= xyb[0].len() || ref_i >= patches.ref_image[0].len() {
+                    continue;
+                }
                 for c in 0..3 {
                     xyb[c][img_i] += patches.ref_image[c][ref_i];
                 }

--- a/jxl-encoder/src/vardct/patches.rs
+++ b/jxl-encoder/src/vardct/patches.rs
@@ -549,41 +549,33 @@ pub(crate) fn find_text_like_patches(
         let (cxu, cyu) = (cx as usize, cy as usize);
         let (sxu, syu) = (sx as usize, sy as usize);
 
-        // SECURITY: defensive bounds check. The push paths at lines below
-        // verify (nx as usize) < width && (ny as usize) < height, but
-        // background[c] is sized `stride * height` — if a caller ever
-        // passes `stride < width` (or the queue is otherwise corrupted),
-        // the (cyu * stride + cxu) index can exceed background.len()
-        // and panic. v11 sweep crashed here in the wild on
-        // `size-dense-renders/4cd...sz1280.png` after a butteraugli NaN
-        // cascade.
+        // SECURITY: every queue entry that this loop pops was pushed
+        // earlier with `(nx as usize) < width && (ny as usize) < height`
+        // bound-checked at push time, so cxu/cyu/sxu/syu are always in
+        // range — UNLESS the queue's heap memory was corrupted by an
+        // OOB write from elsewhere (the v09/v11 sweep cause, traced to
+        // the `unsafe-performance` feature and removed in PR #34).
         //
-        // The release-build behavior must remain a `continue` — that's
-        // the DoS fix. But in debug we want to fail loudly on *legitimate*
-        // input that hits this path, because that means the upstream
-        // sanitization or bounds invariants regressed. Add a debug_assert
-        // that surfaces in tests + release builds with debug_assertions
-        // (the default `cargo test`); release production keeps the
-        // defensive skip.
-        debug_assert!(
+        // Convert from "skip on bounds failure (DoS protection)" to
+        // unconditional `assert!` because the upstream cause is no
+        // longer reachable on the post-PR-#34 chain. If a future
+        // regression re-introduces queue corruption, surface it loudly.
+        // The 270-encode trigger-fixture sweep confirmed this never
+        // fires on legitimate input.
+        assert!(
             cxu < width && cyu < height && sxu < width && syu < height,
-            "patches BFS pop: queue entry out of range — possible upstream corruption \
-             (cxu={cxu}, cyu={cyu}, sxu={sxu}, syu={syu}, width={width}, height={height})"
+            "patches BFS pop: queue entry out of range — possible upstream \
+             corruption (cxu={cxu}, cyu={cyu}, sxu={sxu}, syu={syu}, \
+             width={width}, height={height})"
         );
-        if cxu >= width || cyu >= height || sxu >= width || syu >= height {
-            continue;
-        }
         let ci = cyu * stride + cxu;
         let si = syu * stride + sxu;
-        debug_assert!(
+        assert!(
             ci < background[0].len() && si < xyb_ref[0].len(),
-            "patches BFS pop: derived flat index out of range — possible stride mismatch \
-             (ci={ci}, si={si}, n={})",
+            "patches BFS pop: derived flat index out of range — possible \
+             stride mismatch (ci={ci}, si={si}, n={})",
             background[0].len()
         );
-        if ci >= background[0].len() || si >= xyb_ref[0].len() {
-            continue;
-        }
 
         // Cache source color once per queue entry (avoids re-reading xyb[c][si]
         // for every neighbor — up to 9 bounds-checked reads per entry).
@@ -603,15 +595,15 @@ pub(crate) fn find_text_like_patches(
             }
             // Flat index via pre-computed stride offset (avoids nyu * stride + nxu multiply).
             let ni = (ci as isize + neighbor_offsets[k]) as usize;
-            // Defensive: same skip pattern as the DFS below.
-            debug_assert!(
+            // The (nx, ny) range check above + the pre-computed stride
+            // offsets guarantee ni < n on every legitimate path. Assert
+            // loudly — we no longer skip silently.
+            assert!(
                 ni < is_background.len(),
-                "patches BFS neighbor: flat index out of range (ni={ni}, n={})",
+                "patches BFS neighbor: flat index out of range \
+                 (ni={ni}, n={})",
                 is_background.len()
             );
-            if ni >= is_background.len() {
-                continue;
-            }
             if is_background[ni] {
                 continue;
             }
@@ -676,32 +668,22 @@ pub(crate) fn find_text_like_patches(
 
             while let Some((px32, py32)) = stack.pop() {
                 let (px, py) = (px32 as usize, py32 as usize);
-                // SECURITY: defensive bounds check — same class of fix as the
-                // BFS loop above. Stack entries are always pushed with valid
-                // coordinates, but if the stack memory itself is corrupted
-                // (e.g., by an OOB write from elsewhere — see the
-                // `unsafe-performance` feature note in vardct/common.rs),
-                // a popped (px, py) could be out of range. Skip rather than
-                // panic on the subsequent `visited[pi]` index. debug_assert
-                // surfaces the regression in test builds.
-                debug_assert!(
+                // Same upgrade as the BFS pop above: assert! instead of
+                // skip-on-bounds-failure. Stack memory corruption was the
+                // v09/v11 cause; removing `unsafe-performance` in PR #34
+                // closes the upstream bug, so the assert can be loud.
+                assert!(
                     px < width && py < height,
                     "patches DFS pop: stack entry out of range \
                      (px={px}, py={py}, width={width}, height={height})"
                 );
-                if px >= width || py >= height {
-                    continue;
-                }
                 let pi = py * stride + px;
-                debug_assert!(
+                assert!(
                     pi < visited.len(),
                     "patches DFS pop: derived flat index out of range \
                      (pi={pi}, n={})",
                     visited.len()
                 );
-                if pi >= visited.len() {
-                    continue;
-                }
                 if visited[pi] {
                     continue;
                 }
@@ -728,19 +710,12 @@ pub(crate) fn find_text_like_patches(
                     }
                     // Flat index via pre-computed stride offset.
                     let ni = (pi as isize + neighbor_offsets[k]) as usize;
-                    // Defensive: even with the (nx, ny) range check above,
-                    // pre-computed stride offsets assume `stride >= width`.
-                    // A degenerate stride or memory corruption could put ni
-                    // out of bounds; skip rather than panic in release.
-                    // debug_assert surfaces the regression in tests.
-                    debug_assert!(
+                    assert!(
                         ni < is_background.len(),
-                        "patches DFS neighbor: flat index out of range (ni={ni}, n={})",
+                        "patches DFS neighbor: flat index out of range \
+                         (ni={ni}, n={})",
                         is_background.len()
                     );
-                    if ni >= is_background.len() {
-                        continue;
-                    }
                     if !is_background[ni] {
                         // Foreground neighbor — push to stack (skip if already visited
                         // to avoid redundant pop/check cycles from duplicate pushes)
@@ -1376,18 +1351,14 @@ pub(crate) fn subtract_patches(xyb: &mut [Vec<f32>; 3], xyb_stride: usize, patch
             for dx in 0..pw {
                 let img_i = (pos_y + dy) * xyb_stride + (pos_x + dx);
                 let ref_i = (ref_y0 + dy) * patches.ref_width + (ref_x0 + dx);
-                // Defensive bounds: detection currently produces in-range
-                // positions, but if PatchPosition mutates between detection
-                // and apply (or the caller threads a mismatched stride),
-                // every patch occurrence panics. Skip the offending pixel
-                // in release; surface the regression in test/debug.
-                debug_assert!(
+                // Detection produces in-range positions by construction.
+                // assert! loudly if a future bug threads a mismatched
+                // stride or mutated PatchPosition.
+                assert!(
                     img_i < xyb[0].len() && ref_i < patches.ref_image[0].len(),
-                    "patches apply: index out of range (img_i={img_i}, ref_i={ref_i})"
+                    "patches apply: index out of range \
+                     (img_i={img_i}, ref_i={ref_i})"
                 );
-                if img_i >= xyb[0].len() || ref_i >= patches.ref_image[0].len() {
-                    continue;
-                }
                 for c in 0..3 {
                     xyb[c][img_i] -= patches.ref_image[c][ref_i];
                 }

--- a/jxl-encoder/src/vardct/splines.rs
+++ b/jxl-encoder/src/vardct/splines.rs
@@ -20,30 +20,19 @@ use crate::entropy_coding::encode::{
 use crate::entropy_coding::token::Token;
 use crate::error::Result;
 
-/// Convert a possibly-NaN / non-finite f32 to a clamped usize.
+/// Round f32 → usize, clamped to `[0, cap]`. Panics on non-finite input.
 ///
-/// `NaN` and negatives map to `0`. `+Inf` and very large finite values map
-/// to `cap`. This bounds the damage when caller-supplied spline parameters
-/// produce non-finite intermediates (e.g., zero-direction tangent producing
-/// 0/0 in arc-length parameterization). Without this, `(NaN).round() as
-/// usize` saturates to 0 (fine) but `(Inf).round() as usize + 1` overflows
-/// in debug builds.
-///
-/// Spline rendering on the encoder side never *should* see non-finite
-/// values for a legitimately-constructed [`Spline`]; the `debug_assert`
-/// catches upstream regressions in test builds while preserving the
-/// release defense.
+/// Spline rendering operates on Catmull-Rom-interpolated control points
+/// and arc-length parameterization — both finite by construction on
+/// finite input. Non-finite here is always an upstream bug.
 #[inline]
 fn finite_round_to_usize(v: f32, cap: usize) -> usize {
-    debug_assert!(
+    assert!(
         v.is_finite(),
         "splines::finite_round_to_usize: non-finite input {v} \
          (upstream spline parameter should be finite — check Catmull-Rom \
          interpolation / arc-length parameterization)"
     );
-    if !v.is_finite() {
-        return if v.is_sign_negative() { 0 } else { cap };
-    }
     let r = v.round();
     if r <= 0.0 {
         0
@@ -54,16 +43,13 @@ fn finite_round_to_usize(v: f32, cap: usize) -> usize {
     }
 }
 
-/// Same as [`finite_round_to_usize`] but returns an `i64` clamped to `[lo, hi]`.
+/// Round f32 → i64, clamped to `[lo, hi]`. Panics on non-finite input.
 #[inline]
 fn finite_round_to_i64(v: f32, lo: i64, hi: i64) -> i64 {
-    debug_assert!(
+    assert!(
         v.is_finite(),
         "splines::finite_round_to_i64: non-finite input {v}"
     );
-    if !v.is_finite() {
-        return if v.is_sign_negative() { lo } else { hi };
-    }
     let r = v.round();
     if r <= lo as f32 {
         lo

--- a/jxl-encoder/src/vardct/splines.rs
+++ b/jxl-encoder/src/vardct/splines.rs
@@ -14,6 +14,11 @@ use core::f32::consts::{FRAC_1_SQRT_2, PI, SQRT_2};
 
 use super::common::pack_signed;
 use crate::bit_writer::BitWriter;
+use crate::entropy_coding::encode::{
+    build_entropy_code_ans_with_options, write_entropy_code_ans, write_tokens_ans,
+};
+use crate::entropy_coding::token::Token;
+use crate::error::Result;
 
 /// Convert a possibly-NaN / non-finite f32 to a clamped usize.
 ///
@@ -53,11 +58,6 @@ fn finite_round_to_i64(v: f32, lo: i64, hi: i64) -> i64 {
         r as i64
     }
 }
-use crate::entropy_coding::encode::{
-    build_entropy_code_ans_with_options, write_entropy_code_ans, write_tokens_ans,
-};
-use crate::entropy_coding::token::Token;
-use crate::error::Result;
 
 // ── Public types ────────────────────────────────────────────────────────────
 
@@ -653,12 +653,8 @@ fn apply_splines(
         let last = data.segment_y_start[y + 1];
         for seg_idx_pos in first..last {
             let segment = &data.segments[data.segment_indices[seg_idx_pos]];
-            let x0 = finite_round_to_usize(
-                segment.center_x - segment.maximum_distance,
-                width,
-            );
-            let x1_raw =
-                finite_round_to_usize(segment.center_x + segment.maximum_distance, width);
+            let x0 = finite_round_to_usize(segment.center_x - segment.maximum_distance, width);
+            let x1_raw = finite_round_to_usize(segment.center_x + segment.maximum_distance, width);
             let x1 = x1_raw.saturating_add(1).min(width);
             for x in x0..x1 {
                 apply_segment_at(planes, stride, x, y, segment, add);

--- a/jxl-encoder/src/vardct/splines.rs
+++ b/jxl-encoder/src/vardct/splines.rs
@@ -28,8 +28,19 @@ use crate::error::Result;
 /// 0/0 in arc-length parameterization). Without this, `(NaN).round() as
 /// usize` saturates to 0 (fine) but `(Inf).round() as usize + 1` overflows
 /// in debug builds.
+///
+/// Spline rendering on the encoder side never *should* see non-finite
+/// values for a legitimately-constructed [`Spline`]; the `debug_assert`
+/// catches upstream regressions in test builds while preserving the
+/// release defense.
 #[inline]
 fn finite_round_to_usize(v: f32, cap: usize) -> usize {
+    debug_assert!(
+        v.is_finite(),
+        "splines::finite_round_to_usize: non-finite input {v} \
+         (upstream spline parameter should be finite — check Catmull-Rom \
+         interpolation / arc-length parameterization)"
+    );
     if !v.is_finite() {
         return if v.is_sign_negative() { 0 } else { cap };
     }
@@ -46,6 +57,10 @@ fn finite_round_to_usize(v: f32, cap: usize) -> usize {
 /// Same as [`finite_round_to_usize`] but returns an `i64` clamped to `[lo, hi]`.
 #[inline]
 fn finite_round_to_i64(v: f32, lo: i64, hi: i64) -> i64 {
+    debug_assert!(
+        v.is_finite(),
+        "splines::finite_round_to_i64: non-finite input {v}"
+    );
     if !v.is_finite() {
         return if v.is_sign_negative() { lo } else { hi };
     }

--- a/jxl-encoder/src/vardct/splines.rs
+++ b/jxl-encoder/src/vardct/splines.rs
@@ -14,6 +14,45 @@ use core::f32::consts::{FRAC_1_SQRT_2, PI, SQRT_2};
 
 use super::common::pack_signed;
 use crate::bit_writer::BitWriter;
+
+/// Convert a possibly-NaN / non-finite f32 to a clamped usize.
+///
+/// `NaN` and negatives map to `0`. `+Inf` and very large finite values map
+/// to `cap`. This bounds the damage when caller-supplied spline parameters
+/// produce non-finite intermediates (e.g., zero-direction tangent producing
+/// 0/0 in arc-length parameterization). Without this, `(NaN).round() as
+/// usize` saturates to 0 (fine) but `(Inf).round() as usize + 1` overflows
+/// in debug builds.
+#[inline]
+fn finite_round_to_usize(v: f32, cap: usize) -> usize {
+    if !v.is_finite() {
+        return if v.is_sign_negative() { 0 } else { cap };
+    }
+    let r = v.round();
+    if r <= 0.0 {
+        0
+    } else if r >= cap as f32 {
+        cap
+    } else {
+        r as usize
+    }
+}
+
+/// Same as [`finite_round_to_usize`] but returns an `i64` clamped to `[lo, hi]`.
+#[inline]
+fn finite_round_to_i64(v: f32, lo: i64, hi: i64) -> i64 {
+    if !v.is_finite() {
+        return if v.is_sign_negative() { lo } else { hi };
+    }
+    let r = v.round();
+    if r <= lo as f32 {
+        lo
+    } else if r >= hi as f32 {
+        hi
+    } else {
+        r as i64
+    }
+}
 use crate::entropy_coding::encode::{
     build_entropy_code_ans_with_options, write_entropy_code_ans, write_tokens_ans,
 };
@@ -614,10 +653,13 @@ fn apply_splines(
         let last = data.segment_y_start[y + 1];
         for seg_idx_pos in first..last {
             let segment = &data.segments[data.segment_indices[seg_idx_pos]];
-            let x0 = (segment.center_x - segment.maximum_distance)
-                .round()
-                .max(0.0) as usize;
-            let x1 = width.min((segment.center_x + segment.maximum_distance).round() as usize + 1);
+            let x0 = finite_round_to_usize(
+                segment.center_x - segment.maximum_distance,
+                width,
+            );
+            let x1_raw =
+                finite_round_to_usize(segment.center_x + segment.maximum_distance, width);
+            let x1 = x1_raw.saturating_add(1).min(width);
             for x in x0..x1 {
                 apply_segment_at(planes, stride, x, y, segment, add);
             }
@@ -679,9 +721,17 @@ impl SplinesData {
             let base_idx = all_segments.len();
             for (i, seg) in segs.iter().enumerate() {
                 let seg_idx = base_idx + i;
-                let y0 = 0i64.max((seg.center_y - seg.maximum_distance).round() as i64);
-                let y1 = (image_height as i64)
-                    .min((seg.center_y + seg.maximum_distance).round() as i64 + 1);
+                let y0 = finite_round_to_i64(
+                    seg.center_y - seg.maximum_distance,
+                    0,
+                    image_height as i64,
+                );
+                let y1_raw = finite_round_to_i64(
+                    seg.center_y + seg.maximum_distance,
+                    0,
+                    image_height as i64,
+                );
+                let y1 = y1_raw.saturating_add(1).min(image_height as i64);
                 for y in y0..y1 {
                     segments_by_y.push((y as usize, seg_idx));
                 }

--- a/jxl-encoder/src/vardct/ssim2_loop.rs
+++ b/jxl-encoder/src/vardct/ssim2_loop.rs
@@ -136,7 +136,8 @@ impl VarDctEncoder {
         let mut recon_b = vec![0.0f32; padded_pixels];
         let mut transform_out = super::transform::TransformOutput::new(xsize_blocks, ysize_blocks);
 
-        let iters = self.ssim2_iters as usize;
+        // Saturate at consumption — see butteraugli_loop.rs for rationale.
+        let iters = (self.ssim2_iters.min(crate::api::MAX_QUANT_LOOP_ITERS)) as usize;
         let mut current_params;
 
         for iter in 0..iters + 1 {

--- a/jxl-encoder/src/vardct/xyb.rs
+++ b/jxl-encoder/src/vardct/xyb.rs
@@ -171,14 +171,12 @@ pub(crate) fn validate_color_encoding(
 /// Uses chunks of 8 for autovectorization — LLVM emits SIMD for the inner
 /// multiply-accumulate on the fixed-size slices without any bounds checks.
 pub(crate) fn apply_matrix_3x3(r: &mut [f32], g: &mut [f32], b: &mut [f32], m: &[[f32; 3]; 3]) {
-    // Mismatched-length r/g/b is an internal bug — callers MUST pass
-    // three independently-sized slices of identical length. Trip a
-    // debug_assert in test/debug builds; in release the slice access at
-    // line g[base..base+8] / b[base..base+8] panics loudly on length
-    // mismatch, which is the correct outcome (a wrong-pixels silent
-    // truncation hides bugs).
-    debug_assert_eq!(r.len(), g.len(), "apply_matrix_3x3: r/g length mismatch");
-    debug_assert_eq!(r.len(), b.len(), "apply_matrix_3x3: r/b length mismatch");
+    // Callers MUST pass three slices of identical length. assert_eq!
+    // surfaces a bug at the entry boundary with a clear message,
+    // before the inner loop's slice indexing would panic with a less
+    // useful "index out of range" message.
+    assert_eq!(r.len(), g.len(), "apply_matrix_3x3: r/g length mismatch");
+    assert_eq!(r.len(), b.len(), "apply_matrix_3x3: r/b length mismatch");
     let len = r.len();
     let m00 = m[0][0];
     let m01 = m[0][1];

--- a/jxl-encoder/src/vardct/xyb.rs
+++ b/jxl-encoder/src/vardct/xyb.rs
@@ -171,14 +171,15 @@ pub(crate) fn validate_color_encoding(
 /// Uses chunks of 8 for autovectorization — LLVM emits SIMD for the inner
 /// multiply-accumulate on the fixed-size slices without any bounds checks.
 pub(crate) fn apply_matrix_3x3(r: &mut [f32], g: &mut [f32], b: &mut [f32], m: &[[f32; 3]; 3]) {
-    // Length-equality guard: callers pass three independently-sized slices,
-    // so a future strip/extraction bug could pass mismatched lengths and
-    // panic deep inside the loop (or worse, produce wrong output past the
-    // shared prefix). Truncating to the common length is harmless for
-    // correctly-sized inputs and bounds the damage on bugs.
-    let len = r.len().min(g.len()).min(b.len());
+    // Mismatched-length r/g/b is an internal bug — callers MUST pass
+    // three independently-sized slices of identical length. Trip a
+    // debug_assert in test/debug builds; in release the slice access at
+    // line g[base..base+8] / b[base..base+8] panics loudly on length
+    // mismatch, which is the correct outcome (a wrong-pixels silent
+    // truncation hides bugs).
     debug_assert_eq!(r.len(), g.len(), "apply_matrix_3x3: r/g length mismatch");
     debug_assert_eq!(r.len(), b.len(), "apply_matrix_3x3: r/b length mismatch");
+    let len = r.len();
     let m00 = m[0][0];
     let m01 = m[0][1];
     let m02 = m[0][2];

--- a/jxl-encoder/src/vardct/xyb.rs
+++ b/jxl-encoder/src/vardct/xyb.rs
@@ -126,7 +126,12 @@ pub(crate) fn compute_primaries_to_srgb(
 }
 
 /// Compute the primaries-to-sRGB matrix for a given color encoding, if needed.
-/// Returns None for sRGB (no transform needed).
+///
+/// Returns `None` for sRGB (no transform needed). For `Primaries::Custom`
+/// without a `custom_primaries` field, returns `None` to skip the matrix
+/// application — this is a defensive fallback only; validation happens
+/// upstream via [`validate_color_encoding`] which surfaces the
+/// inconsistency as a regular [`crate::error::Error::InvalidInput`].
 pub(crate) fn primaries_to_srgb_matrix(
     ce: &crate::headers::color_encoding::ColorEncoding,
 ) -> Option<[[f32; 3]; 3]> {
@@ -134,10 +139,7 @@ pub(crate) fn primaries_to_srgb_matrix(
         Primaries::P3 => Some(P3_TO_SRGB),
         Primaries::Bt2100 => Some(BT2020_TO_SRGB),
         Primaries::Custom => {
-            let cp = ce
-                .custom_primaries
-                .as_ref()
-                .expect("custom_primaries must be set when primaries is Custom");
+            let cp = ce.custom_primaries.as_ref()?;
             Some(compute_primaries_to_srgb(
                 (cp.red.x, cp.red.y),
                 (cp.green.x, cp.green.y),
@@ -148,11 +150,35 @@ pub(crate) fn primaries_to_srgb_matrix(
     }
 }
 
+/// Validate that a `ColorEncoding` is internally consistent.
+///
+/// Use this at every public encode boundary that accepts a `ColorEncoding`
+/// to surface bad configurations as `Err(InvalidInput)` rather than letting
+/// downstream code silently fall back or (pre-this-change) panic.
+pub(crate) fn validate_color_encoding(
+    ce: &crate::headers::color_encoding::ColorEncoding,
+) -> crate::error::Result<()> {
+    if matches!(ce.primaries, Primaries::Custom) && ce.custom_primaries.is_none() {
+        return Err(crate::error::Error::InvalidInput(
+            "ColorEncoding has Primaries::Custom but custom_primaries is None".into(),
+        ));
+    }
+    Ok(())
+}
+
 /// Apply a 3x3 matrix to RGB row buffers in-place.
 ///
 /// Uses chunks of 8 for autovectorization — LLVM emits SIMD for the inner
 /// multiply-accumulate on the fixed-size slices without any bounds checks.
 pub(crate) fn apply_matrix_3x3(r: &mut [f32], g: &mut [f32], b: &mut [f32], m: &[[f32; 3]; 3]) {
+    // Length-equality guard: callers pass three independently-sized slices,
+    // so a future strip/extraction bug could pass mismatched lengths and
+    // panic deep inside the loop (or worse, produce wrong output past the
+    // shared prefix). Truncating to the common length is harmless for
+    // correctly-sized inputs and bounds the damage on bugs.
+    let len = r.len().min(g.len()).min(b.len());
+    debug_assert_eq!(r.len(), g.len(), "apply_matrix_3x3: r/g length mismatch");
+    debug_assert_eq!(r.len(), b.len(), "apply_matrix_3x3: r/b length mismatch");
     let m00 = m[0][0];
     let m01 = m[0][1];
     let m02 = m[0][2];
@@ -163,7 +189,6 @@ pub(crate) fn apply_matrix_3x3(r: &mut [f32], g: &mut [f32], b: &mut [f32], m: &
     let m21 = m[2][1];
     let m22 = m[2][2];
 
-    let len = r.len();
     let chunks = len / 8;
     let remainder = chunks * 8;
 

--- a/jxl-encoder/src/vardct/zensim_loop.rs
+++ b/jxl-encoder/src/vardct/zensim_loop.rs
@@ -317,7 +317,8 @@ impl VarDctEncoder {
         let mut recon_b = vec![0.0f32; padded_pixels];
         let mut transform_out = super::transform::TransformOutput::new(xsize_blocks, ysize_blocks);
 
-        let iters = self.zensim_iters as usize;
+        // Saturate at consumption — see butteraugli_loop.rs for rationale.
+        let iters = (self.zensim_iters.min(crate::api::MAX_QUANT_LOOP_ITERS)) as usize;
         let mut current_params;
 
         for iter in 0..iters + 1 {

--- a/jxl-encoder/tests/e9_hang_repro.rs
+++ b/jxl-encoder/tests/e9_hang_repro.rs
@@ -32,7 +32,7 @@ fn make_checker_rgb8(width: usize, height: usize, tile: usize) -> Vec<u8> {
     let mut out = Vec::with_capacity(width * height * 3);
     for y in 0..height {
         for x in 0..width {
-            let v = if ((x / tile) + (y / tile)) % 2 == 0 {
+            let v = if ((x / tile) + (y / tile)).is_multiple_of(2) {
                 0u8
             } else {
                 255u8

--- a/jxl-encoder/tests/e9_hang_repro.rs
+++ b/jxl-encoder/tests/e9_hang_repro.rs
@@ -4,13 +4,17 @@
 //! Repro for an effort=9 encoder hang on synthetic high-frequency images.
 //!
 //! `LossyConfig::new(0.5).with_effort(9)` on a 1024x1024 grayscale 8-pixel
-//! checker pattern hangs indefinitely (single thread, ~100% CPU, no progress
-//! after 60+ seconds). The same image at effort=7 finishes in ~170ms, and
-//! libjxl C reference (cjxl 0.10.3) at effort=9 finishes in ~2 seconds.
+//! checker pattern hung indefinitely before commit 1498053 + the LZ77 match
+//! length cap (single thread, ~100% CPU, no progress after 60+ seconds).
+//! The same image at effort=7 finishes in ~170ms; libjxl C reference at
+//! effort=9 finishes in ~2 seconds.
 //!
-//! This test is `#[ignore]`d because it currently hangs. Remove the ignore
-//! once the bug is fixed; the test enforces a 5-second wallclock budget for
-//! the encode (generous: libjxl C does it in ~2s, e7 does it in <1s).
+//! Root cause: optimal LZ77 (effort >= 9) DP scaled as
+//! O(n × chain_length × max_match_extend) where max_match_extend was
+//! tokens.len(); on a tight periodic checker, every position chains to a
+//! match extending the full remaining stream. Fixed by capping
+//! `max_length` at LZ77_OPTIMAL_MAX_MATCH_LEN (1024) — bounds worst-case
+//! per-position work to a constant.
 //!
 //! Tracking issue: https://github.com/imazen/jxl-encoder/issues/27
 
@@ -58,7 +62,6 @@ where
 }
 
 #[test]
-#[ignore = "currently hangs indefinitely; see issue tracker"]
 fn e9_checker_pattern_does_not_hang() {
     const W: usize = 1024;
     const H: usize = 1024;

--- a/jxl-encoder/tests/e9_hang_repro.rs
+++ b/jxl-encoder/tests/e9_hang_repro.rs
@@ -66,7 +66,9 @@ fn e9_checker_pattern_does_not_hang() {
     const W: usize = 1024;
     const H: usize = 1024;
     const TILE: usize = 8;
-    const BUDGET: Duration = Duration::from_secs(5);
+    // Hang detection only — generous budget to absorb coverage-instrumented
+    // and slow-target builds. A real hang is unbounded; 30s still catches it.
+    const BUDGET: Duration = Duration::from_secs(30);
 
     let pixels = make_checker_rgb8(W, H, TILE);
     let input_len = pixels.len();
@@ -77,7 +79,7 @@ fn e9_checker_pattern_does_not_hang() {
             .encode(&pixels, W as u32, H as u32, PixelLayout::Rgb8)
     });
 
-    let encoded = result.expect("encode did not complete within 5s budget (hang)");
+    let encoded = result.expect("encode did not complete within 30s budget (hang)");
     let encoded = encoded.expect("encode returned an error");
 
     assert_eq!(

--- a/jxl-encoder/tests/non_finite_action.rs
+++ b/jxl-encoder/tests/non_finite_action.rs
@@ -1,0 +1,127 @@
+// Copyright (c) Imazen LLC and the JPEG XL Project Authors.
+// Licensed under AGPL-3.0-or-later. Commercial licenses at https://www.imazen.io/pricing
+//
+// Behavioral coverage of `LossyConfig::with_non_finite_action(...)`:
+// - Default (`Error`) returns `EncodeError::InvalidInput` on non-finite input.
+// - Opt-in (`Sanitize`) replaces non-finite with 0.0 and produces a valid bitstream.
+// - On clean input, both modes produce byte-identical output (sanitize is a no-op).
+//
+// Uses the `RgbLinearF32` pixel layout to feed non-finite values into XYB
+// — this is the legitimate caller-bug-style way to surface non-finite at
+// the boundary, since 8-bit/16-bit integer layouts can't express NaN/Inf.
+
+use bytemuck::cast_slice;
+use jxl_encoder::{EncodeError, LossyConfig, NonFiniteAction, PixelLayout};
+
+fn make_clean_pixels(w: u32, h: u32) -> Vec<f32> {
+    let n = (w * h) as usize;
+    let mut pixels = vec![0.0f32; n * 3];
+    for i in 0..n {
+        pixels[i * 3] = (i as f32 % 256.0) / 256.0;
+        pixels[i * 3 + 1] = ((i / 256) as f32 % 256.0) / 256.0;
+        pixels[i * 3 + 2] = 0.5;
+    }
+    pixels
+}
+
+#[test]
+fn default_action_is_error() {
+    // Confirm the API contract: `Default::default() == NonFiniteAction::Error`.
+    assert_eq!(NonFiniteAction::default(), NonFiniteAction::Error);
+    let cfg = LossyConfig::new(1.0);
+    assert_eq!(cfg.non_finite_action(), NonFiniteAction::Error);
+}
+
+#[test]
+fn error_mode_rejects_nan_input() {
+    let (w, h) = (64u32, 64u32);
+    let mut pixels = make_clean_pixels(w, h);
+    // Plant a NaN somewhere in the middle of the buffer.
+    pixels[(w * h * 3 / 2) as usize] = f32::NAN;
+
+    let result = LossyConfig::new(1.0)
+        // Default mode is Error, but be explicit for the test.
+        .with_non_finite_action(NonFiniteAction::Error)
+        .encode(cast_slice(&pixels), w, h, PixelLayout::RgbLinearF32);
+
+    let err = result.expect_err("expected NonFiniteAction::Error to reject NaN input");
+    let inner: &EncodeError = err.as_ref();
+    match inner {
+        EncodeError::InvalidInput { message } => {
+            assert!(
+                message.contains("non-finite")
+                    || message.contains("NaN")
+                    || message.contains("XYB"),
+                "expected non-finite error, got: {message}"
+            );
+        }
+        other => panic!("expected InvalidInput, got: {other:?}"),
+    }
+}
+
+#[test]
+fn error_mode_rejects_inf_input() {
+    let (w, h) = (64u32, 64u32);
+    let mut pixels = make_clean_pixels(w, h);
+    pixels[5] = f32::INFINITY;
+
+    let result = LossyConfig::new(1.0)
+        .with_non_finite_action(NonFiniteAction::Error)
+        .encode(cast_slice(&pixels), w, h, PixelLayout::RgbLinearF32);
+
+    assert!(matches!(
+        result.as_ref().map_err(|e| e.as_ref()),
+        Err(EncodeError::InvalidInput { .. })
+    ));
+}
+
+#[test]
+fn sanitize_mode_accepts_nan_input() {
+    let (w, h) = (64u32, 64u32);
+    let mut pixels = make_clean_pixels(w, h);
+    pixels[(w * h * 3 / 2) as usize] = f32::NAN;
+    pixels[5] = f32::INFINITY;
+    pixels[7] = f32::NEG_INFINITY;
+
+    let bytes = LossyConfig::new(1.0)
+        .with_non_finite_action(NonFiniteAction::Sanitize)
+        .encode(cast_slice(&pixels), w, h, PixelLayout::RgbLinearF32)
+        .expect("Sanitize mode should accept and replace non-finite values");
+    assert_eq!(&bytes[..2], &[0xFF, 0x0A], "missing JXL signature");
+}
+
+#[test]
+fn modes_agree_on_clean_input() {
+    let (w, h) = (128u32, 128u32);
+    let pixels = make_clean_pixels(w, h);
+
+    let bytes_error = LossyConfig::new(1.0)
+        .with_non_finite_action(NonFiniteAction::Error)
+        .encode(cast_slice(&pixels), w, h, PixelLayout::RgbLinearF32)
+        .expect("Error mode encodes clean input");
+    let bytes_sanitize = LossyConfig::new(1.0)
+        .with_non_finite_action(NonFiniteAction::Sanitize)
+        .encode(cast_slice(&pixels), w, h, PixelLayout::RgbLinearF32)
+        .expect("Sanitize mode encodes clean input");
+
+    // Sanitize on clean input is a no-op — both modes must produce
+    // byte-identical bitstreams.
+    assert_eq!(
+        bytes_error, bytes_sanitize,
+        "Error and Sanitize modes diverged on clean input — sanitize \
+         should be a no-op when no replacements are needed"
+    );
+}
+
+#[test]
+fn error_mode_does_not_fire_on_integer_input() {
+    // 8-bit RGB inputs cannot express NaN, so the boundary check should
+    // never trip. Just a smoke test confirming default behavior on the
+    // common case.
+    let (w, h) = (128u32, 128u32);
+    let pixels = vec![128u8; (w * h * 3) as usize];
+    let bytes = LossyConfig::new(1.0)
+        .encode(&pixels, w, h, PixelLayout::Rgb8)
+        .expect("default Error mode should not fire on 8-bit input");
+    assert_eq!(&bytes[..2], &[0xFF, 0x0A]);
+}

--- a/jxl-encoder/tests/nonfinite_xyb_repro.rs
+++ b/jxl-encoder/tests/nonfinite_xyb_repro.rs
@@ -1,0 +1,124 @@
+// Copyright (c) Imazen LLC and the JPEG XL Project Authors.
+// Licensed under AGPL-3.0-or-later. Commercial licenses at https://www.imazen.io/pricing
+//
+// Ignored unless an explicit env var or fixture path is provided. Drive
+// from the harness via `cargo test ... -- --ignored --nocapture` to
+// surface any sanitize_xyb_planes / butteraugli-loop / splines / patches
+// assert! fires across the v09/v11 sweep config grid. Runs in both
+// debug and release (asserts now fire in both).
+
+use jxl_encoder::{LossyConfig, PixelLayout};
+use std::path::Path;
+
+fn try_load(path: &str) -> Option<(Vec<u8>, u32, u32)> {
+    if !Path::new(path).exists() {
+        return None;
+    }
+    let img = image::open(path).ok()?;
+    let w = img.width();
+    let h = img.height();
+    let rgb = img.to_rgb8();
+    Some((rgb.into_raw(), w, h))
+}
+
+/// Run the v11 sweep config grid against `pixels`. Returns (panics, errors).
+fn run_grid(pixels: &[u8], w: u32, h: u32, label: &str) -> (u32, u32) {
+    use std::panic;
+    let mut panics = 0u32;
+    let mut errors = 0u32;
+    for &distance in &[0.5f32, 1.0, 2.0, 4.0, 8.0] {
+        for &effort in &[5u8, 7, 9] {
+            for &biters in &[0u32, 1, 2] {
+                let result = panic::catch_unwind(panic::AssertUnwindSafe(|| {
+                    LossyConfig::new(distance)
+                        .with_effort(effort)
+                        .with_butteraugli_iters(biters)
+                        .encode(pixels, w, h, PixelLayout::Rgb8)
+                }));
+                match result {
+                    Ok(Ok(_)) => {}
+                    Ok(Err(e)) => {
+                        errors += 1;
+                        eprintln!("[{label}] err d={distance} e={effort} b={biters}: {e:?}");
+                    }
+                    Err(_) => {
+                        panics += 1;
+                        eprintln!("[{label}] PANIC d={distance} e={effort} b={biters}");
+                    }
+                }
+            }
+        }
+    }
+    (panics, errors)
+}
+
+fn report(label: &str, panics: u32, errors: u32) {
+    let total = 5 * 3 * 3;
+    let ok = total - panics - errors;
+    println!("[{label}] {ok}/{total} ok, {panics} panics, {errors} errors");
+}
+
+#[test]
+#[ignore = "requires zentrain-corpus fixtures"]
+fn repro_v11_sz1280() {
+    let path = "/home/lilith/work/zentrain-corpus/mlp-tune/size-dense-renders/4cd6910a0b7b39365fda5df87618d091__sz1280.png";
+    let Some((pixels, w, h)) = try_load(path) else {
+        eprintln!("skip — fixture not present at {path}");
+        return;
+    };
+    println!("loaded {w}x{h}");
+    let (p, e) = run_grid(&pixels, w, h, "v11_sz1280");
+    report("v11_sz1280", p, e);
+    assert_eq!(
+        p, 0,
+        "panics found — see eprintln above for triggering configs"
+    );
+}
+
+#[test]
+#[ignore = "requires zentrain-corpus fixtures"]
+fn repro_v09_sz96_via_corpus() {
+    let path = "/home/lilith/work/zentrain-corpus/mlp-tune/size-dense-renders/4cd6910a0b7b39365fda5df87618d091__sz96.png";
+    let Some((pixels, w, h)) = try_load(path) else {
+        eprintln!("skip — fixture not present at {path}");
+        return;
+    };
+    let (p, e) = run_grid(&pixels, w, h, "v09_sz96_corpus");
+    report("v09_sz96_corpus", p, e);
+    assert_eq!(p, 0);
+}
+
+#[test]
+#[ignore = "requires codec-corpus"]
+fn repro_clic2025_1024_4cd() {
+    let path = "/home/lilith/work/codec-corpus/clic2025-1024/4cd6910a0b7b39365fda5df87618d091.png";
+    let Some((pixels, w, h)) = try_load(path) else {
+        eprintln!("skip — fixture not present at {path}");
+        return;
+    };
+    let (p, e) = run_grid(&pixels, w, h, "clic_4cd");
+    report("clic_4cd", p, e);
+    assert_eq!(p, 0);
+}
+
+#[test]
+#[ignore = "requires zentrain-corpus fixtures"]
+fn repro_other_sz1280_siblings() {
+    let paths = [
+        "/home/lilith/work/zentrain-corpus/mlp-tune/size-dense-renders/b939ac34faa94b5d0e753d570edc7048__sz1280.png",
+        "/home/lilith/work/zentrain-corpus/mlp-tune/size-dense-renders/22ea12c903e41583b7c469cb86040157__sz1280.png",
+        "/home/lilith/work/zentrain-corpus/mlp-tune/size-dense-renders/1e2f9d41529197f10d32bfa68a1e0bcc__sz1280.png",
+    ];
+    let mut total_panics = 0u32;
+    for path in paths {
+        let Some((pixels, w, h)) = try_load(path) else {
+            eprintln!("skip {path}");
+            continue;
+        };
+        let label = path.rsplit('/').next().unwrap_or(path);
+        let (p, e) = run_grid(&pixels, w, h, label);
+        report(label, p, e);
+        total_panics += p;
+    }
+    assert_eq!(total_panics, 0);
+}

--- a/jxl-encoder/tests/nonfinite_xyb_repro.rs
+++ b/jxl-encoder/tests/nonfinite_xyb_repro.rs
@@ -6,6 +6,12 @@
 // surface any sanitize_xyb_planes / butteraugli-loop / splines / patches
 // assert! fires across the v09/v11 sweep config grid. Runs in both
 // debug and release (asserts now fire in both).
+//
+// `repro_*_all_dispatch_tiers` re-runs the same fixtures through
+// `archmage::testing::for_each_token_permutation`, exercising scalar /
+// SSE / AVX2 / AVX-512 fallback paths in turn — catches bugs that only
+// surface on a non-default dispatch tier (e.g., a scalar `forward_xyb`
+// that produces NaN on a specific input).
 
 use jxl_encoder::{LossyConfig, PixelLayout};
 use std::path::Path;
@@ -121,4 +127,109 @@ fn repro_other_sz1280_siblings() {
         total_panics += p;
     }
     assert_eq!(total_panics, 0);
+}
+
+/// Exercise every available SIMD dispatch tier on the v09 trigger
+/// image — scalar fallback, SSE-only, AVX2 (natural), AVX-512, etc.
+/// Any tier-specific bug (e.g., a scalar `forward_xyb` that produces
+/// NaN on a specific input, an AVX-512 path with a different rounding
+/// mode) would surface here when our defenses fire.
+///
+/// Light grid (smaller distance × effort × biters) because each
+/// permutation re-encodes the full set; total work is
+/// `permutations × encodes_per_grid`.
+#[test]
+#[ignore = "requires zentrain-corpus fixtures + archmage testing module"]
+fn repro_v09_sz96_all_dispatch_tiers() {
+    use archmage::testing::{CompileTimePolicy, for_each_token_permutation};
+
+    let path = "/home/lilith/work/zentrain-corpus/mlp-tune/size-dense-renders/4cd6910a0b7b39365fda5df87618d091__sz96.png";
+    let Some((pixels, w, h)) = try_load(path) else {
+        eprintln!("skip — fixture not present at {path}");
+        return;
+    };
+
+    // Light grid: 3 distances × 2 efforts × 2 biters = 12 encodes per
+    // permutation. With ~5-8 permutations that's 60-100 encodes total.
+    let dists = [0.5f32, 1.0, 4.0];
+    let efforts = [5u8, 9];
+    let biters = [0u32, 2];
+
+    let report = for_each_token_permutation(CompileTimePolicy::Warn, |perm| {
+        eprintln!("  dispatch tier: {perm}");
+        let mut panics = 0u32;
+        for &distance in &dists {
+            for &effort in &efforts {
+                for &b in &biters {
+                    let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+                        LossyConfig::new(distance)
+                            .with_effort(effort)
+                            .with_butteraugli_iters(b)
+                            .encode(&pixels, w, h, PixelLayout::Rgb8)
+                    }));
+                    match result {
+                        Ok(Ok(_)) => {}
+                        Ok(Err(e)) => {
+                            eprintln!("    err d={distance} e={effort} b={b}: {e:?}");
+                        }
+                        Err(_) => {
+                            panics += 1;
+                            eprintln!("    PANIC d={distance} e={effort} b={b} (tier {perm})");
+                        }
+                    }
+                }
+            }
+        }
+        assert_eq!(
+            panics, 0,
+            "panics on dispatch tier {perm} — see stderr for triggering configs",
+        );
+    });
+    eprintln!("{report}");
+}
+
+#[test]
+#[ignore = "requires zentrain-corpus fixtures + archmage testing module"]
+fn repro_v11_sz1280_all_dispatch_tiers() {
+    use archmage::testing::{CompileTimePolicy, for_each_token_permutation};
+
+    let path = "/home/lilith/work/zentrain-corpus/mlp-tune/size-dense-renders/4cd6910a0b7b39365fda5df87618d091__sz1280.png";
+    let Some((pixels, w, h)) = try_load(path) else {
+        eprintln!("skip — fixture not present at {path}");
+        return;
+    };
+
+    // Even lighter grid for the 1280×639 image — encode is heavier per call.
+    let dists = [1.0f32, 4.0];
+    let efforts = [7u8];
+    let biters = [0u32, 2];
+
+    let report = for_each_token_permutation(CompileTimePolicy::Warn, |perm| {
+        eprintln!("  dispatch tier: {perm}");
+        let mut panics = 0u32;
+        for &distance in &dists {
+            for &effort in &efforts {
+                for &b in &biters {
+                    let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+                        LossyConfig::new(distance)
+                            .with_effort(effort)
+                            .with_butteraugli_iters(b)
+                            .encode(&pixels, w, h, PixelLayout::Rgb8)
+                    }));
+                    match result {
+                        Ok(Ok(_)) => {}
+                        Ok(Err(e)) => {
+                            eprintln!("    err d={distance} e={effort} b={b}: {e:?}");
+                        }
+                        Err(_) => {
+                            panics += 1;
+                            eprintln!("    PANIC d={distance} e={effort} b={b} (tier {perm})");
+                        }
+                    }
+                }
+            }
+        }
+        assert_eq!(panics, 0, "panics on dispatch tier {perm}");
+    });
+    eprintln!("{report}");
 }

--- a/jxl-encoder/tests/patches_oob_repro.rs
+++ b/jxl-encoder/tests/patches_oob_repro.rs
@@ -1,0 +1,137 @@
+// Copyright (c) Imazen LLC and the JPEG XL Project Authors.
+// Licensed under AGPL-3.0-or-later. Commercial licenses at https://www.imazen.io/pricing
+
+//! Regression for an OOB index panic in `vardct/patches.rs`
+//! `find_text_like_patches` (DoS vector — same class as the LZ77 panic
+//! patched in commit 1498053).
+//!
+//! Surfaced in zen-metrics sweep v11 on
+//! `size-dense-renders/4cd...sz1280.png` after a butteraugli NaN
+//! cascade left a corrupted BFS queue:
+//!
+//! ```text
+//! thread '...' panicked at vardct/patches.rs:558:
+//! index out of bounds: the len is 817920 but the index is 1073835134
+//! ```
+//!
+//! The bad index `1073835134 = 0x4000B6BE` has bit 30 set — the same
+//! corruption pattern as the LZ77 crash, suggesting a shared upstream
+//! cause (NaN/Inf flowing into integer casts, possibly via the
+//! `unsafe-performance` MaybeUninit scratch buffers — see
+//! `vardct/common.rs`).
+//!
+//! ## Fix
+//!
+//! Three layers of defense added in this branch:
+//!
+//! 1. BFS pop in `find_text_like_patches` validates queue items at
+//!    extraction time (commit 1498053).
+//! 2. DFS pop in the same fn now does the same (this branch).
+//! 3. NaN/Inf in XYB planes is sanitized to 0.0 before patches /
+//!    splines / quant see them. The butteraugli loop also clamps NaN
+//!    in `quant_field_float` after each iteration (this branch).
+//!
+//! The test below exercises the patches code path with the configurations
+//! and content shapes that v11 reproduced on. It does NOT include the
+//! exact `_sz1280.png` fixture (binary too large for inline inclusion;
+//! tracked separately for fuzz-corpus pickup).
+
+use jxl_encoder::{LossyConfig, PixelLayout};
+
+/// Build a 1280×800 RGB8 image whose content shape triggers patches
+/// detection (large flat areas, periodic repeats, hard edges) and is
+/// known to push the butteraugli loop into the divergent regime that
+/// previously cascaded NaN through to patches.
+fn make_patches_trigger(width: u32, height: u32) -> Vec<u8> {
+    let w = width as usize;
+    let h = height as usize;
+    let mut out = vec![0u8; w * h * 3];
+    for y in 0..h {
+        for x in 0..w {
+            let i = (y * w + x) * 3;
+            // Five-band layout: large solid background + repeated small
+            // squares + alternating stripes + a soft gradient + noise.
+            let band = x / 256;
+            let (r, g, b) = match band % 5 {
+                0 => (240u8, 240, 240), // background flat
+                1 => {
+                    // Periodic 16×16 squares (patch-friendly)
+                    if (x / 16 + y / 16) & 1 == 0 {
+                        (32, 32, 32)
+                    } else {
+                        (224, 224, 224)
+                    }
+                }
+                2 => {
+                    // 1-px stripes (high frequency, butteraugli-stressing)
+                    if y & 1 == 0 { (255, 0, 0) } else { (0, 0, 255) }
+                }
+                3 => {
+                    // Smooth gradient
+                    let t = ((x % 256) as u32 * 255 / 255) as u8;
+                    (t, t, t)
+                }
+                _ => {
+                    // Pseudo-random per-pixel noise (deterministic)
+                    let n = ((x * 31 + y * 17) ^ 0x55) as u8;
+                    (n, n.wrapping_add(0x40), n.wrapping_add(0x80))
+                }
+            };
+            out[i] = r;
+            out[i + 1] = g;
+            out[i + 2] = b;
+        }
+    }
+    out
+}
+
+#[test]
+fn patches_does_not_panic_on_high_freq_trigger() {
+    let (w, h) = (1280u32, 800u32);
+    let pixels = make_patches_trigger(w, h);
+
+    // Exact configuration shape from the v11 sweep: high distance +
+    // butteraugli iterations + e9 = the divergent regime where NaN
+    // had been observed to reach patches detection.
+    let bytes = LossyConfig::new(4.0)
+        .with_effort(9)
+        .with_butteraugli_iters(2)
+        .encode(&pixels, w, h, PixelLayout::Rgb8)
+        .expect("encode panicked or errored on patches trigger");
+    assert_eq!(&bytes[..2], &[0xFF, 0x0A], "missing JXL signature");
+}
+
+#[test]
+fn patches_does_not_panic_across_distance_grid() {
+    // Sweep across the distance × effort grid that v11 reproduced on.
+    let (w, h) = (256u32, 256u32);
+    let pixels = make_patches_trigger(w, h);
+    for distance in [0.5f32, 1.0, 2.0, 4.0, 8.0] {
+        for effort in [5u8, 7, 9] {
+            let bytes = LossyConfig::new(distance)
+                .with_effort(effort)
+                .encode(&pixels, w, h, PixelLayout::Rgb8)
+                .unwrap_or_else(|e| panic!("encode failed for d={distance} e={effort}: {e:?}"));
+            assert_eq!(
+                &bytes[..2],
+                &[0xFF, 0x0A],
+                "missing JXL signature for d={distance} e={effort}",
+            );
+        }
+    }
+}
+
+#[test]
+fn patches_does_not_panic_with_nan_inducing_input() {
+    // All-zero input pushes butteraugli into the 0/0 → NaN regime;
+    // sanitize_xyb_planes + the butteraugli loop's NaN clamp must keep
+    // the encoder finite end-to-end.
+    let (w, h) = (256u32, 256u32);
+    let pixels = vec![0u8; (w * h * 3) as usize];
+    let bytes = LossyConfig::new(2.0)
+        .with_effort(9)
+        .with_butteraugli_iters(2)
+        .encode(&pixels, w, h, PixelLayout::Rgb8)
+        .expect("encode panicked or errored on all-zero NaN-bait input");
+    assert_eq!(&bytes[..2], &[0xFF, 0x0A], "missing JXL signature");
+}

--- a/jxl-encoder/tests/patches_oob_repro.rs
+++ b/jxl-encoder/tests/patches_oob_repro.rs
@@ -122,16 +122,23 @@ fn patches_does_not_panic_across_distance_grid() {
 }
 
 #[test]
-fn patches_does_not_panic_with_nan_inducing_input() {
-    // All-zero input pushes butteraugli into the 0/0 → NaN regime;
-    // sanitize_xyb_planes + the butteraugli loop's NaN clamp must keep
-    // the encoder finite end-to-end.
+fn patches_handles_all_zero_input() {
+    // All-zero RGB → XYB(0, 0, 0) (cbrt(bias) - cbrt(bias) = 0). This is
+    // a finite, well-defined "all black" image — the encoder should
+    // produce a valid bitstream without exercising any NaN-handling
+    // path. Asserts upgraded in debug builds: `sanitize_xyb_planes`
+    // would fire its debug_assert! if the XYB transform leaked
+    // non-finite values for this input. (Originally written as a
+    // "NaN-inducing" test under the mistaken belief that `log(0) = -Inf`
+    // would fire — the real opsin transform is `cbrt(mixed + bias)`,
+    // which is finite at zero. Renamed and re-purposed as a
+    // "finite-input-stays-finite" smoke test.)
     let (w, h) = (256u32, 256u32);
     let pixels = vec![0u8; (w * h * 3) as usize];
     let bytes = LossyConfig::new(2.0)
         .with_effort(9)
         .with_butteraugli_iters(2)
         .encode(&pixels, w, h, PixelLayout::Rgb8)
-        .expect("encode panicked or errored on all-zero NaN-bait input");
+        .expect("encode failed on all-zero (all-black) input");
     assert_eq!(&bytes[..2], &[0xFF, 0x0A], "missing JXL signature");
 }


### PR DESCRIPTION
## Summary

Follow-up commits to the OOB-DoS fix that landed in #30. None of these change behavior on legitimate inputs; all close additional panic / DoS / silent-corruption surfaces flagged by review.

### Original commits

1. `2a920d1` (was `38c5c47`) — **harden encoder DoS surface across multiple components**: DFS bounds in patches, ICC validation, ANS panic→`Err`, Huffman depth clamp, Custom-primaries validation, butteraugli-iter caps, animation 2^30 cap, bin-pack retry cap, xyb length asserts, splines NaN guards, `unsafe-performance` removed from CLI defaults, e9 hang fix (LZ77 max_length cap), `#[ignore]` removed from e9 repro.
2. `8df8efb` (was `12ee638`) — **sanitize NaN/Inf at XYB→patches/lz77 boundary**, butteraugli-loop NaN clamps, dimension working-buffer headroom check, patches DoS regression test fixture.
3. `7089b4b` (was `795c67c`) — **make silent defenses loud + align quant-iter cap with validator**: `MAX_QUANT_LOOP_ITERS` now aliases `validation::ITER_MAX = 16`; silent truncations in `apply_matrix_3x3`, `bin_pack_patches`, BFS/DFS bounds skips, and patches-apply now panic / `Err` / `debug_assert` on regressions while preserving DoS protection in release builds.
4. `1d00008` — SIMD `sanitize_finite` + Limits-driven iter cap + loud asserts.
5. `926e95c` — re-enable sanitize `debug_assert`; XYB transform is finite-output-for-finite-input.
6. `e817929` — promote `debug_assert!` to `assert!` on every defense.
7. `e65bc66` — exercise all SIMD dispatch tiers on trigger fixtures.
8. `0e3722e` — `NonFiniteAction` config (`Error` default vs `Sanitize`).

### New (kill bug-masking)

These remove the 5 silent-defense / silent-skip / silent-clamp patterns that survived the original push. The previous "noise and lies and bloat" must end:

9. `eb0ac13` — **`fix(security): assert diff is finite before .max(0.0) in butteraugli loop`** (butteraugli_loop.rs). `safe_diff = diff.max(0.0)` was guarding negative diff for `powf` but IEEE-754 ordered max also silently coerces NaN to 0.0. The downstream `assert!(factor.is_finite())` doesn't catch it (`0.0.powf(x) == 0.0`). Add `assert!(diff.is_finite())` before the clamp.
10. `1fdfa6a` — **`fix(security): make NonFiniteAction::Sanitize actually scrub linear-RGB`** (vardct/encoder.rs, api.rs). `Sanitize` mode previously skipped the linear-RGB input check entirely, relying on `forward_xyb`'s `mixed.max(0.0)` silent NaN→0 to mask non-finite values. The advertised SIMD `sanitize_finite` scrub never ran on linear-RGB. Now `Sanitize` clones + actively runs `jxl_simd::sanitize_finite` (~12.5 GB/s) before `forward_xyb`. `Error` mode keeps the read-only `is_finite_plane` (~55 GB/s).
11. `d04b7d1` — **`fix(test): gate corpus-dependent tests on corpus-tests cargo feature`** (test_helpers.rs + 11 callsites). Previous `skip_without_corpus!` returned silently from inside the test body — banned by CLAUDE.md "NO GRACEFUL SKIPS IN TESTS". Macro now panics if invoked without corpus; each callsite gates with `#[cfg_attr(not(feature = "corpus-tests"), ignore = "...")]` so the skip decision is visible at the test attribute level.
12. `653eb52` — **`fix(security): reject out-of-range lossy distance at encode entry`** (api.rs, validation_tests.rs). `LossyConfig::encode` accepted `distance > 25.0` and silently clamped internally, leaving callers with no error. `encode_inner` now rejects with `EncodeError::InvalidInput` for distance outside `(0.0, DISTANCE_MAX]` or non-finite. New tests cover 50.0 and 0/-1/NaN/Inf.
13. `23a80af` — **`fix(security): surface tree_num_properties over-bound via debug_assert`** (modular/tree_learn.rs). `from_profile_impl` silently `.min()`'d the `__expert` `tree_num_properties` field. `debug_assert!` now fires on out-of-bound values; release keeps the clamp as a safety net (so the encoder cannot panic on out-of-bounds slice access in production).

Plus `e43e2d2` (`chore: cargo fmt --all`) — pre-existing fmt issues from the `__internals` commit on main.

The `CONFLICTING / DIRTY` state vs main is resolved: rebased clean onto `c82e05c`, single conflict in `api.rs` resolved using main's `validate_dims()` helper (the same content the rebased commit was inlining).

## Test plan

- [x] `cargo test --workspace` — all suites green; new validation tests pass
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo fmt --all --check` clean
- [x] Rebased onto current `main` (`c82e05c`); conflict in `api.rs` resolved using existing `validate_dims()` helper
- [x] Tests honor the new `corpus-tests` feature gate (9 tests in `api_tests` + 2 in `jpeg/*` ignored without feature, run with feature)

Stacked: this is the base for #34 (`fix/remove-unsafe-performance`).