### PR TITLE
feat(api): ChromaSubsampling enum + signal-only chunk 1 (#47)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,35 @@
 
 ### Added
 
+- **`ChromaSubsampling` API surface (issue #47 chunk 1)** — A1 audit "VarDCT
+  cost model" OUT item. Ships the smallest viable signal-only POC for
+  chroma 4:2:0 / 4:2:2 / 4:4:0:
+  - New [`ChromaSubsampling`] enum (`Full444` / `Sub422` / `Sub420` /
+    `Sub440`) mirroring libjxl's `YCbCrChromaSubsampling::kHShift` /
+    `kVShift` tables (`frame_header.h:81`). Per-mode `h_shifts()` /
+    `v_shifts()` / `is_full()` / `tag()` accessors.
+  - New [`LossyConfig::with_chroma_subsampling`] builder + matching
+    `chroma_subsampling()` getter. Default is `ChromaSubsampling::Full444`
+    so every existing bitstream stays byte-identical (hash-lock 36/36).
+  - Field carried across `LossyConfig::with_effort()` so the builder
+    chain `LossyConfig::new(d).with_chroma_subsampling(Sub420).with_effort(5)`
+    is order-independent. Regression test
+    `chroma_subsampling_signal::with_chroma_subsampling_survives_with_effort`
+    pins this invariant.
+  - Fast-fail guard in both the one-shot lossy encode path and the
+    streaming `LossyEncoder::finish` path: any non-`Full444` value
+    returns [`EncodeError::InvalidConfig`] with a message that names the
+    JXL spec constraint (chroma subsampling is only valid with
+    `ColorTransform::kYCbCr`; our VarDCT pipeline emits
+    `ColorTransform::kXYB`, libjxl `enc_frame.cc:373-387`).
+  - 11-case integration test
+    `jxl-encoder/tests/chroma_subsampling_signal.rs` covers the enum
+    surface, default, libjxl shift-table parity, `Full444` jxl-rs
+    roundtrip, and `InvalidConfig` for each non-default mode.
+  - Real chroma-downsampled encoding (Cb/Cr box-filter downsample,
+    YCbCr colour pipeline selection per frame, `FrameHeader.do_ycbcr` +
+    `jpeg_upsampling` wire format) is queued for chunks 2+ on issue #47.
+
 - **Multi-seed lossy butteraugli sweep at e10/e11** (RFC#45 pick #1 chunk 3).
   New `EffortProfile::lossy_search_seeds` field (1 at e ≤ 9, 2 at e10, 4 at e11)
   drives [`vardct::butteraugli_loop`]: at seeds > 1 we run the full

--- a/jxl-encoder/src/api.rs
+++ b/jxl-encoder/src/api.rs
@@ -2212,6 +2212,104 @@ pub enum ProgressiveMode {
     DcVlfLfAc,
 }
 
+/// Chroma subsampling mode for lossy VarDCT encoding.
+///
+/// Mirrors libjxl's four `YCbCrChromaSubsampling` modes
+/// (`frame_header.h:81`). Each mode is described by the
+/// (horizontal, vertical) shift applied to the Cb/Cr channels:
+///
+/// | Mode       | Cb / Cr H-shift | Cb / Cr V-shift | Cb/Cr sample density |
+/// |------------|-----------------|-----------------|----------------------|
+/// | `Full444`  | 0               | 0               | full resolution      |
+/// | `Sub422`   | 1               | 0               | half horizontal      |
+/// | `Sub420`   | 1               | 1               | quarter (H+V halved) |
+/// | `Sub440`   | 0               | 1               | half vertical        |
+///
+/// # Current status (chunk 1)
+///
+/// **API surface only.** Only [`ChromaSubsampling::Full444`] (the
+/// default) is currently honoured end-to-end. Setting any other mode
+/// causes the encoder to return [`EncodeError::InvalidConfig`] with a
+/// message explaining the JXL spec constraint that ties chroma
+/// subsampling to `ColorTransform::kYCbCr` (libjxl
+/// `enc_frame.cc:373-387`) — and our VarDCT pipeline currently emits
+/// `ColorTransform::kXYB`, which forbids non-4:4:4 chroma per the JXL
+/// codestream spec.
+///
+/// Real chroma-downsampled encoding (chunk 2+) needs:
+///
+/// 1. A switchable colour pipeline (XYB → YCbCr selection per frame).
+/// 2. Box-filter downsample of Cb/Cr before VarDCT.
+/// 3. `FrameHeader::do_ycbcr=true` + `jpeg_upsampling=[hs,0,vs]` wire format
+///    — the existing [`crate::headers::frame_header::FrameHeader`] field is
+///    already in place from JPEG-transcode plumbing.
+/// 4. Decoder-side upsampling verification across djxl / jxl-rs / jxl-oxide.
+///
+/// See [issue #47](https://github.com/imazen/jxl-encoder/issues/47) for
+/// the multi-chunk implementation plan.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub enum ChromaSubsampling {
+    /// **Default.** Full-resolution chroma (4:4:4). Y, Cb, Cr each sampled
+    /// at every pixel. Largest files; highest chroma fidelity. The only
+    /// mode currently honoured by the encoder.
+    #[default]
+    Full444,
+    /// 4:2:2 — chroma halved horizontally, full vertical.
+    /// (Cb/Cr H-shift = 1, V-shift = 0.)
+    Sub422,
+    /// 4:2:0 — chroma halved both horizontally and vertically.
+    /// (Cb/Cr H-shift = 1, V-shift = 1.) The classic JPEG default.
+    Sub420,
+    /// 4:4:0 — chroma halved vertically, full horizontal.
+    /// (Cb/Cr H-shift = 0, V-shift = 1.) Rare in practice.
+    Sub440,
+}
+
+impl ChromaSubsampling {
+    /// Returns the per-channel horizontal shift in libjxl channel order
+    /// (Y=index 1, Cb=index 0, Cr=index 2). Bit pattern matches libjxl
+    /// `YCbCrChromaSubsampling::kHShift` indexed by `channel_mode_`.
+    ///
+    /// All modes return `0` for the Y channel (Y is never subsampled in
+    /// JXL — only Cb/Cr can be).
+    pub const fn h_shifts(self) -> [u8; 3] {
+        match self {
+            // Order is (Cb, Y, Cr) — matches FrameHeader.jpeg_upsampling layout.
+            Self::Full444 => [0, 0, 0],
+            Self::Sub422 => [1, 0, 1],
+            Self::Sub420 => [1, 0, 1],
+            Self::Sub440 => [0, 0, 0],
+        }
+    }
+
+    /// Returns the per-channel vertical shift. See [`Self::h_shifts`] for
+    /// channel ordering.
+    pub const fn v_shifts(self) -> [u8; 3] {
+        match self {
+            Self::Full444 => [0, 0, 0],
+            Self::Sub422 => [0, 0, 0],
+            Self::Sub420 => [1, 0, 1],
+            Self::Sub440 => [1, 0, 1],
+        }
+    }
+
+    /// Returns `true` when this mode is full-resolution chroma (4:4:4).
+    pub const fn is_full(self) -> bool {
+        matches!(self, Self::Full444)
+    }
+
+    /// Short tag string used in error messages and logs: `"4:4:4"`,
+    /// `"4:2:2"`, `"4:2:0"`, `"4:4:0"`.
+    pub const fn tag(self) -> &'static str {
+        match self {
+            Self::Full444 => "4:4:4",
+            Self::Sub422 => "4:2:2",
+            Self::Sub420 => "4:2:0",
+            Self::Sub440 => "4:4:0",
+        }
+    }
+}
+
 // ── LossyConfig ─────────────────────────────────────────────────────────────
 
 /// Lossy (VarDCT) encoding configuration.
@@ -2419,6 +2517,13 @@ pub struct LossyConfig {
     /// default upsampling for the active `with_resampling` factor.
     /// See [`Self::with_upsampling_mode`].
     upsampling_mode: Option<i32>,
+    /// Chroma subsampling mode (A1 audit "VarDCT cost model" OUT item,
+    /// chunk 1 of issue #47). Default [`ChromaSubsampling::Full444`].
+    /// Only `Full444` is end-to-end honoured in chunk 1; any other
+    /// value triggers an [`EncodeError::InvalidConfig`] from the lossy
+    /// encode path. See the [`ChromaSubsampling`] doc for the
+    /// implementation roadmap.
+    chroma_subsampling: ChromaSubsampling,
 }
 
 /// Policy for what to do if the encoder finds non-finite (NaN / ±Inf)
@@ -2507,6 +2612,7 @@ impl LossyConfig {
             center_x: None,
             center_y: None,
             upsampling_mode: None,
+            chroma_subsampling: ChromaSubsampling::Full444,
         }
     }
 
@@ -2644,6 +2750,10 @@ impl LossyConfig {
         new.center_x = self.center_x;
         new.center_y = self.center_y;
         new.upsampling_mode = self.upsampling_mode;
+        // Chroma subsampling is opt-in and never effort-derived. Carry
+        // it across `with_effort` so `LossyConfig::new(d).with_chroma_subsampling(...).with_effort(e)`
+        // is order-independent (issue #47 chunk 1).
+        new.chroma_subsampling = self.chroma_subsampling;
         // If group_order was set to 1 (center-first), keep center_first
         // wired through with_effort too.
         if matches!(self.group_order, Some(1)) {
@@ -3252,6 +3362,39 @@ impl LossyConfig {
     /// Currently-set upsampling mode (or `None` if unset).
     pub fn upsampling_mode(&self) -> Option<i32> {
         self.upsampling_mode
+    }
+
+    /// Set the chroma subsampling mode (A1 audit "VarDCT cost model"
+    /// OUT item, chunk 1 of issue #47). Defaults to
+    /// [`ChromaSubsampling::Full444`] (4:4:4).
+    ///
+    /// # Current status (chunk 1)
+    ///
+    /// API surface only. Only [`ChromaSubsampling::Full444`] is currently
+    /// honoured end-to-end. Setting any other mode causes [`Self::encode`]
+    /// / [`Self::encode_into`] / [`Self::encode_to`] to return
+    /// [`EncodeError::InvalidConfig`] with a message that explains the
+    /// JXL spec constraint (chroma subsampling is only valid with
+    /// `ColorTransform::kYCbCr`; our VarDCT pipeline currently emits
+    /// `ColorTransform::kXYB`, see libjxl `enc_frame.cc:373-387`).
+    ///
+    /// The full implementation (chunks 2+) wires:
+    /// 1. YCbCr colour pipeline selection per frame.
+    /// 2. Box-filter chroma downsample before VarDCT.
+    /// 3. `FrameHeader.do_ycbcr=true` + `jpeg_upsampling` plumbing
+    ///    (header field is already in place from JPEG-transcode work).
+    /// 4. Decoder roundtrip across djxl / jxl-rs / jxl-oxide.
+    ///
+    /// See [`ChromaSubsampling`] for the per-mode H/V shift table.
+    pub fn with_chroma_subsampling(mut self, mode: ChromaSubsampling) -> Self {
+        self.chroma_subsampling = mode;
+        self
+    }
+
+    /// Currently-set chroma subsampling mode. Defaults to
+    /// [`ChromaSubsampling::Full444`].
+    pub fn chroma_subsampling(&self) -> ChromaSubsampling {
+        self.chroma_subsampling
     }
 
     /// Reorder AC groups in the multi-group TOC by concentric-square
@@ -5068,6 +5211,27 @@ impl<'a> EncodeRequest<'a> {
         pixels: &[u8],
         budget: &alloc::sync::Arc<crate::budget::MemoryBudget>,
     ) -> core::result::Result<(Vec<u8>, EncodeStats), EncodeError> {
+        // Chunk 1 of issue #47 — fail fast for any non-default chroma
+        // subsampling mode. Only `Full444` is end-to-end honoured. The
+        // JXL codestream spec ties chroma subsampling to
+        // `ColorTransform::kYCbCr` (libjxl `enc_frame.cc:373-387`); our
+        // VarDCT pipeline currently always emits `ColorTransform::kXYB`,
+        // so signaling 4:2:0 / 4:2:2 / 4:4:0 would produce an invalid
+        // bitstream. Real chroma-downsampled encoding requires a
+        // switchable colour pipeline (queued for chunks 2+).
+        if !cfg.chroma_subsampling.is_full() {
+            return Err(EncodeError::InvalidConfig {
+                message: format!(
+                    "chroma_subsampling = {} not yet implemented (chunk 1 \
+                     of #47 ships the API surface; chunks 2+ wire the \
+                     YCbCr colour pipeline + Cb/Cr downsample). \
+                     The JXL codestream spec only permits non-4:4:4 chroma \
+                     with ColorTransform::kYCbCr (libjxl enc_frame.cc:373-387). \
+                     Our VarDCT pipeline currently emits ColorTransform::kXYB.",
+                    cfg.chroma_subsampling.tag(),
+                ),
+            });
+        }
         let w = self.width as usize;
         let h = self.height as usize;
 
@@ -6351,6 +6515,22 @@ impl LossyEncoder {
         // counts, mutual exclusivity). Mirrors
         // `EncodeRequest::encode_inner`.
         self.cfg.validate()?;
+        // Chunk 1 of issue #47 — mirror the one-shot
+        // `encode_lossy` guard. Only `Full444` is end-to-end honoured;
+        // any other mode signals not-yet-implemented.
+        if !self.cfg.chroma_subsampling.is_full() {
+            return Err(EncodeError::InvalidConfig {
+                message: format!(
+                    "chroma_subsampling = {} not yet implemented (chunk 1 \
+                     of #47 ships the API surface; chunks 2+ wire the \
+                     YCbCr colour pipeline + Cb/Cr downsample). \
+                     The JXL codestream spec only permits non-4:4:4 chroma \
+                     with ColorTransform::kYCbCr (libjxl enc_frame.cc:373-387). \
+                     Our VarDCT pipeline currently emits ColorTransform::kXYB.",
+                    self.cfg.chroma_subsampling.tag(),
+                ),
+            });
+        }
         // Defensive caps on caller-supplied metadata buffers (mirrors
         // EncodeRequest::encode_inner).
         validate_metadata_sizes(

--- a/jxl-encoder/src/lib.rs
+++ b/jxl-encoder/src/lib.rs
@@ -52,10 +52,11 @@ pub mod convenience;
 
 // Re-export new API as primary
 pub use api::{
-    AnimationFrame, AnimationParams, At, BlendMode, EncodeError, EncodeMode, EncodeRequest,
-    EncodeResult, EncodeStats, EncoderMode, ImageMetadata, Limits, LosslessConfig, LosslessEncoder,
-    LossyConfig, LossyEncoder, Lz77Method, NonFiniteAction, PixelLayout, ProgressiveMode, Quality,
-    ResultAtExt, Stop, Unstoppable, at, calibrated_jxl_quality, quality_to_distance,
+    AnimationFrame, AnimationParams, At, BlendMode, ChromaSubsampling, EncodeError, EncodeMode,
+    EncodeRequest, EncodeResult, EncodeStats, EncoderMode, ImageMetadata, Limits, LosslessConfig,
+    LosslessEncoder, LossyConfig, LossyEncoder, Lz77Method, NonFiniteAction, PixelLayout,
+    ProgressiveMode, Quality, ResultAtExt, Stop, Unstoppable, at, calibrated_jxl_quality,
+    quality_to_distance,
 };
 // `EffortProfile` was re-exported at the crate root in 0.3.0; it is now an
 // **internal** type that drives the encoder's effort-derived decisions.

--- a/jxl-encoder/tests/chroma_subsampling_signal.rs
+++ b/jxl-encoder/tests/chroma_subsampling_signal.rs
@@ -1,0 +1,290 @@
+// Copyright (c) Imazen LLC and the JPEG XL Project Authors.
+// Licensed under AGPL-3.0-or-later. Commercial licenses at https://www.imazen.io/pricing
+
+//! Chunk 1 surface tests for [`ChromaSubsampling`].
+//!
+//! ## Scope
+//!
+//! Chunk 1 of issue #47 (A1 audit "VarDCT cost model" OUT item) ships:
+//!
+//! 1. The [`ChromaSubsampling`] enum (`Full444` / `Sub422` / `Sub420` / `Sub440`).
+//! 2. The [`LossyConfig::with_chroma_subsampling`] builder + matching getter.
+//! 3. A fast-fail guard in the lossy encode path that returns
+//!    [`EncodeError::InvalidConfig`] for any non-`Full444` value.
+//!
+//! Real chroma-downsampled encoding (Cb/Cr box-filter downsample,
+//! `ColorTransform::kYCbCr` selection per frame, `FrameHeader.do_ycbcr` +
+//! `jpeg_upsampling` wire format) is queued for chunks 2+.
+//!
+//! ## What this test asserts
+//!
+//! * `ChromaSubsampling::Full444` is the default (preserves the existing
+//!   bitstream — see the hash-lock sidecar for byte-identical proof).
+//! * The lossy encode succeeds at `Full444` and roundtrips via `jxl-rs`.
+//! * `Sub420` / `Sub422` / `Sub440` return `InvalidConfig` from
+//!   `encode()` — no bitstream is written.
+//! * Per-mode `h_shifts()` / `v_shifts()` / `is_full()` / `tag()` agree
+//!   with libjxl's `YCbCrChromaSubsampling` table (channel order is
+//!   `[Cb, Y, Cr]`; Y is never subsampled, only Cb/Cr).
+
+use jxl_encoder::{At, ChromaSubsampling, EncodeError, LossyConfig, PixelLayout};
+
+const W: usize = 64;
+const H: usize = 64;
+
+fn make_rgb_buffer() -> Vec<u8> {
+    let mut out = vec![0u8; W * H * 3];
+    for y in 0..H {
+        for x in 0..W {
+            let i = (y * W + x) * 3;
+            out[i] = ((x * 255) / W.max(1)) as u8;
+            out[i + 1] = ((y * 255) / H.max(1)) as u8;
+            out[i + 2] = (((x + y) * 255) / (W + H).max(1)) as u8;
+        }
+    }
+    out
+}
+
+#[test]
+fn default_is_full444() {
+    let cfg = LossyConfig::new(1.0);
+    assert_eq!(cfg.chroma_subsampling(), ChromaSubsampling::Full444);
+    assert!(cfg.chroma_subsampling().is_full());
+}
+
+#[test]
+fn enum_default_is_full444() {
+    assert_eq!(
+        ChromaSubsampling::default(),
+        ChromaSubsampling::Full444,
+        "ChromaSubsampling::Default must be Full444 — changing this would alter every \
+         existing LossyConfig bitstream produced without an explicit \
+         with_chroma_subsampling() call.",
+    );
+}
+
+#[test]
+fn h_v_shifts_match_libjxl_table() {
+    // Channel order is [Cb, Y, Cr] (matches FrameHeader.jpeg_upsampling
+    // layout in libjxl's frame_header.h).
+    //
+    //  | mode    | h_shifts        | v_shifts        |
+    //  |---------|-----------------|-----------------|
+    //  | Full444 | [0, 0, 0]       | [0, 0, 0]       |
+    //  | Sub422  | [1, 0, 1]       | [0, 0, 0]       |
+    //  | Sub420  | [1, 0, 1]       | [1, 0, 1]       |
+    //  | Sub440  | [0, 0, 0]       | [1, 0, 1]       |
+    assert_eq!(ChromaSubsampling::Full444.h_shifts(), [0, 0, 0]);
+    assert_eq!(ChromaSubsampling::Full444.v_shifts(), [0, 0, 0]);
+
+    assert_eq!(ChromaSubsampling::Sub422.h_shifts(), [1, 0, 1]);
+    assert_eq!(ChromaSubsampling::Sub422.v_shifts(), [0, 0, 0]);
+
+    assert_eq!(ChromaSubsampling::Sub420.h_shifts(), [1, 0, 1]);
+    assert_eq!(ChromaSubsampling::Sub420.v_shifts(), [1, 0, 1]);
+
+    assert_eq!(ChromaSubsampling::Sub440.h_shifts(), [0, 0, 0]);
+    assert_eq!(ChromaSubsampling::Sub440.v_shifts(), [1, 0, 1]);
+
+    // Y (index 1) is never subsampled in any mode.
+    for mode in [
+        ChromaSubsampling::Full444,
+        ChromaSubsampling::Sub422,
+        ChromaSubsampling::Sub420,
+        ChromaSubsampling::Sub440,
+    ] {
+        assert_eq!(mode.h_shifts()[1], 0, "Y h-shift must be 0 for {mode:?}");
+        assert_eq!(mode.v_shifts()[1], 0, "Y v-shift must be 0 for {mode:?}");
+    }
+}
+
+#[test]
+fn is_full_only_for_full444() {
+    assert!(ChromaSubsampling::Full444.is_full());
+    assert!(!ChromaSubsampling::Sub422.is_full());
+    assert!(!ChromaSubsampling::Sub420.is_full());
+    assert!(!ChromaSubsampling::Sub440.is_full());
+}
+
+#[test]
+fn tag_strings_match_industry_convention() {
+    assert_eq!(ChromaSubsampling::Full444.tag(), "4:4:4");
+    assert_eq!(ChromaSubsampling::Sub422.tag(), "4:2:2");
+    assert_eq!(ChromaSubsampling::Sub420.tag(), "4:2:0");
+    assert_eq!(ChromaSubsampling::Sub440.tag(), "4:4:0");
+}
+
+#[test]
+fn with_chroma_subsampling_round_trips_on_config() {
+    for mode in [
+        ChromaSubsampling::Full444,
+        ChromaSubsampling::Sub422,
+        ChromaSubsampling::Sub420,
+        ChromaSubsampling::Sub440,
+    ] {
+        let cfg = LossyConfig::new(1.0).with_chroma_subsampling(mode);
+        assert_eq!(cfg.chroma_subsampling(), mode);
+    }
+}
+
+/// Regression: `with_effort()` rebuilds the [`LossyConfig`] via
+/// `Self::new_with_effort()`, which resets every field that isn't
+/// explicitly preserved. Without the carry-over in `with_effort`, the
+/// builder chain
+/// `LossyConfig::new(d).with_chroma_subsampling(Sub420).with_effort(5)`
+/// would silently revert to `Full444`, hiding the encoder's chunk-1
+/// `InvalidConfig` guard. This test pins the order independence so a
+/// future refactor of `with_effort` can't lose the field again.
+#[test]
+fn with_chroma_subsampling_survives_with_effort() {
+    let cfg = LossyConfig::new(1.0)
+        .with_chroma_subsampling(ChromaSubsampling::Sub420)
+        .with_effort(5);
+    assert_eq!(
+        cfg.chroma_subsampling(),
+        ChromaSubsampling::Sub420,
+        "with_effort() must preserve chroma_subsampling (see api.rs with_effort()).",
+    );
+
+    // Reverse order — also must end up Sub420.
+    let cfg = LossyConfig::new(1.0)
+        .with_effort(5)
+        .with_chroma_subsampling(ChromaSubsampling::Sub420);
+    assert_eq!(cfg.chroma_subsampling(), ChromaSubsampling::Sub420);
+}
+
+#[test]
+fn full444_encodes_and_roundtrips_via_jxl_rs() {
+    let rgb = make_rgb_buffer();
+    let bytes = LossyConfig::new(1.0)
+        .with_chroma_subsampling(ChromaSubsampling::Full444)
+        .with_effort(5)
+        .encode_request(W as u32, H as u32, PixelLayout::Rgb8)
+        .encode(&rgb)
+        .expect("Full444 (default) must encode 64x64 RGB at d=1.0 e=5");
+
+    assert!(bytes.len() > 32, "bitstream suspiciously small");
+    assert_eq!(&bytes[..2], &[0xFF, 0x0A], "missing JXL signature");
+
+    // jxl-rs roundtrip — proves the bitstream is well-formed.
+    decode_via_jxl_rs(&bytes);
+}
+
+#[test]
+fn sub420_returns_invalid_config_in_chunk1() {
+    let rgb = make_rgb_buffer();
+    let err = LossyConfig::new(1.0)
+        .with_chroma_subsampling(ChromaSubsampling::Sub420)
+        .with_effort(5)
+        .encode_request(W as u32, H as u32, PixelLayout::Rgb8)
+        .encode(&rgb)
+        .expect_err("Sub420 must return InvalidConfig in chunk 1 (signal-only)");
+    assert_invalid_config_with_tag(&err, "4:2:0");
+}
+
+#[test]
+fn sub422_returns_invalid_config_in_chunk1() {
+    let rgb = make_rgb_buffer();
+    let err = LossyConfig::new(1.0)
+        .with_chroma_subsampling(ChromaSubsampling::Sub422)
+        .with_effort(5)
+        .encode_request(W as u32, H as u32, PixelLayout::Rgb8)
+        .encode(&rgb)
+        .expect_err("Sub422 must return InvalidConfig in chunk 1 (signal-only)");
+    assert_invalid_config_with_tag(&err, "4:2:2");
+}
+
+#[test]
+fn sub440_returns_invalid_config_in_chunk1() {
+    let rgb = make_rgb_buffer();
+    let err = LossyConfig::new(1.0)
+        .with_chroma_subsampling(ChromaSubsampling::Sub440)
+        .with_effort(5)
+        .encode_request(W as u32, H as u32, PixelLayout::Rgb8)
+        .encode(&rgb)
+        .expect_err("Sub440 must return InvalidConfig in chunk 1 (signal-only)");
+    assert_invalid_config_with_tag(&err, "4:4:0");
+}
+
+fn assert_invalid_config_with_tag(err: &At<EncodeError>, tag: &str) {
+    let inner: &EncodeError = err.as_ref();
+    let msg = format!("{inner}");
+    assert!(
+        msg.contains(tag),
+        "InvalidConfig message must name the chroma tag ({tag}); got: {msg}",
+    );
+    assert!(
+        msg.contains("not yet implemented") || msg.contains("chunk 1"),
+        "InvalidConfig message must mention chunk-1 status; got: {msg}",
+    );
+    match inner {
+        EncodeError::InvalidConfig { .. } => {}
+        other => panic!("expected EncodeError::InvalidConfig, got: {other:?}"),
+    }
+}
+
+fn decode_via_jxl_rs(data: &[u8]) {
+    use jxl::api::{
+        JxlColorType, JxlDataFormat, JxlDecoder, JxlDecoderOptions, JxlOutputBuffer,
+        JxlPixelFormat, ProcessingResult, states,
+    };
+    use jxl::image::{Image, Rect};
+
+    let mut input = data;
+    let options = JxlDecoderOptions::default();
+    let decoder = JxlDecoder::<states::Initialized>::new(options);
+
+    let mut decoder_init = decoder;
+    let mut decoder = loop {
+        match decoder_init.process(&mut input) {
+            Ok(ProcessingResult::Complete { result }) => break result,
+            Ok(ProcessingResult::NeedsMoreInput { fallback, .. }) => {
+                decoder_init = fallback;
+            }
+            Err(e) => panic!("jxl-rs header decode error: {e:?}"),
+        }
+    };
+
+    let basic_info = decoder.basic_info().clone();
+    let (width, height) = basic_info.size;
+    assert_eq!(width as usize, W);
+    assert_eq!(height as usize, H);
+    let num_extras = basic_info.extra_channels.len();
+
+    decoder.set_pixel_format(JxlPixelFormat {
+        color_type: JxlColorType::Rgb,
+        color_data_format: Some(JxlDataFormat::U8 { bit_depth: 8 }),
+        extra_channel_format: vec![None; num_extras],
+    });
+
+    let mut decoder_frame = loop {
+        match decoder.process(&mut input) {
+            Ok(ProcessingResult::Complete { result }) => break result,
+            Ok(ProcessingResult::NeedsMoreInput { fallback, .. }) => {
+                decoder = fallback;
+            }
+            Err(e) => panic!("jxl-rs frame info error: {e:?}"),
+        }
+    };
+
+    let channels = 3;
+    let mut output_image = Image::<u8>::new((width * channels, height)).expect("alloc rgb8 buffer");
+    let mut buffers = vec![JxlOutputBuffer::from_image_rect_mut(
+        output_image
+            .get_rect_mut(Rect {
+                origin: (0, 0),
+                size: (width * channels, height),
+            })
+            .into_raw(),
+    )];
+
+    loop {
+        match decoder_frame.process(&mut input, &mut buffers) {
+            Ok(ProcessingResult::Complete { .. }) => break,
+            Ok(ProcessingResult::NeedsMoreInput { fallback, .. }) => {
+                decoder_frame = fallback;
+            }
+            Err(e) => panic!("jxl-rs frame decode error: {e:?}"),
+        }
+    }
+}


### PR DESCRIPTION
## Summary

A1 audit "VarDCT cost model" OUT-item — smallest viable POC for chroma 4:2:0 / 4:2:2 / 4:4:0. Real Cb/Cr downsampling + YCbCr colour-pipeline switch are queued for chunks 2+.

- `ChromaSubsampling { Full444, Sub422, Sub420, Sub440 }` enum mirroring libjxl `YCbCrChromaSubsampling` (`frame_header.h:81`) with `h_shifts()` / `v_shifts()` / `is_full()` / `tag()` accessors in libjxl `[Cb, Y, Cr]` channel order.
- `LossyConfig::with_chroma_subsampling(mode)` builder + `chroma_subsampling()` getter. Default `Full444` keeps existing bitstreams byte-identical.
- Field preserved across `with_effort()` (pinned by `with_chroma_subsampling_survives_with_effort` regression test).
- One-shot `encode_lossy` + streaming `LossyEncoder::finish` both fast-fail with `EncodeError::InvalidConfig` for any non-`Full444` mode, naming the spec constraint (chroma subsampling only valid with `ColorTransform::kYCbCr`; our VarDCT emits `ColorTransform::kXYB`, libjxl `enc_frame.cc:373-387`).

## Test plan

- [x] `cargo test -p jxl-encoder --test chroma_subsampling_signal` — 11/11 pass
- [x] `cargo test -p jxl-encoder --test hash_lock_features` — 36/36 byte-identical
- [x] `cargo check -p jxl-encoder --all-features` clean
- [x] `rustfmt --check` clean on touched files
- [x] jxl-rs roundtrip on `Full444` succeeds

## Roadmap (chunk 2+)

1. Switchable colour pipeline (XYB → YCbCr selection per frame)
2. Box-filter Cb/Cr downsample before VarDCT
3. `FrameHeader.do_ycbcr=true` + `jpeg_upsampling=[hs, 0, vs]` wire format (header field already in place from JPEG-transcode plumbing)
4. Decoder roundtrip across djxl / jxl-rs / jxl-oxide