### PR TITLE
refactor(simd): remove unsafe-performance feature

### DIFF
--- a/jxl-encoder-cli/Cargo.toml
+++ b/jxl-encoder-cli/Cargo.toml
@@ -19,15 +19,6 @@ name = "cjxl-rs"
 path = "src/main.rs"
 
 [features]
-# SECURITY: `unsafe-performance` is NOT in the default set. It eliminates
-# memset zero-fills on hot-path scratch buffers via MaybeUninit and
-# get_unchecked, but every misuse becomes UB rather than a panic. The
-# v09/v11 production sweep crashes (0x40000000-prefix indices in patches.rs
-# and lz77 chain arrays) are consistent with one such misuse leaking into
-# adjacent heap memory — the defensive bounds added in commit 1498053
-# block the symptom but the underlying UB is still possible. Run
-# `cjxl-rs` with `--features unsafe-performance` only when the input is
-# trusted; do not use it on a public-facing image proxy.
 default = ["jxl_encoder/std", "butteraugli-loop", "parallel"]
 debug-tokens = ["jxl_encoder/debug-tokens"]
 debug-ac-strategy = ["jxl_encoder/debug-ac-strategy"]
@@ -42,8 +33,6 @@ ssim2-loop = ["jxl_encoder/ssim2-loop"]
 zensim-loop = ["jxl_encoder/zensim-loop"]
 # Enable parallel group encoding with rayon
 parallel = ["jxl_encoder/parallel"]
-# Use MaybeUninit for hot-path buffers (eliminates memset zero-fill)
-unsafe-performance = ["jxl_encoder/unsafe-performance"]
 
 [dependencies]
 jxl_encoder = { package = "jxl-encoder", path = "../jxl-encoder", version = "0.3.0", default-features = false }

--- a/jxl-encoder-simd/Cargo.toml
+++ b/jxl-encoder-simd/Cargo.toml
@@ -17,7 +17,6 @@ include = ["/src/**", "/README.md", "/LICENSE*"]
 [features]
 default = ["std"]
 std = ["archmage/std", "magetypes/std"]
-unsafe-performance = []
 
 [dependencies]
 archmage = { version = "0.9.15", default-features = false, features = ["macros"] }

--- a/jxl-encoder-simd/src/lib.rs
+++ b/jxl-encoder-simd/src/lib.rs
@@ -21,108 +21,50 @@
 //! variant directly from an `#[arcane]` function so LLVM can inline across the
 //! target-feature boundary.
 
-#![cfg_attr(not(feature = "unsafe-performance"), forbid(unsafe_code))]
-#![cfg_attr(feature = "unsafe-performance", deny(unsafe_code))]
+#![forbid(unsafe_code)]
 // Numerical SIMD/DSP code: range loops and many-parameter kernels are natural.
 #![allow(clippy::needless_range_loop, clippy::too_many_arguments)]
 #![no_std]
 extern crate alloc;
 
-/// Return an uninitialized `[f32; N]` scratch buffer (unsafe-performance path).
+/// Return a zero-initialized `[f32; N]` scratch buffer.
 ///
-/// # Safety
-/// Caller must write every element before reading it. All call sites are DCT/IDCT
-/// scratch arrays that are immediately filled by copy_from_slice, transpose, or
-/// gather_col before any read occurs.
-#[cfg(feature = "unsafe-performance")]
-#[allow(unsafe_code, clippy::uninit_assumed_init)]
-#[inline(always)]
-pub(crate) fn scratch_buf<const N: usize>() -> [f32; N] {
-    // SAFETY: All call sites write every element via copy_from_slice, transpose,
-    // or gather_col before any read. f32 has no trap representations on IEEE 754.
-    unsafe { core::mem::MaybeUninit::<[f32; N]>::uninit().assume_init() }
-}
-
-/// Return a zero-initialized `[f32; N]` scratch buffer (safe default path).
-#[cfg(not(feature = "unsafe-performance"))]
+/// LLVM elides the dead-store memset on stack arrays whose every position
+/// is later written, so on hot paths this compiles to a no-op zero-fill or
+/// is fully optimized away. Wall-clock benchmarks confirmed no measurable
+/// gain from `MaybeUninit` here on the AMD Ryzen 7950X.
 #[inline(always)]
 pub(crate) fn scratch_buf<const N: usize>() -> [f32; N] {
     [0.0f32; N]
 }
 
-/// Allocate a `Vec<f32>` of length `n` without zeroing (unsafe-performance path).
+/// Allocate a zero-initialized `Vec<f32>` of length `n`.
 ///
-/// # Safety
-/// Caller must write every element before reading it. Intended for output buffers
-/// that are immediately overwritten by IDCT, EPF, gaborish, or similar operations.
-#[cfg(feature = "unsafe-performance")]
-#[allow(unsafe_code, clippy::uninit_vec)]
-#[inline]
-pub fn vec_f32_dirty(n: usize) -> alloc::vec::Vec<f32> {
-    let mut v = alloc::vec::Vec::with_capacity(n);
-    // SAFETY: f32 has no trap representations on IEEE 754. Caller must write all
-    // elements before reading. Length is within the allocated capacity.
-    unsafe { v.set_len(n) };
-    v
-}
-
-/// Allocate a zero-initialized `Vec<f32>` of length `n` (safe default path).
-#[cfg(not(feature = "unsafe-performance"))]
+/// On Linux glibc / musl the underlying `calloc` returns kernel-zeroed
+/// pages from `mmap(MAP_ANON)` for any allocation big enough to bypass
+/// the small-bin allocator — the userspace memset cost is essentially
+/// zero. Wall-clock benchmarks (single-threaded and 32-thread parallel)
+/// found no measurable advantage over the previous `set_len`-on-uninit
+/// `MaybeUninit` form, so the simple safe form ships.
 #[inline]
 pub fn vec_f32_dirty(n: usize) -> alloc::vec::Vec<f32> {
     alloc::vec![0.0f32; n]
 }
 
-/// Slice from offset without bounds check (unsafe-performance path).
-///
-/// # Safety
-/// Caller must ensure `offset <= s.len()`.
-#[cfg(all(feature = "unsafe-performance", target_arch = "x86_64"))]
-#[inline(always)]
-#[allow(unsafe_code)]
-pub(crate) fn slice_from(s: &[f32], offset: usize) -> &[f32] {
-    debug_assert!(offset <= s.len());
-    // SAFETY: Caller guarantees offset <= s.len(); debug_assert checks in debug builds.
-    unsafe { s.get_unchecked(offset..) }
-}
-
-/// Slice from offset with bounds check (safe default path).
-#[cfg(all(not(feature = "unsafe-performance"), target_arch = "x86_64"))]
+/// Slice from offset (bounds-checked).
+#[cfg(target_arch = "x86_64")]
 #[inline(always)]
 pub(crate) fn slice_from(s: &[f32], offset: usize) -> &[f32] {
     &s[offset..]
 }
 
-/// Load 8 floats at offset — no bounds checks (unsafe-performance path).
+/// Load 8 floats at offset.
 ///
-/// Bypasses both slice-from bounds check AND `f32x8::from_slice`'s internal
-/// `[..8]` bounds check by using `_mm256_loadu_ps` directly.
-///
-/// # Safety
-/// Caller must ensure `offset + 8 <= s.len()`.
-#[cfg(all(feature = "unsafe-performance", target_arch = "x86_64"))]
-#[inline(always)]
-#[allow(unsafe_code)]
-pub(crate) fn load_f32x8(
-    token: archmage::X64V3Token,
-    s: &[f32],
-    offset: usize,
-) -> magetypes::simd::f32x8 {
-    use magetypes::simd::f32x8;
-    debug_assert!(
-        offset + 8 <= s.len(),
-        "load_f32x8: offset={offset}, len={}",
-        s.len()
-    );
-    // SAFETY: Caller guarantees offset + 8 <= s.len(); debug_assert checks in debug builds.
-    unsafe {
-        let ptr = s.as_ptr().add(offset);
-        f32x8::from_m256(token, core::arch::x86_64::_mm256_loadu_ps(ptr))
-    }
-}
-
-/// Load 8 floats at offset — with bounds checks (safe default path).
-#[cfg(all(not(feature = "unsafe-performance"), target_arch = "x86_64"))]
+/// `f32x8::from_slice` does the equivalent of `s[offset..offset+8]` plus a
+/// length check; LLVM emits the AVX2 load instruction with the panic edge
+/// as a cold branch — same codegen as a hand-rolled `_mm256_loadu_ps` on
+/// the success path.
+#[cfg(target_arch = "x86_64")]
 #[inline(always)]
 pub(crate) fn load_f32x8(
     token: archmage::X64V3Token,
@@ -133,31 +75,8 @@ pub(crate) fn load_f32x8(
     f32x8::from_slice(token, &s[offset..])
 }
 
-/// Store 8 floats at offset — no bounds checks (unsafe-performance path).
-///
-/// Bypasses slice bounds check and `try_into().unwrap()` by using
-/// `_mm256_storeu_ps` directly.
-///
-/// # Safety
-/// Caller must ensure `offset + 8 <= s.len()`.
-#[cfg(all(feature = "unsafe-performance", target_arch = "x86_64"))]
-#[inline(always)]
-#[allow(unsafe_code)]
-pub(crate) fn store_f32x8(s: &mut [f32], offset: usize, v: magetypes::simd::f32x8) {
-    debug_assert!(
-        offset + 8 <= s.len(),
-        "store_f32x8: offset={offset}, len={}",
-        s.len()
-    );
-    // SAFETY: Caller guarantees offset + 8 <= s.len(); debug_assert checks in debug builds.
-    unsafe {
-        let ptr = s.as_mut_ptr().add(offset);
-        core::arch::x86_64::_mm256_storeu_ps(ptr, v.raw());
-    }
-}
-
-/// Store 8 floats at offset — with bounds checks (safe default path).
-#[cfg(all(not(feature = "unsafe-performance"), target_arch = "x86_64"))]
+/// Store 8 floats at offset.
+#[cfg(target_arch = "x86_64")]
 #[inline(always)]
 pub(crate) fn store_f32x8(s: &mut [f32], offset: usize, v: magetypes::simd::f32x8) {
     let out: &mut [f32; 8] = (&mut s[offset..offset + 8]).try_into().unwrap();
@@ -165,12 +84,8 @@ pub(crate) fn store_f32x8(s: &mut [f32], offset: usize, v: magetypes::simd::f32x
 }
 
 /// Load column `j` from 8 consecutive rows starting at `base_row` with given stride.
-///
-/// Unsafe-performance path: uses unchecked indexing (validated by debug_assert).
-/// Safe path: uses bounds-checked indexing.
 #[cfg(target_arch = "x86_64")]
 #[inline(always)]
-#[cfg_attr(feature = "unsafe-performance", allow(unsafe_code))]
 pub(crate) fn gather_col_strided(
     token: archmage::X64V3Token,
     data: &[f32],
@@ -178,30 +93,6 @@ pub(crate) fn gather_col_strided(
     j: usize,
     stride: usize,
 ) -> magetypes::simd::f32x8 {
-    #[cfg(feature = "unsafe-performance")]
-    {
-        debug_assert!(
-            (base_row + 7) * stride + j < data.len(),
-            "gather_col_strided OOB: base_row={base_row}, j={j}, stride={stride}, len={}",
-            data.len()
-        );
-        // SAFETY: Caller guarantees (base_row + 7) * stride + j < data.len().
-        // All lower indices are within bounds since base_row + r <= base_row + 7.
-        unsafe {
-            let arr = [
-                *data.get_unchecked(base_row * stride + j),
-                *data.get_unchecked((base_row + 1) * stride + j),
-                *data.get_unchecked((base_row + 2) * stride + j),
-                *data.get_unchecked((base_row + 3) * stride + j),
-                *data.get_unchecked((base_row + 4) * stride + j),
-                *data.get_unchecked((base_row + 5) * stride + j),
-                *data.get_unchecked((base_row + 6) * stride + j),
-                *data.get_unchecked((base_row + 7) * stride + j),
-            ];
-            magetypes::simd::f32x8::from_array(token, arr)
-        }
-    }
-    #[cfg(not(feature = "unsafe-performance"))]
     magetypes::simd::f32x8::from_array(
         token,
         [
@@ -218,12 +109,8 @@ pub(crate) fn gather_col_strided(
 }
 
 /// Store f32x8 lanes back to column `j` of 8 consecutive rows with given stride.
-///
-/// Unsafe-performance path: uses unchecked indexing (validated by debug_assert).
-/// Safe path: uses bounds-checked indexing.
 #[cfg(target_arch = "x86_64")]
 #[inline(always)]
-#[cfg_attr(feature = "unsafe-performance", allow(unsafe_code))]
 pub(crate) fn scatter_col_strided(
     v: magetypes::simd::f32x8,
     data: &mut [f32],
@@ -233,21 +120,6 @@ pub(crate) fn scatter_col_strided(
 ) {
     let mut lane = [0.0f32; 8];
     v.store(&mut lane);
-    #[cfg(feature = "unsafe-performance")]
-    {
-        debug_assert!(
-            (base_row + 7) * stride + j < data.len(),
-            "scatter_col_strided OOB: base_row={base_row}, j={j}, stride={stride}, len={}",
-            data.len()
-        );
-        // SAFETY: Caller guarantees (base_row + 7) * stride + j < data.len().
-        unsafe {
-            for (r, &val) in lane.iter().enumerate() {
-                *data.get_unchecked_mut((base_row + r) * stride + j) = val;
-            }
-        }
-    }
-    #[cfg(not(feature = "unsafe-performance"))]
     for (r, &val) in lane.iter().enumerate() {
         data[(base_row + r) * stride + j] = val;
     }

--- a/jxl-encoder/Cargo.toml
+++ b/jxl-encoder/Cargo.toml
@@ -60,12 +60,6 @@ zensim-loop = ["dep:zensim"]
 convenience = ["dep:imgref", "dep:rgb"]
 jpeg-reencoding = ["dep:zenjpeg", "dep:brotli"]
 parallel = ["std", "dep:rayon"]
-# Use MaybeUninit for hot-path temporary buffers instead of zero-initialization.
-# Eliminates ~584M memset writes (24.7% of total data writes) at the cost of
-# requiring `unsafe` in a few carefully audited locations. The crate-level lint
-# is downgraded from `forbid(unsafe_code)` to `deny(unsafe_code)` so that
-# individual functions can `#[allow(unsafe_code)]`.
-unsafe-performance = ["jxl_simd/unsafe-performance"]
 # Picker training / sweep escape hatch: exposes the segmented
 # LossyInternalParams / LosslessInternalParams structs and the
 # LossyConfig::with_internal_params / LosslessConfig::with_internal_params

--- a/jxl-encoder/src/lib.rs
+++ b/jxl-encoder/src/lib.rs
@@ -7,8 +7,7 @@
 //! This crate provides a complete JPEG XL encoder implementation, supporting
 //! both lossless (modular) and lossy (VarDCT) encoding modes.
 
-#![cfg_attr(not(feature = "unsafe-performance"), forbid(unsafe_code))]
-#![cfg_attr(feature = "unsafe-performance", deny(unsafe_code))]
+#![forbid(unsafe_code)]
 
 extern crate alloc;
 

--- a/jxl-encoder/src/vardct/common.rs
+++ b/jxl-encoder/src/vardct/common.rs
@@ -86,68 +86,30 @@ pub const fn floor_log2_nonzero(n: u32) -> u32 {
     31 - n.leading_zeros()
 }
 
-/// Return an uninitialized `[f32; N]` buffer.
+/// Return a zero-initialized `[f32; N]` buffer.
 ///
-/// With the `unsafe-performance` feature, this skips the memset zero-fill and
-/// returns memory with indeterminate contents via [`core::mem::MaybeUninit`].
-/// **Every caller MUST write all `N` positions before reading any of them.**
-///
-/// Without the feature (default), this returns `[0.0f32; N]`.
-#[cfg(feature = "unsafe-performance")]
-#[allow(unsafe_code, clippy::uninit_assumed_init)]
-#[inline(always)]
-pub fn uninit_buf<const N: usize>() -> [f32; N] {
-    // SAFETY: All call sites write every element via extract_block_* / DCT /
-    // IDCT before any read.  f32 has no trap representations on IEEE 754
-    // hardware, and LLVM treats the bytes as "undef" which is exactly what we
-    // want — the dead-store memset is eliminated.
-    unsafe { core::mem::MaybeUninit::<[f32; N]>::uninit().assume_init() }
-}
-
-/// Return a zero-initialized `[f32; N]` buffer (safe default path).
-#[cfg(not(feature = "unsafe-performance"))]
+/// LLVM elides the dead-store memset on stack arrays whose every position
+/// is later written, so on hot paths this compiles to a no-op zero-fill
+/// or is fully optimized away. Previously gated behind `unsafe-performance`
+/// with a `MaybeUninit::uninit().assume_init()` body, but wall-clock
+/// benchmarks (serial and 32-thread parallel) found no measurable
+/// advantage from the unsafe form — the safe path ships unconditionally.
 #[inline(always)]
 pub fn uninit_buf<const N: usize>() -> [f32; N] {
     [0.0f32; N]
 }
 
-/// Convert `&slice[offset..offset+N]` to `&[f32; N]` without bounds checking.
+/// Convert `&slice[offset..offset+N]` to `&[f32; N]`.
 ///
-/// With `unsafe-performance`, skips the slice range check and `try_into` length check.
-/// **Caller MUST ensure `offset + N <= slice.len()`.**
-///
-/// Without the feature, falls back to `slice[offset..offset+N].try_into().unwrap()`.
-#[cfg(feature = "unsafe-performance")]
-#[allow(unsafe_code)]
-#[inline(always)]
-pub fn as_array_ref<const N: usize>(slice: &[f32], offset: usize) -> &[f32; N] {
-    debug_assert!(offset + N <= slice.len());
-    // SAFETY: caller guarantees offset + N <= slice.len()
-    unsafe { &*(slice.as_ptr().add(offset) as *const [f32; N]) }
-}
-
-#[cfg(not(feature = "unsafe-performance"))]
+/// LLVM optimizes the slice + `try_into` to the same codegen as a raw
+/// pointer cast on the success path; the panic edge is a cold branch.
+/// Same wall-clock cost as the previous unsafe pointer-add path.
 #[inline(always)]
 pub fn as_array_ref<const N: usize>(slice: &[f32], offset: usize) -> &[f32; N] {
     slice[offset..offset + N].try_into().unwrap()
 }
 
-/// Convert `&mut slice[offset..offset+N]` to `&mut [f32; N]` without bounds checking.
-///
-/// With `unsafe-performance`, skips the slice range check and `try_into` length check.
-/// **Caller MUST ensure `offset + N <= slice.len()`.**
-///
-/// Without the feature, falls back to `(&mut slice[offset..offset+N]).try_into().unwrap()`.
-#[cfg(feature = "unsafe-performance")]
-#[allow(unsafe_code)]
-#[inline(always)]
-pub fn as_array_mut<const N: usize>(slice: &mut [f32], offset: usize) -> &mut [f32; N] {
-    debug_assert!(offset + N <= slice.len());
-    // SAFETY: caller guarantees offset + N <= slice.len()
-    unsafe { &mut *(slice.as_mut_ptr().add(offset) as *mut [f32; N]) }
-}
-
-#[cfg(not(feature = "unsafe-performance"))]
+/// Convert `&mut slice[offset..offset+N]` to `&mut [f32; N]`.
 #[inline(always)]
 pub fn as_array_mut<const N: usize>(slice: &mut [f32], offset: usize) -> &mut [f32; N] {
     (&mut slice[offset..offset + N]).try_into().unwrap()


### PR DESCRIPTION
Reopens #34 with the same content rebased onto current main (its prior base, #33's branch, was deleted on merge).

The `unsafe-performance` feature offered scratch_buf / vec_f32_dirty / as_array / load_f32x8 / store_f32x8 unsafe variants. Wall-clock measurement: -1.0% serial, -3.4% parallel — sub-noise. Removed and replaced with safe equivalents:

- `vec![0.0; n]` (single calloc, LLVM elides memset for zero-init)
- `[0.0; N]` (LLVM elides memset for fixed-size init)
- `slice[..N].try_into()` (cold panic edge, fully optimized)
- `f32x8::from_slice` / `store_to_slice` (same codegen as the unsafe pointer-arith path)

The crate now ships with `#![forbid(unsafe_code)]` honored throughout (no exception). 270 encodes across SIMD dispatch tiers on the v09/v11 trigger fixtures: 0 panics, no behavior change on legit input, no `0x40000000` corruption pattern.

Test plan: 740 lib tests pass under default features; clippy + fmt clean. The corruption-trigger regression tests in #33 cover this branch's runtime behavior.