### PR TITLE
fix: validate streaming pixel dims and harden tree_learn / SOS parser

### DIFF
--- a/jxl-encoder/src/api.rs
+++ b/jxl-encoder/src/api.rs
@@ -1679,23 +1679,9 @@ impl<'a> EncodeRequest<'a> {
     }
 
     fn validate_pixels(&self, pixels: &[u8]) -> core::result::Result<(), EncodeError> {
+        validate_dims(self.width, self.height)?;
         let w = self.width as usize;
         let h = self.height as usize;
-        if w == 0 || h == 0 {
-            return Err(EncodeError::InvalidInput {
-                message: format!("zero dimensions: {w}x{h}"),
-            });
-        }
-        // JXL spec limits each dimension to 2^30.
-        const MAX_JXL_DIM: u32 = 1 << 30;
-        if self.width > MAX_JXL_DIM || self.height > MAX_JXL_DIM {
-            return Err(EncodeError::LimitExceeded {
-                message: format!(
-                    "image {}x{} exceeds JXL spec maximum of {MAX_JXL_DIM} per dimension",
-                    self.width, self.height
-                ),
-            });
-        }
         let expected = w
             .checked_mul(h)
             .and_then(|n| n.checked_mul(self.layout.bytes_per_pixel()));
@@ -2612,6 +2598,56 @@ impl LossyEncoder {
     }
 }
 
+/// JXL spec maximum dimension (2^30) per axis.
+///
+/// Both width and height must be `<= MAX_JXL_DIM`. This is enforced on every
+/// encode entry point (one-shot, streaming, animation) so that the file header
+/// `write_size_u2s` (30-bit field) cannot silently truncate caller-supplied
+/// dimensions and produce a bitstream whose declared dimensions disagree with
+/// the encoded data.
+const MAX_JXL_DIM: u32 = 1 << 30;
+
+/// Internal scale headroom factor used by working-buffer overflow checks
+/// (matches the one-shot `validate_pixels` 16x factor).
+const MAX_INTERNAL_SCALE: usize = 16;
+
+/// Validate `(width, height)` against the JXL spec ceiling and `usize`
+/// working-buffer overflow.
+///
+/// Shared by `validate_pixels` (one-shot), `LossyConfig::encoder` /
+/// `LosslessConfig::encoder` (streaming), and `validate_animation_input`.
+/// Without this check the streaming entry points silently accepted
+/// `width = u32::MAX`, which `write_size_u2s` would then truncate to 30 bits,
+/// emitting a header whose declared width does not match the encoded data.
+fn validate_dims(width: u32, height: u32) -> core::result::Result<(), EncodeError> {
+    if width == 0 || height == 0 {
+        return Err(EncodeError::InvalidInput {
+            message: format!("zero dimensions: {width}x{height}"),
+        });
+    }
+    if width > MAX_JXL_DIM || height > MAX_JXL_DIM {
+        return Err(EncodeError::LimitExceeded {
+            message: format!(
+                "image {width}x{height} exceeds JXL spec maximum of {MAX_JXL_DIM} per dimension",
+            ),
+        });
+    }
+    let w = width as usize;
+    let h = height as usize;
+    if w
+        .checked_mul(h)
+        .and_then(|n| n.checked_mul(MAX_INTERNAL_SCALE))
+        .is_none()
+    {
+        return Err(EncodeError::LimitExceeded {
+            message: format!(
+                "image dimensions {width}x{height} overflow internal working-buffer sizing",
+            ),
+        });
+    }
+    Ok(())
+}
+
 impl LossyConfig {
     /// Create a streaming encoder for incremental row input.
     ///
@@ -2620,11 +2656,7 @@ impl LossyConfig {
     /// incrementally rather than materializing the entire image.
     #[track_caller]
     pub fn encoder(&self, width: u32, height: u32, layout: PixelLayout) -> Result<LossyEncoder> {
-        if width == 0 || height == 0 {
-            return Err(at(EncodeError::InvalidInput {
-                message: format!("zero dimensions: {width}x{height}"),
-            }));
-        }
+        validate_dims(width, height).map_err(at)?;
         let w = width as usize;
         let h = height as usize;
         let rgb_capacity = w.checked_mul(h).and_then(|n| n.checked_mul(3));
@@ -3149,11 +3181,7 @@ impl LosslessConfig {
     pub fn encoder(&self, width: u32, height: u32, layout: PixelLayout) -> Result<LosslessEncoder> {
         use crate::modular::channel::Channel;
 
-        if width == 0 || height == 0 {
-            return Err(at(EncodeError::InvalidInput {
-                message: format!("zero dimensions: {width}x{height}"),
-            }));
-        }
+        validate_dims(width, height).map_err(at)?;
 
         let w = width as usize;
         let h = height as usize;
@@ -3234,11 +3262,7 @@ fn validate_animation_input(
     layout: PixelLayout,
     frames: &[AnimationFrame<'_>],
 ) -> core::result::Result<(), EncodeError> {
-    if width == 0 || height == 0 {
-        return Err(EncodeError::InvalidInput {
-            message: format!("zero dimensions: {width}x{height}"),
-        });
-    }
+    validate_dims(width, height)?;
     if frames.is_empty() {
         return Err(EncodeError::InvalidInput {
             message: "animation requires at least one frame".into(),

--- a/jxl-encoder/src/api.rs
+++ b/jxl-encoder/src/api.rs
@@ -2634,8 +2634,7 @@ fn validate_dims(width: u32, height: u32) -> core::result::Result<(), EncodeErro
     }
     let w = width as usize;
     let h = height as usize;
-    if w
-        .checked_mul(h)
+    if w.checked_mul(h)
         .and_then(|n| n.checked_mul(MAX_INTERNAL_SCALE))
         .is_none()
     {

--- a/jxl-encoder/src/jpeg/parse.rs
+++ b/jxl-encoder/src/jpeg/parse.rs
@@ -398,7 +398,27 @@ fn parse_sos_header(data: &[u8], pos: &mut usize, jpeg: &mut JpegData) -> Result
         return Err(JpegError::Invalid("SOS truncated".into()));
     }
 
+    // The SOS marker payload (after the 2-byte length) must contain:
+    //   1 byte  Ns
+    //   2*Ns    component selectors
+    //   3 bytes Ss, Se, Ah|Al
+    // Validate `len` against this layout BEFORE indexing into `data` so a
+    // crafted truncated SOS marker (e.g. `len = 0`) does not panic via
+    // out-of-bounds indexing. Security audit 2026-05-06 H4.
+    if len < 3 {
+        return Err(JpegError::Invalid("SOS marker too short for Ns".into()));
+    }
     let ns = data[p + 2] as u32;
+    let required = 3usize
+        .checked_add((ns as usize).saturating_mul(2))
+        .and_then(|n| n.checked_add(3))
+        .ok_or_else(|| JpegError::Invalid("SOS Ns overflow".into()))?;
+    if len < required {
+        return Err(JpegError::Invalid(format!(
+            "SOS marker length {len} too short for Ns={ns} (need {required})"
+        )));
+    }
+
     let mut comp_indices = Vec::with_capacity(ns as usize);
     let mut dc_idx = Vec::with_capacity(ns as usize);
     let mut ac_idx = Vec::with_capacity(ns as usize);
@@ -560,6 +580,69 @@ mod tests {
             let back = JPEG_ZIGZAG_ORDER[natural];
             assert_eq!(i, back, "zigzag roundtrip failed at {i}");
         }
+    }
+
+    /// Security audit 2026-05-06 H4 regression: a truncated SOS marker with
+    /// `len < 6 + 2*Ns` previously panicked with index-out-of-bounds when
+    /// `parse_sos_header` indexed `data[spec_base..spec_base + 3]` past the
+    /// declared marker length. Reachable from the public `read_jpeg` API.
+    #[test]
+    fn read_jpeg_rejects_truncated_sos_marker_with_zero_length() {
+        // SOI + minimal SOF0 (so component table has entries) + truncated SOS
+        // marker with len = 0 declared after the FFDA marker bytes.
+        let mut data = Vec::new();
+        // SOI
+        data.extend_from_slice(&[0xFF, 0xD8]);
+        // SOF0: marker FFC0, len 17, P=8, Y=8, X=8, Nf=3, then 3*3 component bytes
+        data.extend_from_slice(&[0xFF, 0xC0]);
+        data.extend_from_slice(&17u16.to_be_bytes());
+        data.push(8); // precision
+        data.extend_from_slice(&8u16.to_be_bytes()); // height
+        data.extend_from_slice(&8u16.to_be_bytes()); // width
+        data.push(3); // Nf
+        // component 1
+        data.extend_from_slice(&[1, 0x22, 0]);
+        // component 2
+        data.extend_from_slice(&[2, 0x11, 1]);
+        // component 3
+        data.extend_from_slice(&[3, 0x11, 1]);
+        // SOS marker with declared len = 0 (truncated). Without the bounds
+        // check this panicked while reading data[spec_base..spec_base+3].
+        data.extend_from_slice(&[0xFF, 0xDA]);
+        data.extend_from_slice(&0u16.to_be_bytes());
+
+        let result = read_jpeg(&data);
+        assert!(matches!(result, Err(JpegError::Invalid(_))));
+    }
+
+    /// Security audit 2026-05-06 H4 regression: SOS marker with a body
+    /// covering Ns and component selectors but missing the trailing 3-byte
+    /// (Ss, Se, Ah/Al) tuple. `len = 3 + 2*Ns` (no Ss/Se/Ah/Al). Should error,
+    /// not panic.
+    #[test]
+    fn read_jpeg_rejects_sos_marker_missing_spec_bytes() {
+        let mut data = Vec::new();
+        data.extend_from_slice(&[0xFF, 0xD8]); // SOI
+        // SOF0
+        data.extend_from_slice(&[0xFF, 0xC0]);
+        data.extend_from_slice(&17u16.to_be_bytes());
+        data.push(8);
+        data.extend_from_slice(&8u16.to_be_bytes());
+        data.extend_from_slice(&8u16.to_be_bytes());
+        data.push(3);
+        data.extend_from_slice(&[1, 0x22, 0]);
+        data.extend_from_slice(&[2, 0x11, 1]);
+        data.extend_from_slice(&[3, 0x11, 1]);
+        // SOS: Ns = 1, then 2 bytes selector, but len declared as 5 (covers
+        // length-bytes + Ns + 2 selector bytes only — no trailing Ss/Se/Ah).
+        // Required: 3 + 2*Ns + 3 = 8. Declared: 5.
+        data.extend_from_slice(&[0xFF, 0xDA]);
+        data.extend_from_slice(&5u16.to_be_bytes());
+        data.push(1); // Ns
+        data.extend_from_slice(&[1, 0x00]); // component selector + table
+
+        let result = read_jpeg(&data);
+        assert!(matches!(result, Err(JpegError::Invalid(_))));
     }
 
     #[test]

--- a/jxl-encoder/src/modular/tree_learn.rs
+++ b/jxl-encoder/src/modular/tree_learn.rs
@@ -703,7 +703,7 @@ fn gather_channel_samples(
                     let residual = pixel - prediction;
                     let packed = pack_signed(residual);
                     let (token, _extra_bits, num_extra) = GATHER_HYBRID_UINT.encode(packed);
-                    samples.residual_tokens[pred_idx].push(token as u8);
+                    samples.residual_tokens[pred_idx].push(saturating_token_u8(token));
                     samples.extra_bits[pred_idx].push(num_extra as u8);
                 }
 
@@ -1609,12 +1609,33 @@ pub fn compute_best_tree_with_multipliers(
     tree
 }
 
-/// Padded histogram size for count_increase: next power of 2 above typical
-/// histogram_size (~56 for 8-bit, HybridUint {4,1,2}). Using a power-of-2
-/// stride with bitmask indexing eliminates bounds checks: `tok & HISTO_MASK`
-/// is guaranteed < HISTO_PADDED. Set to 128 for safety margin.
-const HISTO_PADDED: usize = 128;
+/// Padded histogram size for count_increase: next power of 2 above the
+/// observed maximum token value, after saturation to `u8::MAX` (see the
+/// `saturating_token_u8` helper). Using a power-of-2 stride with bitmask
+/// indexing eliminates bounds checks: `tok & HISTO_MASK` is guaranteed
+/// `< HISTO_PADDED`.
+///
+/// Sized to 256 so the workspace can accommodate every possible u8 token,
+/// closing the security audit H3 panic in `SplitWorkspace::new` for
+/// adversarial 16-bit input (tokens above 127 are reachable through
+/// caller-controlled pixel residuals).
+const HISTO_PADDED: usize = 256;
 const HISTO_MASK: usize = HISTO_PADDED - 1;
+
+/// Saturate a `u32` token to `u8` instead of silently wrapping.
+///
+/// The downstream `SplitWorkspace::count_increase` table is sized at
+/// `HISTO_PADDED = 256` entries per bucket and indexed by the u8 token,
+/// so saturating to `u8::MAX` keeps all logical tokens above 255 bucketed
+/// into the same overflow slot rather than aliasing into low-numbered
+/// histogram bins via wrapping `as u8` truncation. This bounds the
+/// histogram size at 256 (the workspace capacity) and prevents both the
+/// `SplitWorkspace::new` panic and the silent histogram-bucket collision
+/// flagged in the security audit (H3, L4).
+#[inline]
+fn saturating_token_u8(token: u32) -> u8 {
+    token.min(u8::MAX as u32) as u8
+}
 
 /// Pre-allocated workspace for find_best_split, reused across calls.
 /// Avoids per-call Vec allocation and resize overhead.
@@ -1639,12 +1660,14 @@ struct SplitWorkspace {
 
 impl SplitWorkspace {
     fn new(max_count: usize, histogram_size: usize, max_buckets: usize) -> Self {
-        assert!(
-            histogram_size <= HISTO_PADDED,
-            "histogram_size {} exceeds HISTO_PADDED {}",
-            histogram_size,
-            HISTO_PADDED
-        );
+        // Saturating_token_u8 keeps every observed token within `[0, u8::MAX]`,
+        // and HISTO_PADDED = 256 covers that full range. Clamp defensively
+        // here in case histogram_size ever drifts above the workspace size:
+        // overflow tokens collide into the highest histogram bin rather than
+        // panicking the encoder. The previous `assert!` was reachable from
+        // caller-controlled 16-bit pixel residuals (security audit H3).
+        let histogram_size = histogram_size.min(HISTO_PADDED);
+        debug_assert!(histogram_size <= HISTO_PADDED);
         Self {
             count_increase: vec![0u32; max_buckets * HISTO_PADDED],
             extra_bits_increase: vec![0u64; max_buckets],
@@ -2454,6 +2477,38 @@ mod tests {
         props[0] = 1;
         let leaf = traverse_with_spec_props(&tree, &props);
         assert_eq!(leaf.predictor, Predictor::Gradient);
+    }
+
+    #[test]
+    fn saturating_token_u8_is_saturating_not_wrapping() {
+        // Below the cap: pass-through.
+        assert_eq!(saturating_token_u8(0), 0);
+        assert_eq!(saturating_token_u8(127), 127);
+        assert_eq!(saturating_token_u8(255), 255);
+        // At and above the cap: saturate to u8::MAX, never wrap.
+        assert_eq!(saturating_token_u8(256), 255);
+        assert_eq!(saturating_token_u8(1024), 255);
+        assert_eq!(saturating_token_u8(u32::MAX), 255);
+    }
+
+    #[test]
+    fn split_workspace_clamps_oversize_histogram() {
+        // Security audit H3: the previous implementation `assert!`-panicked
+        // for histogram_size > HISTO_PADDED, which was reachable via
+        // adversarial 16-bit pixel residuals. After the fix the workspace
+        // clamps the histogram size and never panics.
+        let max_count = 32;
+        let max_buckets = 4;
+        let _ws = SplitWorkspace::new(max_count, HISTO_PADDED + 64, max_buckets);
+        let _ws = SplitWorkspace::new(max_count, usize::MAX / 2, max_buckets);
+    }
+
+    #[test]
+    fn split_workspace_handles_boundary_histogram_size() {
+        // Exactly at the cap is also accepted.
+        let _ws = SplitWorkspace::new(8, HISTO_PADDED, 2);
+        let _ws = SplitWorkspace::new(8, HISTO_PADDED - 1, 2);
+        let _ws = SplitWorkspace::new(8, 1, 2);
     }
 
     #[test]

--- a/jxl-encoder/src/modular/tree_learn.rs
+++ b/jxl-encoder/src/modular/tree_learn.rs
@@ -703,7 +703,7 @@ fn gather_channel_samples(
                     let residual = pixel - prediction;
                     let packed = pack_signed(residual);
                     let (token, _extra_bits, num_extra) = GATHER_HYBRID_UINT.encode(packed);
-                    samples.residual_tokens[pred_idx].push(saturating_token_u8(token));
+                    samples.residual_tokens[pred_idx].push(token as u8);
                     samples.extra_bits[pred_idx].push(num_extra as u8);
                 }
 
@@ -1609,33 +1609,18 @@ pub fn compute_best_tree_with_multipliers(
     tree
 }
 
-/// Padded histogram size for count_increase: next power of 2 above the
-/// observed maximum token value, after saturation to `u8::MAX` (see the
-/// `saturating_token_u8` helper). Using a power-of-2 stride with bitmask
-/// indexing eliminates bounds checks: `tok & HISTO_MASK` is guaranteed
-/// `< HISTO_PADDED`.
+/// Padded histogram size for `count_increase`: power-of-2 stride above the
+/// maximum token `GATHER_HYBRID_UINT.encode` can produce. Bitmask indexing
+/// (`tok & HISTO_MASK`) is bounds-check-free given `tok < HISTO_PADDED`.
 ///
-/// Sized to 256 so the workspace can accommodate every possible u8 token,
-/// closing the security audit H3 panic in `SplitWorkspace::new` for
-/// adversarial 16-bit input (tokens above 127 are reachable through
-/// caller-controlled pixel residuals).
+/// Bound derivation for `GATHER_HYBRID_UINT { split=16, m=1, l=2 }`:
+/// `token = 16 + 8·n_extra + 4·token_shift + low_bits`. With u32 input,
+/// `value_shifted ≤ 2^30 − 1`, `value_bits ≤ 30`, `n ≤ 28`, `n_extra ≤ 27`,
+/// so `token ≤ 16 + 216 + 4 + 3 = 239`. The previous size (128) was
+/// reachable past via RCT/Squeeze-amplified 16-bit residuals — closed
+/// by the bump to 256 (security audit H3).
 const HISTO_PADDED: usize = 256;
 const HISTO_MASK: usize = HISTO_PADDED - 1;
-
-/// Saturate a `u32` token to `u8` instead of silently wrapping.
-///
-/// The downstream `SplitWorkspace::count_increase` table is sized at
-/// `HISTO_PADDED = 256` entries per bucket and indexed by the u8 token,
-/// so saturating to `u8::MAX` keeps all logical tokens above 255 bucketed
-/// into the same overflow slot rather than aliasing into low-numbered
-/// histogram bins via wrapping `as u8` truncation. This bounds the
-/// histogram size at 256 (the workspace capacity) and prevents both the
-/// `SplitWorkspace::new` panic and the silent histogram-bucket collision
-/// flagged in the security audit (H3, L4).
-#[inline]
-fn saturating_token_u8(token: u32) -> u8 {
-    token.min(u8::MAX as u32) as u8
-}
 
 /// Pre-allocated workspace for find_best_split, reused across calls.
 /// Avoids per-call Vec allocation and resize overhead.
@@ -1660,13 +1645,8 @@ struct SplitWorkspace {
 
 impl SplitWorkspace {
     fn new(max_count: usize, histogram_size: usize, max_buckets: usize) -> Self {
-        // Saturating_token_u8 keeps every observed token within `[0, u8::MAX]`,
-        // and HISTO_PADDED = 256 covers that full range. Clamp defensively
-        // here in case histogram_size ever drifts above the workspace size:
-        // overflow tokens collide into the highest histogram bin rather than
-        // panicking the encoder. The previous `assert!` was reachable from
-        // caller-controlled 16-bit pixel residuals (security audit H3).
-        let histogram_size = histogram_size.min(HISTO_PADDED);
+        // Provable: `histogram_size` derives from `GATHER_HYBRID_UINT.encode`
+        // tokens, max 239 for any u32 input (see HISTO_PADDED comment).
         debug_assert!(histogram_size <= HISTO_PADDED);
         Self {
             count_increase: vec![0u32; max_buckets * HISTO_PADDED],
@@ -2480,35 +2460,32 @@ mod tests {
     }
 
     #[test]
-    fn saturating_token_u8_is_saturating_not_wrapping() {
-        // Below the cap: pass-through.
-        assert_eq!(saturating_token_u8(0), 0);
-        assert_eq!(saturating_token_u8(127), 127);
-        assert_eq!(saturating_token_u8(255), 255);
-        // At and above the cap: saturate to u8::MAX, never wrap.
-        assert_eq!(saturating_token_u8(256), 255);
-        assert_eq!(saturating_token_u8(1024), 255);
-        assert_eq!(saturating_token_u8(u32::MAX), 255);
-    }
-
-    #[test]
-    fn split_workspace_clamps_oversize_histogram() {
-        // Security audit H3: the previous implementation `assert!`-panicked
-        // for histogram_size > HISTO_PADDED, which was reachable via
-        // adversarial 16-bit pixel residuals. After the fix the workspace
-        // clamps the histogram size and never panics.
-        let max_count = 32;
-        let max_buckets = 4;
-        let _ws = SplitWorkspace::new(max_count, HISTO_PADDED + 64, max_buckets);
-        let _ws = SplitWorkspace::new(max_count, usize::MAX / 2, max_buckets);
-    }
-
-    #[test]
     fn split_workspace_handles_boundary_histogram_size() {
-        // Exactly at the cap is also accepted.
+        // HISTO_PADDED = 256 covers the max token (239) the GATHER_HYBRID_UINT
+        // config can produce; this confirms the workspace constructs at the cap.
         let _ws = SplitWorkspace::new(8, HISTO_PADDED, 2);
         let _ws = SplitWorkspace::new(8, HISTO_PADDED - 1, 2);
         let _ws = SplitWorkspace::new(8, 1, 2);
+    }
+
+    #[test]
+    fn gather_hybrid_uint_token_bound() {
+        // Proof companion to HISTO_PADDED's bound derivation: any u32 input
+        // produces a token <= 239, which fits in a u8 without saturation.
+        let probes: [u32; 8] = [
+            0,
+            15,
+            16,
+            (1u32 << 17) - 2, // max packed for ±65535 (16-bit pixel residual)
+            (1u32 << 20),
+            (1u32 << 25),
+            (1u32 << 30),
+            u32::MAX,
+        ];
+        for v in probes {
+            let (token, _, _) = GATHER_HYBRID_UINT.encode(v);
+            assert!(token <= 239, "token {token} exceeded 239 for input {v}");
+        }
     }
 
     #[test]

--- a/jxl-encoder/tests/streaming_dim_limits.rs
+++ b/jxl-encoder/tests/streaming_dim_limits.rs
@@ -1,0 +1,86 @@
+// Copyright (c) Imazen LLC and the JPEG XL Project Authors.
+// Licensed under AGPL-3.0-or-later. Commercial licenses at https://www.imazen.io/pricing
+
+//! Regression tests for the streaming-encoder dimension validation gate (H1).
+//!
+//! Both `LossyConfig::encoder` and `LosslessConfig::encoder` previously accepted
+//! `width = u32::MAX`, which the `write_size_u2s` 30-bit field would silently
+//! truncate, producing a JXL header whose declared dimensions did not match the
+//! encoded data. The shared `validate_dims` helper now rejects any dimension
+//! greater than `MAX_JXL_DIM = 2^30` up front.
+
+use jxl_encoder::{At, EncodeError, LosslessConfig, LossyConfig, PixelLayout};
+
+const MAX_JXL_DIM: u32 = 1 << 30;
+
+fn require_limit_exceeded<T>(result: Result<T, At<EncodeError>>, ctx: &str) {
+    match result {
+        Ok(_) => panic!("{ctx}: expected error, got Ok"),
+        Err(at) => match at.error() {
+            EncodeError::LimitExceeded { .. } => {}
+            other => panic!("{ctx}: expected LimitExceeded, got {other:?}"),
+        },
+    }
+}
+
+fn require_invalid_input<T>(result: Result<T, At<EncodeError>>, ctx: &str) {
+    match result {
+        Ok(_) => panic!("{ctx}: expected error, got Ok"),
+        Err(at) => match at.error() {
+            EncodeError::InvalidInput { .. } => {}
+            other => panic!("{ctx}: expected InvalidInput, got {other:?}"),
+        },
+    }
+}
+
+#[test]
+fn streaming_lossy_rejects_width_above_spec_max() {
+    let result = LossyConfig::new(1.0).encoder(MAX_JXL_DIM + 1, 16, PixelLayout::Rgb8);
+    require_limit_exceeded(result, "lossy width=2^30+1");
+}
+
+#[test]
+fn streaming_lossy_rejects_height_above_spec_max() {
+    let result = LossyConfig::new(1.0).encoder(16, MAX_JXL_DIM + 1, PixelLayout::Rgb8);
+    require_limit_exceeded(result, "lossy height=2^30+1");
+}
+
+#[test]
+fn streaming_lossy_rejects_u32_max() {
+    let result = LossyConfig::new(1.0).encoder(u32::MAX, 2, PixelLayout::Rgb8);
+    require_limit_exceeded(result, "lossy width=u32::MAX");
+}
+
+#[test]
+fn streaming_lossy_rejects_zero_dim() {
+    let result = LossyConfig::new(1.0).encoder(0, 16, PixelLayout::Rgb8);
+    require_invalid_input(result, "lossy width=0");
+    let result = LossyConfig::new(1.0).encoder(16, 0, PixelLayout::Rgb8);
+    require_invalid_input(result, "lossy height=0");
+}
+
+#[test]
+fn streaming_lossless_rejects_width_above_spec_max() {
+    let result = LosslessConfig::new().encoder(MAX_JXL_DIM + 1, 16, PixelLayout::Rgb8);
+    require_limit_exceeded(result, "lossless width=2^30+1");
+}
+
+#[test]
+fn streaming_lossless_rejects_height_above_spec_max() {
+    let result = LosslessConfig::new().encoder(16, MAX_JXL_DIM + 1, PixelLayout::Rgb8);
+    require_limit_exceeded(result, "lossless height=2^30+1");
+}
+
+#[test]
+fn streaming_lossless_rejects_u32_max() {
+    let result = LosslessConfig::new().encoder(u32::MAX, 2, PixelLayout::Rgb8);
+    require_limit_exceeded(result, "lossless width=u32::MAX");
+}
+
+#[test]
+fn streaming_lossless_rejects_zero_dim() {
+    let result = LosslessConfig::new().encoder(0, 16, PixelLayout::Rgb8);
+    require_invalid_input(result, "lossless width=0");
+    let result = LosslessConfig::new().encoder(16, 0, PixelLayout::Rgb8);
+    require_invalid_input(result, "lossless height=0");
+}


### PR DESCRIPTION
## Summary

Three HIGH findings from the 2026-05-06 security audit. H2 (memory budget threading) is in flight on PR #32.

### H1 — Streaming dim validation (`api.rs`)

`LossyConfig::encoder` and `LosslessConfig::encoder` accepted `width = u32::MAX`, which `write_size_u2s` silently truncated to 30 bits, producing a header whose declared dimensions disagreed with the encoded data.

Fix: hoist the existing one-shot dim validation (zero check, `MAX_JXL_DIM = 2^30` cap, `w*h*16` overflow check) into a shared `validate_dims` helper, called from both streaming entry points, `validate_pixels`, and `validate_animation_input`. New regression tests in `jxl-encoder/tests/streaming_dim_limits.rs`.

### H3 — `tree_learn::SplitWorkspace::new` panic (`modular/tree_learn.rs`)

`assert!(histogram_size <= HISTO_PADDED)` (HISTO_PADDED = 128) was reachable from caller-controlled input. The `gather_channel_samples` path runs every pixel through `GATHER_HYBRID_UINT.encode(pack_signed(residual))` with config `{split_exponent=4, msb_in_token=1, lsb_in_token=2}`.

Token bound (corrected from earlier draft of this PR): max `token = 16 + 8·n_extra + 4·token_shift + low_bits`. With u32 input, `value_shifted ≤ 2^30 − 1`, `value_bits ≤ 30`, `n ≤ 28`, `n_extra ≤ 27`, `token ≤ 16 + 216 + 4 + 3 = 239`. So tokens fit in u8 with no wrapping — the earlier description claim about \"wrapping tokens above 255\" was wrong. The real reachability is tokens in [128, 239] from RCT/Squeeze-amplified residuals on 16-bit input, which trip the assert at the existing HISTO_PADDED=128.

Fix:
- Bump `HISTO_PADDED` 128 → 256 (next power-of-2 above the 239 bound, preserves the bitmask-indexing invariant).
- Replace `assert!` with `debug_assert!` since 239 < 256 is provable from the encode formula.

The `saturating_token_u8` helper introduced in an earlier draft is unnecessary defense-in-depth — `token as u8` is provably non-wrapping for any u32 input under this config. (Worth keeping as a guard if `GATHER_HYBRID_UINT` is ever retuned, but that's a forward-compat concern, not the audit finding.)

### H4 — JPEG SOS marker bounds check (`jpeg/parse.rs`)

`parse_sos_header` validated that the SOS marker fit in `data` then unconditionally indexed `data[p+2]`, the per-component selectors, and the (Ss, Se, Ah/Al) trailer. A crafted JPEG with `FF D8 FF DA 00 00 EOF` (SOI + zero-length SOS) panicked the parser via OOB index. Reachable via the public `read_jpeg` API behind the `jpeg-reencoding` feature.

Fix: validate `len >= 3` before reading Ns, then validate `len >= 3 + 2*Ns + 3` before reading the trailer. Both checks return `JpegError::Invalid` instead of panicking. Two regression tests added.

> The `jpeg-reencoding` feature currently fails to build because of an upstream `zenjpeg 0.7.1` / archmage API skew unrelated to this PR (`encode/dct.rs:409,715` calls `mf32x8::load_8x8` with one argument; the trait now requires the token argument). The new \`parse_sos_header\` tests will run once that build is restored. The parser fix itself compiles under default features.

### H2 — Deferred

Memory budget threading (audit H2) is in flight on PR #32 (\`fix/alloc-budget-tracker\`), now also covered by the rework on \`fix/alloc-budget-rework\`.

## Test plan

- [x] \`cargo build -p jxl-encoder --no-default-features --features std\`
- [x] \`cargo test -p jxl-encoder --lib --no-default-features --features std\` (747 pass)
- [x] \`cargo test -p jxl-encoder --no-default-features --features std --test streaming_dim_limits\` (8 pass)
- [x] \`cargo test -p jxl-encoder --doc --no-default-features --features std\` (6 pass)
- [x] \`cargo fmt --all -- --check\`

## Files changed

- \`jxl-encoder/src/api.rs\` — \`validate_dims\` helper, applied at four entry points
- \`jxl-encoder/src/modular/tree_learn.rs\` — \`HISTO_PADDED\` 128 → 256, \`assert!\` → \`debug_assert!\` with proof
- \`jxl-encoder/src/jpeg/parse.rs\` — SOS length validation, two new tests
- \`jxl-encoder/tests/streaming_dim_limits.rs\` — new file, eight tests