### PR TITLE
Harden the JPEG-transcode path: pixel cap + MemoryBudget + cancellation (closes #77 P1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,29 @@
   `EncodeRequest` / streaming encoders / `PixelLayout` / `EncodeError` /
   `Limits` / `ImageMetadata` / `EncoderStrategy`). Tracking: #76.
 
+### Security
+- **Configurable pre-flight pixel cap on the untrusted JPEG-transcode SOF
+  (#77 / #78).** The JPEG-reconstruction/transcode path (`read_jpeg` /
+  `encode_jpeg_transcode*`) parses untrusted bytes and sizes per-block
+  `i16` coefficient buffers from the SOF dimensions, but builds no
+  `MemoryBudget`. Since JPEG dims are `u16` (≤ 65535 each), a ~12-byte
+  crafted SOF could advertise up to ~4.3 Gpx and force a multi-gigabyte
+  allocation. `parse_sof_marker` now rejects `width × height` over a cap
+  **immediately after reading the SOF dimensions, before any coefficient
+  allocation**. The cap is **configurable**: it defaults to the new
+  `Limits::DEFAULT_MAX_JPEG_TRANSCODE_PIXELS` (120 MP — admits 108 MP
+  phone photos) and is overridden through `Limits::max_pixels`, attached
+  to the transcode path via the new `LosslessConfig::with_limits` /
+  `limits()` (a trusted batch caller raises it or passes
+  `with_max_pixels(u64::MAX)` to opt out; a hostile-input proxy tightens
+  it). `read_jpeg` gains a `max_pixels: Option<u64>` parameter (`None`
+  applies the default). Byte-identical for all real input: the cap only
+  fires above the configured limit, and the JBRD byte-exact transcode
+  conformance (28 `tests/it/jpeg_reencoding.rs` fixtures, all < 120 MP)
+  still passes. Pixel-path entry points are unchanged. Follow-ups (full
+  `MemoryBudget` threading through `jpeg/encode.rs`, the PreserveJxl
+  `encode_jpeg_recompress_*` free functions) remain tracked in #77.
+
 ### Added
 - **Calibrated peak-memory estimation (`heuristics` module + per-config
   `estimate_encode`).** New `jxl_encoder::heuristics::EncodeEstimate`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -93,17 +93,31 @@
   `test_jpeg_recompress_limits_and_stop`; the 14 byte-exact JBRD reconstruction
   / transcode-roundtrip gates still pass. This closes the remaining #77 P1
   follow-ups.
-- **Runtime-configurable fallible allocation (`Limits::with_fallible_alloc`).**
-  The choice between fast `vec!`/`Vec::with_capacity` (a single `calloc`,
-  trusted input) and graceful `try_reserve` (returns `Error::OutOfMemory`
-  instead of aborting on a genuine OOM, untrusted input) is now a **runtime**
-  toggle on `Limits` rather than a compile-time decision — the JPEG-transcode
-  coefficient + working-set allocations select the mechanism from the
-  budget's policy (`MemoryBudget::is_fallible`). Defaults to infallible
-  (fast); a hostile-input proxy opts into `with_fallible_alloc(true)`. The
-  toggle changes the allocation *mechanism* only, never the output bytes —
-  pinned by `test_jpeg_transcode_fallible_alloc_toggle` (both modes
-  byte-identical on success, both honour the budget under a tight cap).
+- **Runtime-configurable fallible allocation (`Limits::with_fallible_alloc`),
+  wired through ALL standard encodes.** The choice between fast
+  `vec!`/`Vec::with_capacity` (a single `calloc`, trusted input) and graceful
+  `try_reserve` (returns `Error::OutOfMemory` instead of aborting on a genuine
+  OOM, untrusted input) is a **runtime** toggle on `Limits` rather than a
+  compile-time decision. All five standard-encode budget constructions
+  (one-shot + streaming + animation, lossy + lossless) now build the
+  `MemoryBudget` via `with_alloc_policy(cap, fallible)` instead of the
+  infallible `MemoryBudget::new`, and the **dimension-driven** allocations
+  select their mechanism from the budget policy (`MemoryBudget::is_fallible`):
+  lossy output / DC+AC group BitWriters (`BitWriter::with_capacity_policy`),
+  the flat quant + masking fields (`vec_with_capacity_policy`), the XYB planes
+  (already), and the lossless modular channel buffers (the dominant lossless
+  allocation, via `try_alloc_zeroed_permanent`); the JPEG-transcode path was
+  the first consumer. Defaults to infallible (fast); a hostile-input proxy
+  opts into `with_fallible_alloc(true)`. Byte-identical (mechanism only) on
+  success — pinned by `test_standard_encode_fallible_alloc_toggle` (lossy +
+  lossless) and `test_jpeg_transcode_fallible_alloc_toggle`, both asserting
+  byte-identity across modes and budget rejection under a tight cap. Tiny
+  fixed-size allocations and the modular tree-learning sample-collection
+  working set (already budget-*capacity*-bounded via the `*_with_budget`
+  gather/compute variants, but grown through hot-path `Vec::reserve` in
+  budget-less sample structs) intentionally stay infallible — wiring those
+  would be a hot-path method-signature refactor with perf risk and little
+  fallibility benefit.
 - **Checked SOF-derived overflow in the JPEG coefficient parser (#77 item 3).**
   `extract_coefficients_zenjpeg` computed `width_in_blocks * height_in_blocks`
   (and `* 64`) as unchecked `u32` / `usize` on attacker-controlled SOF dims —

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,21 @@
   still passes. Pixel-path entry points are unchanged. Follow-ups (full
   `MemoryBudget` threading through `jpeg/encode.rs`, the PreserveJxl
   `encode_jpeg_recompress_*` free functions) remain tracked in #77.
+- **Cooperative cancellation on the JPEG-transcode path (#77 item 2).**
+  The transcode path previously ignored cancellation entirely — `parse.rs`
+  hardcoded an `Unstoppable` token into the zenjpeg coefficient decode and
+  the JXL entropy phase had no `Stop` at all, so a server could not abort a
+  slow transcode of an oversized upload. New
+  `LosslessConfig::encode_jpeg_transcode_with_stop` /
+  `encode_jpeg_transcode_codestream_with_stop` accept an `enough::Stop` and
+  poll it at coarse boundaries — entry, the zenjpeg decode, and per-group /
+  pre-entropy during encoding — returning `EncodeError::Cancelled` (mapped
+  from the new `JpegError::Cancelled` / the existing `Error::Cancelled`).
+  Byte-identical to the non-stop entry points on the success path: the polls
+  are skipped when no token is attached and are no-ops under an `Unstoppable`
+  token (verified by `test_jpeg_transcode_cancellation`). Mirrors #81's
+  VarDCT-path cancellation. Encode-phase `MemoryBudget` and a `Stop` on the
+  PreserveJxl `encode_jpeg_recompress_*` free functions remain #77 follow-ups.
 
 ### Added
 - **Calibrated peak-memory estimation (`heuristics` module + per-config

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,30 +57,55 @@
   `Limits::max_memory_bytes` (the lossless 8 GiB default when unset) and
   threads it through both phases: the per-component `i16` coefficient buffers
   are reserved before allocation in `read_jpeg_with_stop` (the largest
-  attacker-controlled decode buffer), and a conservative encode working-set
-  estimate (~32 B/DCT-coefficient: i32 quant arrays + the AC token stream
-  held twice during clustering + output) is reserved up front in
-  `encode_jpeg_to_jxl_inner` so an oversized frame is rejected
-  (`EncodeError::LimitExceeded`, via the new `JpegError::ResourceLimit`)
-  **before** the expensive token collection / histogram clustering. Default-on
-  for every transcode entry point (`encode_jpeg_transcode*`), like the pixel
-  path. The PreserveJxl `encode_jpeg_recompress_{,auto_,planar_}codestream`
-  free functions gain `limits: Option<&Limits>` + `stop: Option<&dyn Stop>`
-  parameters (the encode estimate is an RAII reservation released between the
-  lossless-floor and lossy encodes so their working sets don't double-count).
-  Byte-identical for all real input under the default cap. Verified by
-  `test_jpeg_transcode_memory_budget` + `test_jpeg_recompress_limits_and_stop`;
-  the 14 byte-exact JBRD reconstruction / transcode-roundtrip gates still pass.
-  This closes the remaining #77 P1 follow-ups.
+  attacker-controlled decode buffer), and a **measured** encode working-set
+  estimate is reserved as an RAII guard up front in `encode_jpeg_to_jxl_inner`
+  so an oversized frame is rejected (`EncodeError::LimitExceeded`, via the new
+  `JpegError::ResourceLimit`) **before** the expensive token collection /
+  histogram clustering. The per-coefficient constant is `heaptrack`-calibrated,
+  not guessed: on real photos the transcode peak heap is ≤ 44.1 B/DCT-coeff
+  (wrenches, the worst of 4 corpus images; effort-independent, e7 == e9), so
+  `ENCODE_BYTES_PER_COEFF = 56` carries a ~1.3× margin over the worst measured
+  cell (provenance `benchmarks/transcode_mem_2026-06-18.tsv`, harness
+  `examples/transcode_mem_probe.rs`). An earlier per-site reservation scheme
+  under-counted (≈ 46 MB reserved vs 82 MB real peak on wrenches — the diffuse
+  `AccumulatedAnsData` clustering allocations were unbudgeted), which is why the
+  whole-working-set measured estimate replaced it. Default-on for every
+  transcode entry point (`encode_jpeg_transcode*`), like the pixel path. The
+  PreserveJxl `encode_jpeg_recompress_{,auto_,planar_}codestream` free functions
+  gain `limits: Option<&Limits>` + `stop: Option<&dyn Stop>` parameters (the
+  encode estimate is an RAII reservation released between the lossless-floor and
+  lossy encodes so their working sets don't double-count), and a budget
+  rejection on their decode side now maps to `Error::AllocationLimit`
+  (reconstructed from the owned budget's live `cap`/`used`) instead of being
+  funnelled into a misleading `InvalidInput`. Byte-identical for all real input
+  under the default cap. Verified by `test_jpeg_transcode_memory_budget` +
+  `test_jpeg_recompress_limits_and_stop`; the 14 byte-exact JBRD reconstruction
+  / transcode-roundtrip gates still pass. This closes the remaining #77 P1
+  follow-ups.
+- **Runtime-configurable fallible allocation (`Limits::with_fallible_alloc`).**
+  The choice between fast `vec!`/`Vec::with_capacity` (a single `calloc`,
+  trusted input) and graceful `try_reserve` (returns `Error::OutOfMemory`
+  instead of aborting on a genuine OOM, untrusted input) is now a **runtime**
+  toggle on `Limits` rather than a compile-time decision — the JPEG-transcode
+  coefficient + working-set allocations select the mechanism from the
+  budget's policy (`MemoryBudget::is_fallible`). Defaults to infallible
+  (fast); a hostile-input proxy opts into `with_fallible_alloc(true)`. The
+  toggle changes the allocation *mechanism* only, never the output bytes —
+  pinned by `test_jpeg_transcode_fallible_alloc_toggle` (both modes
+  byte-identical on success, both honour the budget under a tight cap).
 - **Checked SOF-derived overflow in the JPEG coefficient parser (#77 item 3).**
   `extract_coefficients_zenjpeg` computed `width_in_blocks * height_in_blocks`
   (and `* 64`) as unchecked `u32` / `usize` on attacker-controlled SOF dims —
   a crafted SOF could wrap the count, size `comp.coeffs` short, and make the
   zigzag copy read out of bounds. Now computed with checked `usize` arithmetic
-  (a malformed SOF errors), and the SOF-derived count is reconciled against
-  zenjpeg's actually-decoded coefficient length before the copy. The `jbrd.rs`
-  `write_u32_jbrd` `unreachable!` on the write path is replaced with a typed
-  `Error::InvalidInput`.
+  via the pure `checked_coeff_len` helper (a malformed SOF errors; the wrap only
+  bites 32-bit `usize` — i686 / wasm32 — where `*_in_blocks * 64` overflows at
+  the largest representable JPEG), and the SOF-derived count is reconciled
+  against zenjpeg's actually-decoded coefficient length before the copy. The
+  `jbrd.rs` `write_u32_jbrd` `unreachable!` on the write path is replaced with a
+  typed `Error::InvalidInput`. Both guards are pinned host-independently by
+  `checked_coeff_len_guards_overflow` (parse) and
+  `write_u32_jbrd_no_selector_match_is_typed_error` (jbrd).
 
 ### Fixed
 - **Cooperative cancellation now aborts on every VarDCT entropy path (#77
@@ -92,6 +117,18 @@
   checkpoint at the top of `encode_inner` that fires before any encode work on
   **all** paths; the per-group checkpoints remain for mid-encode responsiveness.
   Byte-identical under `Unstoppable` / `None`.
+- **Full cross-codec cancellation coverage — butteraugli loop + modular
+  lossless (#77 cancellation follow-up).** The cooperative `Stop` token is now
+  threaded through the two heaviest non-JPEG encode paths that previously could
+  not be aborted mid-work: the effort-8+ butteraugli quantization loop
+  (`butteraugli_refine_quant_field*`, polled per iteration) and the modular
+  (lossless) `FrameEncoder` — `encode_modular` / `encode_modular_with_patches` /
+  the multi-group inner + lossy-palette + squeeze + squeeze-with-tree variants,
+  polled at the encode boundary and again before each heavy per-group
+  `parallel_map_result` (after tree learning). Coarse-grained (boundary /
+  per-iteration, not per-coefficient) and byte-identical under `Unstoppable` /
+  `None`, verified by `test_stop_cancels_lossy_e8_buttloop` +
+  `test_stop_cancels_lossless_multigroup`.
 
 ### Added
 - **Calibrated peak-memory estimation (`heuristics` module + per-config

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -103,8 +103,8 @@
   `MemoryBudget` via `with_alloc_policy(cap, fallible)` instead of the
   infallible `MemoryBudget::new`, and the **dimension-driven** allocations
   select their mechanism from the budget policy (`MemoryBudget::is_fallible`):
-  lossy output / DC+AC group BitWriters (`BitWriter::with_capacity_policy`),
-  the flat quant + masking fields (`vec_with_capacity_policy`), the XYB planes
+  lossy output / DC+AC group BitWriters (`BitWriter::with_capacity_fallible`),
+  the flat quant + masking fields (`vec_with_capacity_fallible`), the XYB planes
   (already), and the lossless modular channel buffers (the dominant lossless
   allocation, via `try_alloc_zeroed_permanent`); the JPEG-transcode path was
   the first consumer. Defaults to infallible (fast); a hostile-input proxy

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,11 @@
   intentional public API (`LossyConfig` / `LosslessConfig` /
   `EncodeRequest` / streaming encoders / `PixelLayout` / `EncodeError` /
   `Limits` / `ImageMetadata` / `EncoderStrategy`). Tracking: #76.
+- **`jpeg::read_jpeg` signature** is now
+  `read_jpeg(data, limits: Option<&Limits>, stop: Option<&dyn Stop>)`
+  (was the interim `(data, max_pixels: Option<u64>)`). `Limits` bundles the
+  pixel cap + memory budget + fallible policy; `Stop` cancels — the same
+  pair the encode side takes. Approved API change (#77 / #78).
 
 ### Security
 - **Configurable pre-flight pixel cap on the untrusted JPEG-transcode SOF
@@ -31,13 +36,19 @@
   to the transcode path via the new `LosslessConfig::with_limits` /
   `limits()` (a trusted batch caller raises it or passes
   `with_max_pixels(u64::MAX)` to opt out; a hostile-input proxy tightens
-  it). `read_jpeg` gains a `max_pixels: Option<u64>` parameter (`None`
-  applies the default). Byte-identical for all real input: the cap only
-  fires above the configured limit, and the JBRD byte-exact transcode
-  conformance (28 `tests/it/jpeg_reencoding.rs` fixtures, all < 120 MP)
-  still passes. Pixel-path entry points are unchanged. (The full
-  `MemoryBudget` threading and the `encode_jpeg_recompress_*` limits — the
-  former #77 follow-ups — are now done; see the budget bullet below.)
+  it). The public `read_jpeg` now takes
+  `(data, limits: Option<&Limits>, stop: Option<&dyn Stop>)` — `Limits`
+  bundles the pixel cap + memory budget + fallible policy and `Stop`
+  cancels, matching the encode-side `with_limits` / `with_stop` pattern
+  (both `None` = the historical pixel-cap-only, zero-overhead parse). This
+  replaces the interim `max_pixels: Option<u64>` parameter (an approved
+  public-API change — see QUEUED BREAKING CHANGES above). Byte-
+  identical for all real input: the cap only fires above the configured
+  limit, and the JBRD byte-exact transcode conformance (28
+  `tests/it/jpeg_reencoding.rs` fixtures, all < 120 MP) still passes.
+  Pixel-path entry points are unchanged. (The full `MemoryBudget` threading
+  and the `encode_jpeg_recompress_*` limits — the former #77 follow-ups —
+  are now done; see the budget bullet below.)
 - **Cooperative cancellation on the JPEG-transcode path (#77 item 2).**
   The transcode path previously ignored cancellation entirely — `parse.rs`
   hardcoded an `Unstoppable` token into the zenjpeg coefficient decode and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,9 +35,9 @@
   applies the default). Byte-identical for all real input: the cap only
   fires above the configured limit, and the JBRD byte-exact transcode
   conformance (28 `tests/it/jpeg_reencoding.rs` fixtures, all < 120 MP)
-  still passes. Pixel-path entry points are unchanged. Follow-ups (full
-  `MemoryBudget` threading through `jpeg/encode.rs`, the PreserveJxl
-  `encode_jpeg_recompress_*` free functions) remain tracked in #77.
+  still passes. Pixel-path entry points are unchanged. (The full
+  `MemoryBudget` threading and the `encode_jpeg_recompress_*` limits — the
+  former #77 follow-ups — are now done; see the budget bullet below.)
 - **Cooperative cancellation on the JPEG-transcode path (#77 item 2).**
   The transcode path previously ignored cancellation entirely — `parse.rs`
   hardcoded an `Unstoppable` token into the zenjpeg coefficient decode and
@@ -51,8 +51,47 @@
   Byte-identical to the non-stop entry points on the success path: the polls
   are skipped when no token is attached and are no-ops under an `Unstoppable`
   token (verified by `test_jpeg_transcode_cancellation`). Mirrors #81's
-  VarDCT-path cancellation. Encode-phase `MemoryBudget` and a `Stop` on the
-  PreserveJxl `encode_jpeg_recompress_*` free functions remain #77 follow-ups.
+  VarDCT-path cancellation.
+- **Per-encode `MemoryBudget` on the JPEG-transcode + PreserveJxl paths
+  (#77 item 1, full).** The transcode path now builds a `MemoryBudget` from
+  `Limits::max_memory_bytes` (the lossless 8 GiB default when unset) and
+  threads it through both phases: the per-component `i16` coefficient buffers
+  are reserved before allocation in `read_jpeg_with_stop` (the largest
+  attacker-controlled decode buffer), and a conservative encode working-set
+  estimate (~32 B/DCT-coefficient: i32 quant arrays + the AC token stream
+  held twice during clustering + output) is reserved up front in
+  `encode_jpeg_to_jxl_inner` so an oversized frame is rejected
+  (`EncodeError::LimitExceeded`, via the new `JpegError::ResourceLimit`)
+  **before** the expensive token collection / histogram clustering. Default-on
+  for every transcode entry point (`encode_jpeg_transcode*`), like the pixel
+  path. The PreserveJxl `encode_jpeg_recompress_{,auto_,planar_}codestream`
+  free functions gain `limits: Option<&Limits>` + `stop: Option<&dyn Stop>`
+  parameters (the encode estimate is an RAII reservation released between the
+  lossless-floor and lossy encodes so their working sets don't double-count).
+  Byte-identical for all real input under the default cap. Verified by
+  `test_jpeg_transcode_memory_budget` + `test_jpeg_recompress_limits_and_stop`;
+  the 14 byte-exact JBRD reconstruction / transcode-roundtrip gates still pass.
+  This closes the remaining #77 P1 follow-ups.
+- **Checked SOF-derived overflow in the JPEG coefficient parser (#77 item 3).**
+  `extract_coefficients_zenjpeg` computed `width_in_blocks * height_in_blocks`
+  (and `* 64`) as unchecked `u32` / `usize` on attacker-controlled SOF dims —
+  a crafted SOF could wrap the count, size `comp.coeffs` short, and make the
+  zigzag copy read out of bounds. Now computed with checked `usize` arithmetic
+  (a malformed SOF errors), and the SOF-derived count is reconciled against
+  zenjpeg's actually-decoded coefficient length before the copy. The `jbrd.rs`
+  `write_u32_jbrd` `unreachable!` on the write path is replaced with a typed
+  `Error::InvalidInput`.
+
+### Fixed
+- **Cooperative cancellation now aborts on every VarDCT entropy path (#77
+  item 2 / #81).** `#81` wired per-DC/AC-group `Stop` checkpoints into
+  `VarDctEncoder::encode_inner`, but they lived only in the multi-group
+  two-pass entropy branch, so a single-pass or single-group (`num_sections == 4`)
+  encode never polled the token — `test_stop_cancels_lossy_multigroup` failed
+  (the encode completed instead of returning `Cancelled`). Added an entry-point
+  checkpoint at the top of `encode_inner` that fires before any encode work on
+  **all** paths; the per-group checkpoints remain for mid-encode responsiveness.
+  Byte-identical under `Unstoppable` / `None`.
 
 ### Added
 - **Calibrated peak-memory estimation (`heuristics` module + per-config

--- a/benchmarks/transcode_mem_2026-06-18.tsv
+++ b/benchmarks/transcode_mem_2026-06-18.tsv
@@ -1,0 +1,16 @@
+# JPEG-transcode peak-heap measurement (heaptrack) — #77 MemoryBudget calibration
+# host: WSL2 (AMD Ryzen 9 7950X); jxl-encoder PR #78 (harden-jpeg-transcode-cap)
+# build: cargo build --release --example transcode_mem_probe --features jpeg-reencoding
+# cmd:   heaptrack ./transcode_mem_probe <jpeg> <effort>; peak = "peak heap memory consumption"
+# corpus: ~/work/codec-corpus/imageflow/test_inputs/ (real photos, 3-component baseline)
+# Note: peak is effort-independent (e7 == e9 to the reported precision) — kBest
+#   clustering at e9 adds bounded (not coeff-proportional) histogram memory.
+# Used to set ENCODE_BYTES_PER_COEFF=56 in jpeg/encode.rs (jpeg_to_jxl_inner):
+#   worst measured B/coeff = 44.1 (wrenches, high detail); 56 adds ~1.3x margin.
+#   The per-component i16 coeff buffer (~2 B/coeff) is reserved separately/exactly.
+image	width	height	coeffs	effort	peak_heap_MB	B_per_coeff
+wrenches	1800	676	1865856	7	82.24	44.1
+wrenches	1800	676	1865856	9	82.24	44.1
+waterhouse	-	-	3588096	7	90.83	25.3
+canon_5d_srgb	-	-	1305600	7	31.80	24.4
+roof_test_800x600	800	600	1440000	7	25.77	17.9

--- a/jxl-encoder-cli/src/main.rs
+++ b/jxl-encoder-cli/src/main.rs
@@ -884,6 +884,8 @@ fn main() {
                 &jpeg_bytes,
                 scale,
                 args.effort,
+                None,
+                None,
             ) {
                 Ok(b) => b,
                 Err(e) => {

--- a/jxl-encoder/Cargo.toml
+++ b/jxl-encoder/Cargo.toml
@@ -3001,6 +3001,10 @@ path = "examples/dump_cjxl_jbrd_reset_points.rs"
 name = "jpeg_recompress"
 required-features = ["jpeg-reencoding"]
 
+[[example]]
+name = "transcode_mem_probe"
+required-features = ["jpeg-reencoding"]
+
 # Debug helper for the JBRD round-trip gate: transcode + reconstruct (via
 # zenjxl-decoder dev-dep) and print the first diverging byte.
 [[example]]

--- a/jxl-encoder/examples/jpeg_recompress.rs
+++ b/jxl-encoder/examples/jpeg_recompress.rs
@@ -25,14 +25,17 @@ fn main() {
     let ls: f32 = args[2].parse().expect("scale must be a float");
     let out = if args.len() <= 4 {
         // scale-only: bundled production policy (deadzone + mild chroma lead)
-        jxl_encoder::jpeg::encode_jpeg_recompress_auto_codestream(&bytes, ls, 7)
+        // `None, None`: default resource limits, no cancellation token.
+        jxl_encoder::jpeg::encode_jpeg_recompress_auto_codestream(&bytes, ls, 7, None, None)
     } else {
         // explicit planar knobs (ablation)
         let p = |i: usize, d: f32| args.get(i).map(|s| s.parse().expect("float")).unwrap_or(d);
         let ldz = p(4, 0.0);
         let cs = p(5, ls);
         let cdz = p(6, ldz);
-        jxl_encoder::jpeg::encode_jpeg_recompress_planar_codestream(&bytes, ls, ldz, cs, cdz, 7)
+        jxl_encoder::jpeg::encode_jpeg_recompress_planar_codestream(
+            &bytes, ls, ldz, cs, cdz, 7, None, None,
+        )
     }
     .expect("recompress");
     fs::write(&args[3], &out).expect("write output");

--- a/jxl-encoder/examples/transcode_mem_probe.rs
+++ b/jxl-encoder/examples/transcode_mem_probe.rs
@@ -25,7 +25,7 @@ fn main() {
     let bytes = std::fs::read(&path).expect("read jpeg");
 
     // Parse once (no budget) to report the budget-relevant dimensions.
-    let jpeg = jxl_encoder::jpeg::read_jpeg(&bytes, None).expect("parse jpeg");
+    let jpeg = jxl_encoder::jpeg::read_jpeg(&bytes, None, None).expect("parse jpeg");
     let px = jpeg.width as u64 * jpeg.height as u64;
     let comp_blocks: Vec<u64> = jpeg
         .components

--- a/jxl-encoder/examples/transcode_mem_probe.rs
+++ b/jxl-encoder/examples/transcode_mem_probe.rs
@@ -1,0 +1,89 @@
+// Copyright (c) Imazen LLC and the JPEG XL Project Authors.
+// Licensed under AGPL-3.0-or-later.
+
+//! Transcode-path memory probe (#77 budget validation).
+//!
+//! Parses a JPEG, prints the per-site `MemoryBudget` reservation breakdown the
+//! transcode encoder makes (coefficient buffers, quant planes, AC tokens,
+//! output buffer), then runs the actual transcode. Run under `heaptrack` (or
+//! `/usr/bin/time -v`) to confirm the reservations cover the real peak heap:
+//!
+//! ```text
+//! heaptrack ./transcode_mem_probe photo.jpg
+//! heaptrack_print heaptrack.transcode_mem_probe.NNNN.zst | grep -i 'peak heap'
+//! ```
+//!
+//! `quant`/`tokens` use the exact per-block / per-token data sizes (261 B/block
+//! = i16 DC + [i32;64] AC + u8 nz + u16 raw_nz; 16 B/token-pair held during
+//! clustering), NOT a guessed per-coefficient constant.
+
+#[cfg(feature = "jpeg-reencoding")]
+fn main() {
+    let path = std::env::args()
+        .nth(1)
+        .expect("usage: transcode_mem_probe <jpeg>");
+    let bytes = std::fs::read(&path).expect("read jpeg");
+
+    // Parse once (no budget) to report the budget-relevant dimensions.
+    let jpeg = jxl_encoder::jpeg::read_jpeg(&bytes, None).expect("parse jpeg");
+    let px = jpeg.width as u64 * jpeg.height as u64;
+    let comp_blocks: Vec<u64> = jpeg
+        .components
+        .iter()
+        .map(|c| c.width_in_blocks as u64 * c.height_in_blocks as u64)
+        .collect();
+    let total_blocks: u64 = comp_blocks.iter().sum();
+    let coeffs = total_blocks * 64;
+
+    // Per-site reservations the transcode encoder makes (exact data sizes):
+    let coeff_b = coeffs * 2; // read_jpeg: per-component i16 coeff buffers
+    // map_jpeg_coefficients allocates 3 JXL channels of 261 B/block. A
+    // 3-component JPEG maps one channel per component (sum == comps); grayscale
+    // maps all 3 channels to component 0.
+    let quant_b = if comp_blocks.len() == 1 {
+        3 * comp_blocks[0] * 261
+    } else {
+        total_blocks * 261
+    };
+    let token_b_max = coeffs * 16; // <= 2 * total_ac_tokens * 8 (Token = 8 B)
+    let output_b = px * 4; // output BitWriter capacity
+    let sum = coeff_b + quant_b + token_b_max + output_b;
+
+    let mb = |b: u64| b as f64 / 1e6;
+    eprintln!(
+        "{path}: {}x{} px={px} comps={} blocks={total_blocks} coeffs={coeffs}",
+        jpeg.width,
+        jpeg.height,
+        jpeg.components.len()
+    );
+    eprintln!(
+        "  budget reserve: coeff={:.1}MB quant={:.1}MB tokens<={:.1}MB output={:.1}MB  SUM<={:.1}MB",
+        mb(coeff_b),
+        mb(quant_b),
+        mb(token_b_max),
+        mb(output_b),
+        mb(sum)
+    );
+
+    // The actual transcode — what heaptrack measures. Effort from argv[2]
+    // (default 7); e9 enables kBest histogram clustering, the heaviest path.
+    let effort: u8 = std::env::args()
+        .nth(2)
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(7);
+    let out = jxl_encoder::LosslessConfig::new()
+        .with_effort(effort)
+        .encode_jpeg_transcode_codestream(&bytes)
+        .expect("transcode");
+    eprintln!("  effort={effort}");
+    eprintln!(
+        "  transcoded output = {} bytes ({:.1}MB)",
+        out.len(),
+        mb(out.len() as u64)
+    );
+}
+
+#[cfg(not(feature = "jpeg-reencoding"))]
+fn main() {
+    eprintln!("transcode_mem_probe requires the `jpeg-reencoding` feature");
+}

--- a/jxl-encoder/src/api.rs
+++ b/jxl-encoder/src/api.rs
@@ -155,8 +155,13 @@ impl From<enough::StopReason> for EncodeError {
 #[cfg(feature = "jpeg-reencoding")]
 impl From<crate::jpeg::JpegError> for EncodeError {
     fn from(e: crate::jpeg::JpegError) -> Self {
-        Self::JpegParse {
-            message: format!("{e}"),
+        match e {
+            // Cooperative cancellation surfaces as the dedicated variant, not
+            // a parse error (mirrors the VarDCT path's `Error::Cancelled`).
+            crate::jpeg::JpegError::Cancelled => Self::Cancelled,
+            other => Self::JpegParse {
+                message: format!("{other}"),
+            },
         }
     }
 }
@@ -3516,6 +3521,53 @@ impl LosslessConfig {
         let jpeg =
             crate::jpeg::read_jpeg(jpeg_bytes, max_pixels).map_err(|e| at(EncodeError::from(e)))?;
         crate::jpeg::encode_jpeg_to_jxl_with_effort(&jpeg, self.effort)
+            .map_err(|e| at(EncodeError::from(e)))
+    }
+
+    /// Cancellable variant of [`Self::encode_jpeg_transcode`].
+    ///
+    /// Polls `stop` (an [`enough::Stop`] token) at coarse boundaries — entry,
+    /// the zenjpeg coefficient decode, and per-group / pre-entropy during JXL
+    /// encoding — returning [`EncodeError::Cancelled`] if cancellation is
+    /// requested. Output is byte-identical to [`Self::encode_jpeg_transcode`]
+    /// when the token never fires (e.g. an [`Unstoppable`] token); each poll
+    /// is a cheap check skipped entirely on the non-stop path.
+    ///
+    /// This is the untrusted-input cancellation hook from issue #77 item 2 —
+    /// a server can abort a slow transcode of an oversized JPEG.
+    ///
+    /// Requires the `jpeg-reencoding` cargo feature.
+    #[cfg(feature = "jpeg-reencoding")]
+    #[track_caller]
+    pub fn encode_jpeg_transcode_with_stop(
+        &self,
+        jpeg_bytes: &[u8],
+        stop: &dyn Stop,
+    ) -> Result<Vec<u8>> {
+        let max_pixels = self.limits.as_ref().and_then(|l| l.max_pixels());
+        let jpeg = crate::jpeg::read_jpeg_with_stop(jpeg_bytes, max_pixels, Some(stop))
+            .map_err(|e| at(EncodeError::from(e)))?;
+        crate::jpeg::encode_jpeg_to_jxl_container_with_effort_stop(&jpeg, self.effort, Some(stop))
+            .map_err(|e| at(EncodeError::from(e)))
+    }
+
+    /// Cancellable variant of [`Self::encode_jpeg_transcode_codestream`].
+    ///
+    /// See [`Self::encode_jpeg_transcode_with_stop`] for the polling contract
+    /// and byte-identity guarantee.
+    ///
+    /// Requires the `jpeg-reencoding` cargo feature.
+    #[cfg(feature = "jpeg-reencoding")]
+    #[track_caller]
+    pub fn encode_jpeg_transcode_codestream_with_stop(
+        &self,
+        jpeg_bytes: &[u8],
+        stop: &dyn Stop,
+    ) -> Result<Vec<u8>> {
+        let max_pixels = self.limits.as_ref().and_then(|l| l.max_pixels());
+        let jpeg = crate::jpeg::read_jpeg_with_stop(jpeg_bytes, max_pixels, Some(stop))
+            .map_err(|e| at(EncodeError::from(e)))?;
+        crate::jpeg::encode_jpeg_to_jxl_with_effort_stop(&jpeg, self.effort, Some(stop))
             .map_err(|e| at(EncodeError::from(e)))
     }
 }
@@ -15910,6 +15962,62 @@ mod tests {
             .with_stop(&enough::Unstoppable)
             .encode(&pixels);
         assert!(ok.is_ok(), "Unstoppable lossy encode failed: {ok:?}");
+    }
+
+    /// Issue #77 item 2: the JPEG-transcode path is cancellable via the
+    /// `*_with_stop` entry points (the formerly-dead `Stop` plumbing). A
+    /// cancelling token aborts with `Cancelled`; an `Unstoppable` token is
+    /// byte-identical to the non-stop path — proving the per-phase polls
+    /// (decode + per-group + pre-entropy) are harmless no-ops on success.
+    #[cfg(feature = "jpeg-reencoding")]
+    #[test]
+    fn test_jpeg_transcode_cancellation() {
+        use enough::{Stop, StopReason, Unstoppable};
+
+        // A committed baseline 4:4:4 JPEG — the transcode path's supported shape.
+        let data = include_bytes!("../tests/fixtures/jbrd/base_a_444.jpg");
+        let cfg = LosslessConfig::new();
+
+        struct AlwaysCancel;
+        impl Stop for AlwaysCancel {
+            fn check(&self) -> core::result::Result<(), StopReason> {
+                Err(StopReason::Cancelled)
+            }
+        }
+
+        // A cancelling Stop aborts both transcode entry points with
+        // `Cancelled` (mapped from `JpegError::Cancelled` / `Error::Cancelled`).
+        let cancelled = cfg.encode_jpeg_transcode_with_stop(data, &AlwaysCancel);
+        assert!(
+            matches!(&cancelled, Err(e) if matches!(e.error(), EncodeError::Cancelled)),
+            "expected EncodeError::Cancelled, got {cancelled:?}"
+        );
+        let cancelled_cs = cfg.encode_jpeg_transcode_codestream_with_stop(data, &AlwaysCancel);
+        assert!(
+            matches!(&cancelled_cs, Err(e) if matches!(e.error(), EncodeError::Cancelled)),
+            "codestream: expected EncodeError::Cancelled, got {cancelled_cs:?}"
+        );
+
+        // Unstoppable runs every poll (decode + per-group + pre-entropy),
+        // each returning Ok → byte-identical to the non-stop entry points.
+        let with_uns = cfg
+            .encode_jpeg_transcode_with_stop(data, &Unstoppable)
+            .expect("Unstoppable transcode should succeed");
+        let plain = cfg
+            .encode_jpeg_transcode(data)
+            .expect("plain transcode should succeed");
+        assert_eq!(
+            with_uns, plain,
+            "Unstoppable diverged from the no-stop path"
+        );
+
+        let with_uns_cs = cfg
+            .encode_jpeg_transcode_codestream_with_stop(data, &Unstoppable)
+            .expect("Unstoppable codestream transcode should succeed");
+        let plain_cs = cfg
+            .encode_jpeg_transcode_codestream(data)
+            .expect("plain codestream transcode should succeed");
+        assert_eq!(with_uns_cs, plain_cs, "codestream Unstoppable diverged");
     }
 
     #[test]

--- a/jxl-encoder/src/api.rs
+++ b/jxl-encoder/src/api.rs
@@ -1392,6 +1392,22 @@ impl Limits {
     /// batch raises it explicitly.
     pub const DEFAULT_MAX_MEMORY_BYTES_LOSSLESS: u64 = 8 * 1024 * 1024 * 1024;
 
+    /// Default pre-flight pixel cap (`width × height`) applied to the
+    /// untrusted JPEG-transcode path
+    /// ([`LosslessConfig::encode_jpeg_transcode`] and friends) when the
+    /// caller sets no explicit [`Self::with_max_pixels`].
+    ///
+    /// Set to 120 MP — admits 108 MP phone photos while bounding a crafted
+    /// SOF (JPEG dims are `u16`, so up to ~4.3 Gpx) from forcing a
+    /// multi-gigabyte `i16` coefficient allocation in the transcode parser,
+    /// which builds no `MemoryBudget`. The cap is checked immediately after
+    /// the SOF dimensions are read, before any allocation.
+    ///
+    /// Callers override it through [`Self::with_max_pixels`]: a higher value
+    /// for trusted batch input (or [`u64::MAX`] to opt out entirely), a lower
+    /// value to tighten the bound on a hostile-input proxy.
+    pub const DEFAULT_MAX_JPEG_TRANSCODE_PIXELS: u64 = 120_000_000;
+
     /// Path-aware default memory cap: [`Self::DEFAULT_MAX_MEMORY_BYTES`]
     /// for lossy, [`Self::DEFAULT_MAX_MEMORY_BYTES_LOSSLESS`] for
     /// lossless. Used when the caller set no explicit
@@ -2244,6 +2260,16 @@ pub struct LosslessConfig {
     /// bytes are identical regardless of `buffering`. See
     /// [`Self::with_buffering`].
     buffering: Buffering,
+    /// Resource [`Limits`] consulted by the untrusted JPEG-transcode path
+    /// ([`Self::encode_jpeg_transcode`] /
+    /// [`Self::encode_jpeg_transcode_codestream`]). Currently the transcode
+    /// parser reads [`Limits::max_pixels`] as the pre-flight SOF pixel cap
+    /// (default [`Limits::DEFAULT_MAX_JPEG_TRANSCODE_PIXELS`] = 120 MP when
+    /// `None`). Set via [`Self::with_limits`]. (The pixel / [`EncodeRequest`]
+    /// lossless path takes its limits from [`EncodeRequest::with_limits`]
+    /// instead.)
+    #[cfg(feature = "jpeg-reencoding")]
+    limits: Option<Limits>,
 }
 
 impl Default for LosslessConfig {
@@ -2286,6 +2312,8 @@ impl LosslessConfig {
             modular_group_size_shift: None,
             auto_delta_frames: false,
             buffering: Buffering::Auto,
+            #[cfg(feature = "jpeg-reencoding")]
+            limits: None,
         }
     }
 
@@ -3373,6 +3401,38 @@ impl LosslessConfig {
     // future investigation. Other `LosslessConfig` settings (mode, patches,
     // lossy_palette, etc.) do not affect the transcode path.
 
+    /// Attach resource [`Limits`] consulted by the JPEG-transcode path
+    /// ([`Self::encode_jpeg_transcode`] /
+    /// [`Self::encode_jpeg_transcode_codestream`]).
+    ///
+    /// The transcode parser reads [`Limits::max_pixels`] as the pre-flight
+    /// `width × height` cap applied to the untrusted SOF dimensions before
+    /// any coefficient buffer is allocated. When unset (or no `Limits` is
+    /// attached), the secure default
+    /// [`Limits::DEFAULT_MAX_JPEG_TRANSCODE_PIXELS`] (120 MP) applies; a
+    /// trusted batch caller can raise it (or pass
+    /// [`Limits::with_max_pixels`]`(u64::MAX)` to opt out), and a
+    /// hostile-input proxy can tighten it.
+    ///
+    /// Only the `max_pixels` field is consulted today; the rest of the
+    /// transcode-path [`Limits`] wiring (a full `MemoryBudget`) is tracked in
+    /// issue #77.
+    ///
+    /// Requires the `jpeg-reencoding` cargo feature.
+    #[cfg(feature = "jpeg-reencoding")]
+    pub fn with_limits(mut self, limits: &Limits) -> Self {
+        self.limits = Some(limits.clone());
+        self
+    }
+
+    /// The [`Limits`] attached via [`Self::with_limits`], if any.
+    ///
+    /// Requires the `jpeg-reencoding` cargo feature.
+    #[cfg(feature = "jpeg-reencoding")]
+    pub fn limits(&self) -> Option<&Limits> {
+        self.limits.as_ref()
+    }
+
     /// Losslessly transcode a JPEG file into JXL with JBRD container for
     /// byte-exact JPEG reconstruction.
     ///
@@ -3419,7 +3479,12 @@ impl LosslessConfig {
         // 2026-05-28: effort gates kBest pair-merge clustering at e>=8 and LZ77
         // (greedy at e=8, optimal at e>=9) on the AC code. See
         // `crate::jpeg::encode_jpeg_to_jxl_container_with_effort`.
-        let jpeg = crate::jpeg::read_jpeg(jpeg_bytes).map_err(|e| at(EncodeError::from(e)))?;
+        // Pre-flight SOF pixel cap from the attached `Limits::max_pixels`
+        // (default 120 MP — `Limits::DEFAULT_MAX_JPEG_TRANSCODE_PIXELS` —
+        // when unset; see `Self::with_limits`).
+        let max_pixels = self.limits.as_ref().and_then(|l| l.max_pixels());
+        let jpeg =
+            crate::jpeg::read_jpeg(jpeg_bytes, max_pixels).map_err(|e| at(EncodeError::from(e)))?;
         crate::jpeg::encode_jpeg_to_jxl_container_with_effort(&jpeg, self.effort)
             .map_err(|e| at(EncodeError::from(e)))
     }
@@ -3444,7 +3509,12 @@ impl LosslessConfig {
     #[track_caller]
     pub fn encode_jpeg_transcode_codestream(&self, jpeg_bytes: &[u8]) -> Result<Vec<u8>> {
         // 2026-05-28: see `encode_jpeg_transcode` for the effort gating.
-        let jpeg = crate::jpeg::read_jpeg(jpeg_bytes).map_err(|e| at(EncodeError::from(e)))?;
+        // Pre-flight SOF pixel cap from the attached `Limits::max_pixels`
+        // (default 120 MP — `Limits::DEFAULT_MAX_JPEG_TRANSCODE_PIXELS` —
+        // when unset; see `Self::with_limits`).
+        let max_pixels = self.limits.as_ref().and_then(|l| l.max_pixels());
+        let jpeg =
+            crate::jpeg::read_jpeg(jpeg_bytes, max_pixels).map_err(|e| at(EncodeError::from(e)))?;
         crate::jpeg::encode_jpeg_to_jxl_with_effort(&jpeg, self.effort)
             .map_err(|e| at(EncodeError::from(e)))
     }

--- a/jxl-encoder/src/api.rs
+++ b/jxl-encoder/src/api.rs
@@ -1368,6 +1368,7 @@ pub struct Limits {
     max_pixels: Option<u64>,
     max_memory_bytes: Option<u64>,
     max_quant_loop_iters: Option<u32>,
+    fallible_alloc: bool,
 }
 
 impl Limits {
@@ -1524,6 +1525,30 @@ impl Limits {
     pub fn effective_max_quant_loop_iters(&self) -> u32 {
         self.max_quant_loop_iters
             .unwrap_or(Self::DEFAULT_MAX_QUANT_LOOP_ITERS)
+    }
+
+    /// Choose **fallible** allocation for the large dimension-driven buffers
+    /// sized from untrusted input (the JPEG-transcode coefficient / working
+    /// buffers).
+    ///
+    /// - `false` (default): `vec![v; n]` — LLVM lowers the zeroed case to a
+    ///   single `calloc`, the faster path. An allocation that the OS cannot
+    ///   satisfy aborts the process.
+    /// - `true`: `try_reserve` — a failed allocation returns
+    ///   [`EncodeError`] / [`crate::error::Error::OutOfMemory`] instead of
+    ///   aborting. Slightly slower, but a hostile-input image proxy stays up.
+    ///
+    /// Orthogonal to [`Self::with_max_memory_bytes`]: the budget *rejects*
+    /// oversized requests up front; this controls how an *accepted* request is
+    /// allocated. A server handling untrusted uploads typically wants both.
+    pub fn with_fallible_alloc(mut self, fallible: bool) -> Self {
+        self.fallible_alloc = fallible;
+        self
+    }
+
+    /// Whether fallible allocation is enabled (see [`Self::with_fallible_alloc`]).
+    pub fn fallible_alloc(&self) -> bool {
+        self.fallible_alloc
     }
 }
 
@@ -3496,7 +3521,7 @@ impl LosslessConfig {
         // `Self::with_limits`). DoS protection is default-on for this untrusted-
         // bytes path, like the pixel path (#77 item 1).
         let max_pixels = self.limits.as_ref().and_then(|l| l.max_pixels());
-        let budget = crate::budget::MemoryBudget::new(self.transcode_budget_cap());
+        let budget = self.transcode_budget();
         let jpeg = crate::jpeg::read_jpeg_with_stop(jpeg_bytes, max_pixels, None, Some(&budget))
             .map_err(|e| at(EncodeError::from(e)))?;
         crate::jpeg::encode_jpeg_to_jxl_container_with_effort_stop(
@@ -3532,7 +3557,7 @@ impl LosslessConfig {
         // (default 120 MP — `Limits::DEFAULT_MAX_JPEG_TRANSCODE_PIXELS` —
         // when unset; see `Self::with_limits`).
         let max_pixels = self.limits.as_ref().and_then(|l| l.max_pixels());
-        let budget = crate::budget::MemoryBudget::new(self.transcode_budget_cap());
+        let budget = self.transcode_budget();
         let jpeg = crate::jpeg::read_jpeg_with_stop(jpeg_bytes, max_pixels, None, Some(&budget))
             .map_err(|e| at(EncodeError::from(e)))?;
         crate::jpeg::encode_jpeg_to_jxl_with_effort_stop(&jpeg, self.effort, None, Some(&budget))
@@ -3560,7 +3585,7 @@ impl LosslessConfig {
         stop: &dyn Stop,
     ) -> Result<Vec<u8>> {
         let max_pixels = self.limits.as_ref().and_then(|l| l.max_pixels());
-        let budget = crate::budget::MemoryBudget::new(self.transcode_budget_cap());
+        let budget = self.transcode_budget();
         let jpeg =
             crate::jpeg::read_jpeg_with_stop(jpeg_bytes, max_pixels, Some(stop), Some(&budget))
                 .map_err(|e| at(EncodeError::from(e)))?;
@@ -3587,7 +3612,7 @@ impl LosslessConfig {
         stop: &dyn Stop,
     ) -> Result<Vec<u8>> {
         let max_pixels = self.limits.as_ref().and_then(|l| l.max_pixels());
-        let budget = crate::budget::MemoryBudget::new(self.transcode_budget_cap());
+        let budget = self.transcode_budget();
         let jpeg =
             crate::jpeg::read_jpeg_with_stop(jpeg_bytes, max_pixels, Some(stop), Some(&budget))
                 .map_err(|e| at(EncodeError::from(e)))?;
@@ -3600,16 +3625,20 @@ impl LosslessConfig {
         .map_err(|e| at(EncodeError::from(e)))
     }
 
-    /// The per-encode memory cap for the JPEG-transcode path: the caller's
-    /// explicit [`Limits::max_memory_bytes`] if set, else the lossless default
+    /// Build the per-encode [`crate::budget::MemoryBudget`] for the
+    /// JPEG-transcode path from the attached [`Limits`]: the explicit
+    /// [`Limits::max_memory_bytes`] cap if set, else the lossless default
     /// [`Limits::DEFAULT_MAX_MEMORY_BYTES_LOSSLESS`] (transcode emits a lossless
-    /// bitstream). Used to build the per-encode [`crate::budget::MemoryBudget`].
+    /// bitstream); plus the [`Limits::fallible_alloc`] allocation policy.
     #[cfg(feature = "jpeg-reencoding")]
-    fn transcode_budget_cap(&self) -> u64 {
-        self.limits
+    fn transcode_budget(&self) -> alloc::sync::Arc<crate::budget::MemoryBudget> {
+        let cap = self
+            .limits
             .as_ref()
             .and_then(|l| l.max_memory_bytes())
-            .unwrap_or(Limits::DEFAULT_MAX_MEMORY_BYTES_LOSSLESS)
+            .unwrap_or(Limits::DEFAULT_MAX_MEMORY_BYTES_LOSSLESS);
+        let fallible = self.limits.as_ref().is_some_and(|l| l.fallible_alloc());
+        crate::budget::MemoryBudget::with_alloc_policy(cap, fallible)
     }
 }
 
@@ -9335,6 +9364,7 @@ impl<'a> EncodeRequest<'a> {
                 &color_encoding,
                 &mut writer,
                 patches_data.as_ref(),
+                self.stop,
             )
             .map_err(EncodeError::from)?;
 
@@ -12435,6 +12465,7 @@ impl LosslessEncoder {
                     &color_encoding,
                     &mut writer,
                     patches_data.as_ref(),
+                    None,
                 )
                 .map_err(EncodeError::from)?;
 
@@ -12946,7 +12977,7 @@ fn encode_animation_lossless(
             make_opts(crop, identity_blend_mode, identity_ec_override),
         )
         .with_budget(alloc::sync::Arc::clone(&budget))
-        .encode_modular(&image, &color_encoding, &mut writer_a)
+        .encode_modular(&image, &color_encoding, &mut writer_a, None)
         .map_err(at_from)?;
 
         // Trial-encode candidate B: full-frame `BlendMode::Add` delta
@@ -12994,7 +13025,7 @@ fn encode_animation_lossless(
                         ),
                     )
                     .with_budget(alloc::sync::Arc::clone(&budget))
-                    .encode_modular(&delta_image, &color_encoding, &mut wb)
+                    .encode_modular(&delta_image, &color_encoding, &mut wb, None)
                     .map_err(at_from)?;
                     Some(wb)
                 }
@@ -16005,6 +16036,99 @@ mod tests {
         assert!(ok.is_ok(), "Unstoppable lossy encode failed: {ok:?}");
     }
 
+    /// Issue #77 cross-codec cancellation: the effort-8 butteraugli quantization
+    /// loop polls `Stop` per iteration, and the VarDCT encode entry polls before
+    /// any work. An always-cancelling token aborts an e8 encode with `Cancelled`;
+    /// `Unstoppable` runs every poll (entry + per-buttloop-iteration) and is
+    /// byte-identical to the no-stop path — proving the buttloop poll is a no-op.
+    #[test]
+    fn test_stop_cancels_lossy_e8_buttloop() {
+        // 128x128 single-group: small enough to keep the debug-mode e8 butteraugli
+        // loop fast, large enough that the loop actually runs (and polls).
+        let (w, h) = (128u32, 128u32);
+        let mut pixels = vec![0u8; (w * h * 3) as usize];
+        for (i, p) in pixels.iter_mut().enumerate() {
+            *p = (i.wrapping_mul(2_654_435_761) >> 11) as u8;
+        }
+
+        struct AlwaysCancel;
+        impl enough::Stop for AlwaysCancel {
+            fn check(&self) -> core::result::Result<(), enough::StopReason> {
+                Err(enough::StopReason::Cancelled)
+            }
+        }
+
+        let cancelled = LossyConfig::new(1.0)
+            .with_effort(8)
+            .encode_request(w, h, PixelLayout::Rgb8)
+            .with_stop(&AlwaysCancel)
+            .encode(&pixels);
+        assert!(
+            matches!(&cancelled, Err(e) if matches!(e.error(), EncodeError::Cancelled)),
+            "expected EncodeError::Cancelled at e8, got {cancelled:?}"
+        );
+
+        // Unstoppable runs the buttloop polls and matches the no-stop output.
+        let with_uns = LossyConfig::new(1.0)
+            .with_effort(8)
+            .encode_request(w, h, PixelLayout::Rgb8)
+            .with_stop(&enough::Unstoppable)
+            .encode(&pixels)
+            .expect("Unstoppable e8 encode should succeed");
+        let plain = LossyConfig::new(1.0)
+            .with_effort(8)
+            .encode_request(w, h, PixelLayout::Rgb8)
+            .encode(&pixels)
+            .expect("plain e8 encode should succeed");
+        assert_eq!(with_uns, plain, "Unstoppable e8 diverged from no-stop path");
+    }
+
+    /// Issue #77 cross-codec cancellation: the modular (lossless) multi-group
+    /// path polls `Stop` at the encode boundary and before the heavy per-group
+    /// parallel encode (after tree learning). An always-cancelling token aborts a
+    /// multi-group lossless encode with `Cancelled`; `Unstoppable` is byte-
+    /// identical to the no-stop path.
+    #[test]
+    fn test_stop_cancels_lossless_multigroup() {
+        // 512x512 → multi-group modular; the default effort runs tree learning
+        // + per-group parallel encoding (where the polls live).
+        let (w, h) = (512u32, 512u32);
+        let mut pixels = vec![0u8; (w * h * 3) as usize];
+        for (i, p) in pixels.iter_mut().enumerate() {
+            *p = (i.wrapping_mul(2_654_435_761) >> 13) as u8;
+        }
+
+        struct AlwaysCancel;
+        impl enough::Stop for AlwaysCancel {
+            fn check(&self) -> core::result::Result<(), enough::StopReason> {
+                Err(enough::StopReason::Cancelled)
+            }
+        }
+
+        let cancelled = LosslessConfig::new()
+            .encode_request(w, h, PixelLayout::Rgb8)
+            .with_stop(&AlwaysCancel)
+            .encode(&pixels);
+        assert!(
+            matches!(&cancelled, Err(e) if matches!(e.error(), EncodeError::Cancelled)),
+            "expected EncodeError::Cancelled for lossless multi-group, got {cancelled:?}"
+        );
+
+        let with_uns = LosslessConfig::new()
+            .encode_request(w, h, PixelLayout::Rgb8)
+            .with_stop(&enough::Unstoppable)
+            .encode(&pixels)
+            .expect("Unstoppable lossless encode should succeed");
+        let plain = LosslessConfig::new()
+            .encode_request(w, h, PixelLayout::Rgb8)
+            .encode(&pixels)
+            .expect("plain lossless encode should succeed");
+        assert_eq!(
+            with_uns, plain,
+            "Unstoppable lossless multi-group diverged from no-stop path"
+        );
+    }
+
     /// Issue #77 item 2: the JPEG-transcode path is cancellable via the
     /// `*_with_stop` entry points (the formerly-dead `Stop` plumbing). A
     /// cancelling token aborts with `Cancelled`; an `Unstoppable` token is
@@ -16103,6 +16227,58 @@ mod tests {
                 .encode_jpeg_transcode(data)
                 .is_ok(),
             "u64::MAX cap should transcode fine"
+        );
+    }
+
+    /// User directive (2026-06-17): fallible-vs-infallible allocation is a
+    /// **runtime** toggle (`Limits::with_fallible_alloc`) — `vec!` (fast,
+    /// calloc) vs `try_reserve` (graceful OOM). The toggle changes the
+    /// allocation *mechanism*, not the bytes, so a successful transcode is
+    /// byte-identical in both modes; the difference only surfaces as a clean
+    /// error (vs abort) on a genuine OOM, which can't be provoked without
+    /// exhausting memory. Both modes still honour the `MemoryBudget`.
+    #[cfg(feature = "jpeg-reencoding")]
+    #[test]
+    fn test_jpeg_transcode_fallible_alloc_toggle() {
+        let data = include_bytes!("../tests/fixtures/jbrd/base_a_444.jpg");
+
+        let infallible = Limits::new().with_fallible_alloc(false);
+        let fallible = Limits::new().with_fallible_alloc(true);
+
+        let out_infallible = LosslessConfig::new()
+            .with_limits(&infallible)
+            .encode_jpeg_transcode(data)
+            .expect("infallible-alloc transcode should succeed");
+        let out_fallible = LosslessConfig::new()
+            .with_limits(&fallible)
+            .encode_jpeg_transcode(data)
+            .expect("fallible-alloc transcode should succeed");
+        assert_eq!(
+            out_infallible, out_fallible,
+            "fallible toggle changed output bytes (must be alloc-mechanism only)"
+        );
+
+        // Both modes still honour the budget: a 1 KiB cap rejects either way
+        // (the byte reservation fails before the allocation in both modes).
+        let tight_inf = Limits::new()
+            .with_fallible_alloc(false)
+            .with_max_memory_bytes(1024);
+        let tight_fal = Limits::new()
+            .with_fallible_alloc(true)
+            .with_max_memory_bytes(1024);
+        assert!(
+            LosslessConfig::new()
+                .with_limits(&tight_inf)
+                .encode_jpeg_transcode(data)
+                .is_err(),
+            "infallible + 1 KiB cap must reject"
+        );
+        assert!(
+            LosslessConfig::new()
+                .with_limits(&tight_fal)
+                .encode_jpeg_transcode(data)
+                .is_err(),
+            "fallible + 1 KiB cap must reject"
         );
     }
 

--- a/jxl-encoder/src/api.rs
+++ b/jxl-encoder/src/api.rs
@@ -159,6 +159,10 @@ impl From<crate::jpeg::JpegError> for EncodeError {
             // Cooperative cancellation surfaces as the dedicated variant, not
             // a parse error (mirrors the VarDCT path's `Error::Cancelled`).
             crate::jpeg::JpegError::Cancelled => Self::Cancelled,
+            // A coefficient-buffer reservation that overran the memory budget
+            // surfaces as a limit error, not a parse error (mirrors the pixel
+            // path's `AllocationLimit` → `LimitExceeded` mapping).
+            crate::jpeg::JpegError::ResourceLimit(message) => Self::LimitExceeded { message },
             other => Self::JpegParse {
                 message: format!("{other}"),
             },
@@ -3487,11 +3491,21 @@ impl LosslessConfig {
         // Pre-flight SOF pixel cap from the attached `Limits::max_pixels`
         // (default 120 MP — `Limits::DEFAULT_MAX_JPEG_TRANSCODE_PIXELS` —
         // when unset; see `Self::with_limits`).
+        // Pre-flight SOF pixel cap + per-encode memory budget from the attached
+        // `Limits` (default 120 MP / the lossless 8 GiB default when unset; see
+        // `Self::with_limits`). DoS protection is default-on for this untrusted-
+        // bytes path, like the pixel path (#77 item 1).
         let max_pixels = self.limits.as_ref().and_then(|l| l.max_pixels());
-        let jpeg =
-            crate::jpeg::read_jpeg(jpeg_bytes, max_pixels).map_err(|e| at(EncodeError::from(e)))?;
-        crate::jpeg::encode_jpeg_to_jxl_container_with_effort(&jpeg, self.effort)
-            .map_err(|e| at(EncodeError::from(e)))
+        let budget = crate::budget::MemoryBudget::new(self.transcode_budget_cap());
+        let jpeg = crate::jpeg::read_jpeg_with_stop(jpeg_bytes, max_pixels, None, Some(&budget))
+            .map_err(|e| at(EncodeError::from(e)))?;
+        crate::jpeg::encode_jpeg_to_jxl_container_with_effort_stop(
+            &jpeg,
+            self.effort,
+            None,
+            Some(&budget),
+        )
+        .map_err(|e| at(EncodeError::from(e)))
     }
 
     /// Losslessly transcode a JPEG file into a bare JXL codestream
@@ -3518,9 +3532,10 @@ impl LosslessConfig {
         // (default 120 MP — `Limits::DEFAULT_MAX_JPEG_TRANSCODE_PIXELS` —
         // when unset; see `Self::with_limits`).
         let max_pixels = self.limits.as_ref().and_then(|l| l.max_pixels());
-        let jpeg =
-            crate::jpeg::read_jpeg(jpeg_bytes, max_pixels).map_err(|e| at(EncodeError::from(e)))?;
-        crate::jpeg::encode_jpeg_to_jxl_with_effort(&jpeg, self.effort)
+        let budget = crate::budget::MemoryBudget::new(self.transcode_budget_cap());
+        let jpeg = crate::jpeg::read_jpeg_with_stop(jpeg_bytes, max_pixels, None, Some(&budget))
+            .map_err(|e| at(EncodeError::from(e)))?;
+        crate::jpeg::encode_jpeg_to_jxl_with_effort_stop(&jpeg, self.effort, None, Some(&budget))
             .map_err(|e| at(EncodeError::from(e)))
     }
 
@@ -3545,10 +3560,17 @@ impl LosslessConfig {
         stop: &dyn Stop,
     ) -> Result<Vec<u8>> {
         let max_pixels = self.limits.as_ref().and_then(|l| l.max_pixels());
-        let jpeg = crate::jpeg::read_jpeg_with_stop(jpeg_bytes, max_pixels, Some(stop))
-            .map_err(|e| at(EncodeError::from(e)))?;
-        crate::jpeg::encode_jpeg_to_jxl_container_with_effort_stop(&jpeg, self.effort, Some(stop))
-            .map_err(|e| at(EncodeError::from(e)))
+        let budget = crate::budget::MemoryBudget::new(self.transcode_budget_cap());
+        let jpeg =
+            crate::jpeg::read_jpeg_with_stop(jpeg_bytes, max_pixels, Some(stop), Some(&budget))
+                .map_err(|e| at(EncodeError::from(e)))?;
+        crate::jpeg::encode_jpeg_to_jxl_container_with_effort_stop(
+            &jpeg,
+            self.effort,
+            Some(stop),
+            Some(&budget),
+        )
+        .map_err(|e| at(EncodeError::from(e)))
     }
 
     /// Cancellable variant of [`Self::encode_jpeg_transcode_codestream`].
@@ -3565,10 +3587,29 @@ impl LosslessConfig {
         stop: &dyn Stop,
     ) -> Result<Vec<u8>> {
         let max_pixels = self.limits.as_ref().and_then(|l| l.max_pixels());
-        let jpeg = crate::jpeg::read_jpeg_with_stop(jpeg_bytes, max_pixels, Some(stop))
-            .map_err(|e| at(EncodeError::from(e)))?;
-        crate::jpeg::encode_jpeg_to_jxl_with_effort_stop(&jpeg, self.effort, Some(stop))
-            .map_err(|e| at(EncodeError::from(e)))
+        let budget = crate::budget::MemoryBudget::new(self.transcode_budget_cap());
+        let jpeg =
+            crate::jpeg::read_jpeg_with_stop(jpeg_bytes, max_pixels, Some(stop), Some(&budget))
+                .map_err(|e| at(EncodeError::from(e)))?;
+        crate::jpeg::encode_jpeg_to_jxl_with_effort_stop(
+            &jpeg,
+            self.effort,
+            Some(stop),
+            Some(&budget),
+        )
+        .map_err(|e| at(EncodeError::from(e)))
+    }
+
+    /// The per-encode memory cap for the JPEG-transcode path: the caller's
+    /// explicit [`Limits::max_memory_bytes`] if set, else the lossless default
+    /// [`Limits::DEFAULT_MAX_MEMORY_BYTES_LOSSLESS`] (transcode emits a lossless
+    /// bitstream). Used to build the per-encode [`crate::budget::MemoryBudget`].
+    #[cfg(feature = "jpeg-reencoding")]
+    fn transcode_budget_cap(&self) -> u64 {
+        self.limits
+            .as_ref()
+            .and_then(|l| l.max_memory_bytes())
+            .unwrap_or(Limits::DEFAULT_MAX_MEMORY_BYTES_LOSSLESS)
     }
 }
 
@@ -16018,6 +16059,108 @@ mod tests {
             .encode_jpeg_transcode_codestream(data)
             .expect("plain codestream transcode should succeed");
         assert_eq!(with_uns_cs, plain_cs, "codestream Unstoppable diverged");
+    }
+
+    /// Issue #77 item 1 (full): the JPEG-transcode path is bounded by a
+    /// per-encode `MemoryBudget` built from `Limits::max_memory_bytes`,
+    /// threaded through the decode coefficient buffers AND the encode working
+    /// set. A tight cap is rejected with `LimitExceeded`; `u64::MAX` opts out.
+    #[cfg(feature = "jpeg-reencoding")]
+    #[test]
+    fn test_jpeg_transcode_memory_budget() {
+        let data = include_bytes!("../tests/fixtures/jbrd/base_a_444.jpg");
+
+        // Default cap (8 GiB lossless default) transcodes the small fixture.
+        assert!(
+            LosslessConfig::new().encode_jpeg_transcode(data).is_ok(),
+            "default-budget transcode should succeed"
+        );
+
+        // A 1 KiB cap can't fit the coefficient buffers / encode working set —
+        // rejected with LimitExceeded (proves the budget is threaded through
+        // both the decode and encode phases).
+        let tight = Limits::new().with_max_memory_bytes(1024);
+        let r = LosslessConfig::new()
+            .with_limits(&tight)
+            .encode_jpeg_transcode(data);
+        assert!(
+            matches!(&r, Err(e) if matches!(e.error(), EncodeError::LimitExceeded { .. })),
+            "expected LimitExceeded under a 1 KiB cap, got {r:?}"
+        );
+        let r_cs = LosslessConfig::new()
+            .with_limits(&tight)
+            .encode_jpeg_transcode_codestream(data);
+        assert!(
+            matches!(&r_cs, Err(e) if matches!(e.error(), EncodeError::LimitExceeded { .. })),
+            "codestream: expected LimitExceeded under a 1 KiB cap, got {r_cs:?}"
+        );
+
+        // `u64::MAX` opts out of the cap → succeeds.
+        let unbounded = Limits::new().with_max_memory_bytes(u64::MAX);
+        assert!(
+            LosslessConfig::new()
+                .with_limits(&unbounded)
+                .encode_jpeg_transcode(data)
+                .is_ok(),
+            "u64::MAX cap should transcode fine"
+        );
+    }
+
+    /// Issue #77 follow-ups: the PreserveJxl `encode_jpeg_recompress_*` free
+    /// functions honour `Limits` (memory budget + pixel cap) and `Stop`.
+    #[cfg(feature = "jpeg-reencoding")]
+    #[test]
+    fn test_jpeg_recompress_limits_and_stop() {
+        use enough::{Stop, StopReason, Unstoppable};
+
+        let data = include_bytes!("../tests/fixtures/jbrd/base_a_444.jpg");
+
+        // Default (no limits / unstoppable): the lossless floor succeeds.
+        assert!(
+            crate::jpeg::encode_jpeg_recompress_auto_codestream(data, 1.0, 7, None, None).is_ok(),
+            "default recompress should succeed"
+        );
+
+        // A tight memory cap rejects.
+        let tight = Limits::new().with_max_memory_bytes(1024);
+        let r =
+            crate::jpeg::encode_jpeg_recompress_auto_codestream(data, 2.0, 7, Some(&tight), None);
+        assert!(
+            r.is_err(),
+            "expected a memory-limit rejection under a 1 KiB cap"
+        );
+
+        // A cancelling Stop aborts with `Error::Cancelled`.
+        struct AlwaysCancel;
+        impl Stop for AlwaysCancel {
+            fn check(&self) -> core::result::Result<(), StopReason> {
+                Err(StopReason::Cancelled)
+            }
+        }
+        let c = crate::jpeg::encode_jpeg_recompress_auto_codestream(
+            data,
+            2.0,
+            7,
+            None,
+            Some(&AlwaysCancel),
+        );
+        assert!(
+            matches!(c, Err(crate::error::Error::Cancelled)),
+            "expected Error::Cancelled, got {c:?}"
+        );
+
+        // Unstoppable + default cap succeeds.
+        assert!(
+            crate::jpeg::encode_jpeg_recompress_auto_codestream(
+                data,
+                2.0,
+                7,
+                None,
+                Some(&Unstoppable)
+            )
+            .is_ok(),
+            "Unstoppable recompress should succeed"
+        );
     }
 
     #[test]

--- a/jxl-encoder/src/api.rs
+++ b/jxl-encoder/src/api.rs
@@ -8553,7 +8553,8 @@ impl<'a> EncodeRequest<'a> {
         let budget_cap = self.limits.and_then(|l| l.max_memory_bytes()).unwrap_or(
             Limits::default_max_memory_bytes(matches!(self.config, ConfigRef::Lossless(_))),
         );
-        let budget = crate::budget::MemoryBudget::new(budget_cap);
+        let fallible = self.limits.is_some_and(|l| l.fallible_alloc());
+        let budget = crate::budget::MemoryBudget::with_alloc_policy(budget_cap, fallible);
         let est_bytes = (self.width as u64)
             .checked_mul(self.height as u64)
             .and_then(|n| n.checked_mul(40))
@@ -11169,7 +11170,8 @@ impl LossyEncoder {
             .as_ref()
             .and_then(|l| l.max_memory_bytes())
             .unwrap_or(Limits::default_max_memory_bytes(false));
-        let budget = crate::budget::MemoryBudget::new(budget_cap);
+        let fallible = self.limits.as_ref().is_some_and(|l| l.fallible_alloc());
+        let budget = crate::budget::MemoryBudget::with_alloc_policy(budget_cap, fallible);
         let est_bytes = (self.width as u64)
             .checked_mul(self.height as u64)
             .and_then(|n| n.checked_mul(40))
@@ -12254,7 +12256,8 @@ impl LosslessEncoder {
             .as_ref()
             .and_then(|l| l.max_memory_bytes())
             .unwrap_or(Limits::default_max_memory_bytes(true));
-        let budget = crate::budget::MemoryBudget::new(budget_cap);
+        let fallible = self.limits.as_ref().is_some_and(|l| l.fallible_alloc());
+        let budget = crate::budget::MemoryBudget::with_alloc_policy(budget_cap, fallible);
         let est_bytes = (self.width as u64)
             .checked_mul(self.height as u64)
             .and_then(|n| n.checked_mul(40))
@@ -12729,7 +12732,8 @@ fn encode_animation_lossless(
     let budget_cap = limits
         .and_then(|l| l.max_memory_bytes())
         .unwrap_or(Limits::default_max_memory_bytes(true));
-    let budget = crate::budget::MemoryBudget::new(budget_cap);
+    let fallible = limits.is_some_and(|l| l.fallible_alloc());
+    let budget = crate::budget::MemoryBudget::with_alloc_policy(budget_cap, fallible);
     let est_bytes = (width as u64)
         .checked_mul(height as u64)
         .and_then(|n| n.checked_mul(40))
@@ -13201,7 +13205,8 @@ fn encode_animation_lossy(
     let budget_cap = limits
         .and_then(|l| l.max_memory_bytes())
         .unwrap_or(Limits::default_max_memory_bytes(false));
-    let budget = crate::budget::MemoryBudget::new(budget_cap);
+    let fallible = limits.is_some_and(|l| l.fallible_alloc());
+    let budget = crate::budget::MemoryBudget::with_alloc_policy(budget_cap, fallible);
     let est_bytes = (width as u64)
         .checked_mul(height as u64)
         .and_then(|n| n.checked_mul(40))
@@ -16127,6 +16132,83 @@ mod tests {
             with_uns, plain,
             "Unstoppable lossless multi-group diverged from no-stop path"
         );
+    }
+
+    /// User directive (2026-06-17): the runtime fallible-alloc toggle
+    /// (`Limits::with_fallible_alloc`) is wired through the STANDARD lossy +
+    /// lossless encodes, not just JPEG transcode. The dimension-driven output /
+    /// group-writer / quant / XYB-plane / modular-channel buffers pick `vec!`
+    /// (fast) vs `try_reserve` (graceful OOM) from the budget policy, so the
+    /// toggle changes only the allocation *mechanism* — a successful encode is
+    /// byte-identical in both modes — and both modes still honour the budget.
+    #[test]
+    fn test_standard_encode_fallible_alloc_toggle() {
+        let (w, h) = (256u32, 256u32);
+        let mut pixels = vec![0u8; (w * h * 3) as usize];
+        for (i, p) in pixels.iter_mut().enumerate() {
+            *p = (i.wrapping_mul(2_654_435_761) >> 13) as u8;
+        }
+
+        let inf = Limits::new().with_fallible_alloc(false);
+        let fal = Limits::new().with_fallible_alloc(true);
+
+        // Lossy: fallible vs infallible → byte-identical output.
+        let lossy_inf = LossyConfig::new(1.0)
+            .encode_request(w, h, PixelLayout::Rgb8)
+            .with_limits(&inf)
+            .encode(&pixels)
+            .expect("lossy infallible encode");
+        let lossy_fal = LossyConfig::new(1.0)
+            .encode_request(w, h, PixelLayout::Rgb8)
+            .with_limits(&fal)
+            .encode(&pixels)
+            .expect("lossy fallible encode");
+        assert_eq!(
+            lossy_inf, lossy_fal,
+            "lossy fallible toggle changed output bytes"
+        );
+
+        // Lossless: fallible vs infallible → byte-identical output (exercises
+        // the modular channel-data allocation path).
+        let ll_inf = LosslessConfig::new()
+            .encode_request(w, h, PixelLayout::Rgb8)
+            .with_limits(&inf)
+            .encode(&pixels)
+            .expect("lossless infallible encode");
+        let ll_fal = LosslessConfig::new()
+            .encode_request(w, h, PixelLayout::Rgb8)
+            .with_limits(&fal)
+            .encode(&pixels)
+            .expect("lossless fallible encode");
+        assert_eq!(
+            ll_inf, ll_fal,
+            "lossless fallible toggle changed output bytes"
+        );
+
+        // Both modes honour the budget: a 1 KiB cap rejects lossy + lossless
+        // either way (the dimension-driven buffers can't fit — the reservation
+        // fails before allocation regardless of the fallible policy).
+        for fallible in [false, true] {
+            let tight = Limits::new()
+                .with_fallible_alloc(fallible)
+                .with_max_memory_bytes(1024);
+            assert!(
+                LossyConfig::new(1.0)
+                    .encode_request(w, h, PixelLayout::Rgb8)
+                    .with_limits(&tight)
+                    .encode(&pixels)
+                    .is_err(),
+                "lossy + 1 KiB cap (fallible={fallible}) must reject"
+            );
+            assert!(
+                LosslessConfig::new()
+                    .encode_request(w, h, PixelLayout::Rgb8)
+                    .with_limits(&tight)
+                    .encode(&pixels)
+                    .is_err(),
+                "lossless + 1 KiB cap (fallible={fallible}) must reject"
+            );
+        }
     }
 
     /// Issue #77 item 2: the JPEG-transcode path is cancellable via the

--- a/jxl-encoder/src/bit_writer.rs
+++ b/jxl-encoder/src/bit_writer.rs
@@ -71,6 +71,10 @@ impl BitWriter {
     /// policy for the initial capacity: `Vec::with_capacity` (infallible) when
     /// `fallible` is false, `try_reserve` (returns [`crate::error::Error::OutOfMemory`]
     /// instead of aborting) when true. Subsequent growth is already fallible.
+    ///
+    /// Used only by the `jpeg-reencoding` transcode output buffer — dead code
+    /// when that feature is off.
+    #[cfg_attr(not(feature = "jpeg-reencoding"), allow(dead_code))]
     pub fn with_capacity_policy(
         fallible: bool,
         capacity_bytes: usize,

--- a/jxl-encoder/src/bit_writer.rs
+++ b/jxl-encoder/src/bit_writer.rs
@@ -71,10 +71,6 @@ impl BitWriter {
     /// policy for the initial capacity: `Vec::with_capacity` (infallible) when
     /// `fallible` is false, `try_reserve` (returns [`crate::error::Error::OutOfMemory`]
     /// instead of aborting) when true. Subsequent growth is already fallible.
-    ///
-    /// Used only by the `jpeg-reencoding` transcode output buffer — dead code
-    /// when that feature is off.
-    #[cfg_attr(not(feature = "jpeg-reencoding"), allow(dead_code))]
     pub fn with_capacity_policy(
         fallible: bool,
         capacity_bytes: usize,

--- a/jxl-encoder/src/bit_writer.rs
+++ b/jxl-encoder/src/bit_writer.rs
@@ -67,6 +67,27 @@ impl BitWriter {
         }
     }
 
+    /// Like [`Self::with_capacity`] but honors a runtime fallible-allocation
+    /// policy for the initial capacity: `Vec::with_capacity` (infallible) when
+    /// `fallible` is false, `try_reserve` (returns [`crate::error::Error::OutOfMemory`]
+    /// instead of aborting) when true. Subsequent growth is already fallible.
+    pub fn with_capacity_policy(
+        fallible: bool,
+        capacity_bytes: usize,
+    ) -> crate::error::Result<Self> {
+        let storage = if fallible {
+            let mut v = alloc::vec::Vec::new();
+            v.try_reserve(capacity_bytes)?;
+            v
+        } else {
+            alloc::vec::Vec::with_capacity(capacity_bytes)
+        };
+        Ok(Self {
+            storage,
+            bits_written: 0,
+        })
+    }
+
     /// Returns the total number of bits written.
     #[inline]
     pub fn bits_written(&self) -> usize {

--- a/jxl-encoder/src/bit_writer.rs
+++ b/jxl-encoder/src/bit_writer.rs
@@ -71,7 +71,7 @@ impl BitWriter {
     /// policy for the initial capacity: `Vec::with_capacity` (infallible) when
     /// `fallible` is false, `try_reserve` (returns [`crate::error::Error::OutOfMemory`]
     /// instead of aborting) when true. Subsequent growth is already fallible.
-    pub fn with_capacity_policy(
+    pub(crate) fn with_capacity_fallible(
         fallible: bool,
         capacity_bytes: usize,
     ) -> crate::error::Result<Self> {

--- a/jxl-encoder/src/budget.rs
+++ b/jxl-encoder/src/budget.rs
@@ -61,6 +61,11 @@ pub(crate) struct MemoryBudget {
     /// guards: `false` uses `vec![v; n]` (one `calloc`, faster), `true` uses
     /// `try_reserve_exact` (graceful OOM on untrusted sizes). See
     /// [`try_alloc_zeroed_permanent`] and [`crate::api::Limits::fallible_alloc`].
+    ///
+    /// Read only via [`Self::is_fallible`], whose sole consumers are the
+    /// `jpeg-reencoding` transcode allocations; `dead_code` is expected (the
+    /// field is still written by `with_alloc_policy`) when that feature is off.
+    #[cfg_attr(not(feature = "jpeg-reencoding"), allow(dead_code))]
     fallible: bool,
 }
 
@@ -83,6 +88,10 @@ impl MemoryBudget {
 
     /// Whether dimension-driven buffers should be allocated fallibly
     /// (`try_reserve`) rather than via the faster infallible `vec!` path.
+    ///
+    /// Consumed only by the `jpeg-reencoding` transcode allocations, so it is
+    /// dead code when that feature is off.
+    #[cfg_attr(not(feature = "jpeg-reencoding"), allow(dead_code))]
     pub fn is_fallible(&self) -> bool {
         self.fallible
     }
@@ -371,6 +380,10 @@ pub(crate) fn try_alloc_vec_f32_dirty_permanent(
 /// [`Error::OutOfMemory`] instead of aborting) when true. Capacity sizing only
 /// — reserves nothing against a [`MemoryBudget`]; pair with an explicit
 /// `reserve_permanent_opt` for the budget accounting.
+///
+/// Used only by the `jpeg-reencoding` transcode allocations — dead code when
+/// that feature is off.
+#[cfg_attr(not(feature = "jpeg-reencoding"), allow(dead_code))]
 pub(crate) fn vec_with_capacity_policy<T>(fallible: bool, cap: usize) -> Result<Vec<T>> {
     if fallible {
         let mut v: Vec<T> = Vec::new();
@@ -392,6 +405,10 @@ pub(crate) fn vec_with_capacity_policy<T>(fallible: bool, cap: usize) -> Result<
 ///
 /// `None` budget reserves nothing and uses the infallible path. Used for the
 /// JPEG-transcode coefficient buffers, sized from untrusted SOF dimensions.
+///
+/// Used only by the `jpeg-reencoding` transcode path — dead code when that
+/// feature is off.
+#[cfg_attr(not(feature = "jpeg-reencoding"), allow(dead_code))]
 pub(crate) fn try_alloc_zeroed_permanent<T: Copy + Default>(
     budget: Option<&Arc<MemoryBudget>>,
     len: usize,

--- a/jxl-encoder/src/budget.rs
+++ b/jxl-encoder/src/budget.rs
@@ -376,7 +376,7 @@ pub(crate) fn try_alloc_vec_f32_dirty_permanent(
 /// [`Error::OutOfMemory`] instead of aborting) when true. Capacity sizing only
 /// — reserves nothing against a [`MemoryBudget`]; pair with an explicit
 /// `reserve_permanent_opt` for the budget accounting.
-pub(crate) fn vec_with_capacity_policy<T>(fallible: bool, cap: usize) -> Result<Vec<T>> {
+pub(crate) fn vec_with_capacity_fallible<T>(fallible: bool, cap: usize) -> Result<Vec<T>> {
     if fallible {
         let mut v: Vec<T> = Vec::new();
         v.try_reserve(cap)?;

--- a/jxl-encoder/src/budget.rs
+++ b/jxl-encoder/src/budget.rs
@@ -61,16 +61,16 @@ pub(crate) struct MemoryBudget {
     /// guards: `false` uses `vec![v; n]` (one `calloc`, faster), `true` uses
     /// `try_reserve_exact` (graceful OOM on untrusted sizes). See
     /// [`try_alloc_zeroed_permanent`] and [`crate::api::Limits::fallible_alloc`].
-    ///
-    /// Read only via [`Self::is_fallible`], whose sole consumers are the
-    /// `jpeg-reencoding` transcode allocations; `dead_code` is expected (the
-    /// field is still written by `with_alloc_policy`) when that feature is off.
-    #[cfg_attr(not(feature = "jpeg-reencoding"), allow(dead_code))]
     fallible: bool,
 }
 
 impl MemoryBudget {
     /// Construct a budget with `cap` bytes available (infallible-alloc policy).
+    ///
+    /// Test-only convenience: production code constructs budgets via
+    /// [`Self::with_alloc_policy`] so the runtime fallible-alloc policy
+    /// (`Limits::fallible_alloc`) is always threaded explicitly.
+    #[cfg(test)]
     pub fn new(cap: u64) -> Arc<Self> {
         Self::with_alloc_policy(cap, false)
     }
@@ -88,10 +88,6 @@ impl MemoryBudget {
 
     /// Whether dimension-driven buffers should be allocated fallibly
     /// (`try_reserve`) rather than via the faster infallible `vec!` path.
-    ///
-    /// Consumed only by the `jpeg-reencoding` transcode allocations, so it is
-    /// dead code when that feature is off.
-    #[cfg_attr(not(feature = "jpeg-reencoding"), allow(dead_code))]
     pub fn is_fallible(&self) -> bool {
         self.fallible
     }
@@ -380,10 +376,6 @@ pub(crate) fn try_alloc_vec_f32_dirty_permanent(
 /// [`Error::OutOfMemory`] instead of aborting) when true. Capacity sizing only
 /// — reserves nothing against a [`MemoryBudget`]; pair with an explicit
 /// `reserve_permanent_opt` for the budget accounting.
-///
-/// Used only by the `jpeg-reencoding` transcode allocations — dead code when
-/// that feature is off.
-#[cfg_attr(not(feature = "jpeg-reencoding"), allow(dead_code))]
 pub(crate) fn vec_with_capacity_policy<T>(fallible: bool, cap: usize) -> Result<Vec<T>> {
     if fallible {
         let mut v: Vec<T> = Vec::new();
@@ -404,11 +396,8 @@ pub(crate) fn vec_with_capacity_policy<T>(fallible: bool, cap: usize) -> Result<
 ///   size cannot be allocated.
 ///
 /// `None` budget reserves nothing and uses the infallible path. Used for the
-/// JPEG-transcode coefficient buffers, sized from untrusted SOF dimensions.
-///
-/// Used only by the `jpeg-reencoding` transcode path — dead code when that
-/// feature is off.
-#[cfg_attr(not(feature = "jpeg-reencoding"), allow(dead_code))]
+/// JPEG-transcode coefficient buffers and the modular channel buffers, both
+/// sized from untrusted dimensions.
 pub(crate) fn try_alloc_zeroed_permanent<T: Copy + Default>(
     budget: Option<&Arc<MemoryBudget>>,
     len: usize,

--- a/jxl-encoder/src/budget.rs
+++ b/jxl-encoder/src/budget.rs
@@ -57,16 +57,34 @@ pub(crate) struct MemoryBudget {
     cap: u64,
     used: AtomicU64,
     peak: AtomicU64,
+    /// Runtime allocation policy for the dimension-driven buffers this budget
+    /// guards: `false` uses `vec![v; n]` (one `calloc`, faster), `true` uses
+    /// `try_reserve_exact` (graceful OOM on untrusted sizes). See
+    /// [`try_alloc_zeroed_permanent`] and [`crate::api::Limits::fallible_alloc`].
+    fallible: bool,
 }
 
 impl MemoryBudget {
-    /// Construct a budget with `cap` bytes available.
+    /// Construct a budget with `cap` bytes available (infallible-alloc policy).
     pub fn new(cap: u64) -> Arc<Self> {
+        Self::with_alloc_policy(cap, false)
+    }
+
+    /// Construct a budget with `cap` bytes available and an explicit
+    /// fallible-allocation policy (`true` = `try_reserve`, `false` = `vec!`).
+    pub fn with_alloc_policy(cap: u64, fallible: bool) -> Arc<Self> {
         Arc::new(Self {
             cap,
             used: AtomicU64::new(0),
             peak: AtomicU64::new(0),
+            fallible,
         })
+    }
+
+    /// Whether dimension-driven buffers should be allocated fallibly
+    /// (`try_reserve`) rather than via the faster infallible `vec!` path.
+    pub fn is_fallible(&self) -> bool {
+        self.fallible
     }
 
     /// Construct a budget that never denies a reservation.
@@ -345,6 +363,49 @@ pub(crate) fn try_alloc_vec_f32_dirty_permanent(
     let bytes = elem_bytes::<f32>(len)?;
     MemoryBudget::reserve_permanent_opt(budget, bytes)?;
     Ok(jxl_simd::vec_f32_dirty(len))
+}
+
+/// Create an empty `Vec<T>` with reserved capacity for `cap` elements, honoring
+/// a runtime fallible-allocation policy: `Vec::with_capacity` (infallible,
+/// fast) when `fallible` is false, `try_reserve` (returns
+/// [`Error::OutOfMemory`] instead of aborting) when true. Capacity sizing only
+/// — reserves nothing against a [`MemoryBudget`]; pair with an explicit
+/// `reserve_permanent_opt` for the budget accounting.
+pub(crate) fn vec_with_capacity_policy<T>(fallible: bool, cap: usize) -> Result<Vec<T>> {
+    if fallible {
+        let mut v: Vec<T> = Vec::new();
+        v.try_reserve(cap)?;
+        Ok(v)
+    } else {
+        Ok(Vec::with_capacity(cap))
+    }
+}
+
+/// Reserve `len * size_of::<T>()` permanently against `budget`, then allocate a
+/// zeroed `Vec<T>`, honoring the budget's **runtime** fallible-allocation
+/// policy ([`MemoryBudget::is_fallible`]):
+/// - infallible (default): `vec![T::default(); len]` — LLVM lowers the zeroed
+///   case to a single `calloc`, the faster path for trusted sizes;
+/// - fallible: `try_reserve_exact` + `resize` — returns
+///   [`Error::OutOfMemory`] instead of aborting if the (untrusted-derived)
+///   size cannot be allocated.
+///
+/// `None` budget reserves nothing and uses the infallible path. Used for the
+/// JPEG-transcode coefficient buffers, sized from untrusted SOF dimensions.
+pub(crate) fn try_alloc_zeroed_permanent<T: Copy + Default>(
+    budget: Option<&Arc<MemoryBudget>>,
+    len: usize,
+) -> Result<Vec<T>> {
+    let bytes = elem_bytes::<T>(len)?;
+    MemoryBudget::reserve_permanent_opt(budget, bytes)?;
+    if budget.is_some_and(|b| b.is_fallible()) {
+        let mut v: Vec<T> = Vec::new();
+        v.try_reserve_exact(len)?;
+        v.resize(len, T::default());
+        Ok(v)
+    } else {
+        Ok(vec![T::default(); len])
+    }
 }
 
 /// Convenience macro: `try_alloc_plane_f32!(budget, w, h)` reserves and

--- a/jxl-encoder/src/jpeg/encode.rs
+++ b/jxl-encoder/src/jpeg/encode.rs
@@ -12,6 +12,7 @@ use super::data::*;
 use super::jbrd::{encode_jbrd, extract_exif, extract_icc, extract_xmp};
 use crate::BLOCK_SIZE;
 use crate::bit_writer::BitWriter;
+use crate::budget::MemoryBudget;
 use crate::container::wrap_in_container_jxlp;
 use crate::entropy_coding::encode::{
     OwnedAnsEntropyCode, build_entropy_code_ans_with_options, write_entropy_code_ans,
@@ -39,6 +40,7 @@ use crate::vardct::dc_coding::{
 use crate::vardct::frame::{
     assemble_frame_sections, write_dc_group_from_tokens, write_quant_scales,
 };
+use alloc::sync::Arc;
 use enough::Stop;
 
 /// Lever A (2026-05-28): when `true`, the JPEG path emits the libjxl-style
@@ -104,38 +106,70 @@ pub fn encode_jpeg_to_jxl(jpeg: &JpegData) -> Result<Vec<u8>> {
 ///
 /// Effort 0-8 is byte-identical to [`encode_jpeg_to_jxl`] (which uses effort 7).
 pub fn encode_jpeg_to_jxl_with_effort(jpeg: &JpegData, effort: u8) -> Result<Vec<u8>> {
-    let (codestream, _split) = encode_jpeg_to_jxl_inner(jpeg, effort, None)?;
+    let (codestream, _split) = encode_jpeg_to_jxl_inner(jpeg, effort, None, None)?;
     Ok(codestream)
 }
 
-/// Like [`encode_jpeg_to_jxl_with_effort`], but polls `stop` at coarse
-/// boundaries (per group during AC token collection, and before the entropy
-/// phase) so a server can abort a slow transcode. `None` is byte-identical
-/// (no poll). Returns [`crate::error::Error::Cancelled`] if cancelled.
+/// Like [`encode_jpeg_to_jxl_with_effort`], but polls `stop` and reserves the
+/// estimated encode working set against `budget` at coarse boundaries (per
+/// group during AC token collection, and before the entropy phase) so a server
+/// can abort or bound a slow transcode. Both `None` are byte-identical (no poll
+/// / no reservation). Returns [`crate::error::Error::Cancelled`] if cancelled
+/// or [`crate::error::Error::AllocationLimit`] if the budget is exceeded.
 pub(crate) fn encode_jpeg_to_jxl_with_effort_stop(
     jpeg: &JpegData,
     effort: u8,
     stop: Option<&dyn Stop>,
+    budget: Option<&Arc<MemoryBudget>>,
 ) -> Result<Vec<u8>> {
-    let (codestream, _split) = encode_jpeg_to_jxl_inner(jpeg, effort, stop)?;
+    let (codestream, _split) = encode_jpeg_to_jxl_inner(jpeg, effort, stop, budget)?;
     Ok(codestream)
 }
 
 /// Inner function that returns both codestream bytes and the file header size
 /// (split point for jxlp box splitting when JBRD is needed).
 ///
-/// `stop` (when `Some`) is polled at coarse boundaries during encoding; `None`
-/// performs no poll and is byte-identical to the pre-cancellation path.
+/// `stop` (when `Some`) is polled at coarse boundaries during encoding; `budget`
+/// (when `Some`) gates the estimated encode working set up front. Both `None`
+/// perform no poll / no reservation and are byte-identical to the
+/// pre-cancellation path.
 fn encode_jpeg_to_jxl_inner(
     jpeg: &JpegData,
     effort: u8,
     stop: Option<&dyn Stop>,
+    budget: Option<&Arc<MemoryBudget>>,
 ) -> Result<(Vec<u8>, usize)> {
     if let Some(s) = stop {
         s.check().map_err(|_| crate::error::Error::Cancelled)?;
     }
     let width = jpeg.width as usize;
     let height = jpeg.height as usize;
+
+    // Pre-flight budget gate for the encode working set, reserved up front so
+    // an oversized untrusted frame is rejected BEFORE the expensive token
+    // collection + histogram clustering. Conservative estimate: ~32 bytes per
+    // DCT coefficient covers the i32 quant arrays (~5 B/coeff), the AC token
+    // stream held twice during clustering (2 × 8 B/coeff), the output buffer,
+    // and clustering scratch. The per-component i16 coefficient buffers are
+    // reserved separately in `read_jpeg_with_stop`. The reservation is an RAII
+    // guard held for this function's scope so it is RELEASED when the encode
+    // returns — the PreserveJxl recompress path runs two encodes on one budget
+    // (lossless floor + lossy) and the working sets do not coexist. `None`
+    // budget is a no-op.
+    const ENCODE_BYTES_PER_COEFF: u64 = 32;
+    let total_coeffs: u64 = jpeg
+        .components
+        .iter()
+        .map(|c| (c.width_in_blocks as u64) * (c.height_in_blocks as u64) * 64)
+        .sum();
+    let est_encode_bytes = total_coeffs.checked_mul(ENCODE_BYTES_PER_COEFF).ok_or(
+        crate::error::Error::AllocationLimit {
+            requested: u64::MAX,
+            used: 0,
+            cap: 0,
+        },
+    )?;
+    let _encode_budget_guard = MemoryBudget::reserve_opt(budget, est_encode_bytes)?;
 
     // Channel mapping: JXL c0=Cb, c1=Y, c2=Cr for YCbCr-flavored frames.
     //   - For semantic-YCbCr (3-comp, libjxl `color_transform == kYCbCr`):
@@ -1308,19 +1342,22 @@ pub fn encode_jpeg_to_jxl_container(jpeg: &JpegData) -> Result<Vec<u8>> {
 /// codestream side. Container wrapping (JBRD / Exif / XMP boxes) is
 /// effort-independent.
 pub fn encode_jpeg_to_jxl_container_with_effort(jpeg: &JpegData, effort: u8) -> Result<Vec<u8>> {
-    encode_jpeg_to_jxl_container_with_effort_stop(jpeg, effort, None)
+    encode_jpeg_to_jxl_container_with_effort_stop(jpeg, effort, None, None)
 }
 
-/// Like [`encode_jpeg_to_jxl_container_with_effort`], but polls `stop` at
-/// coarse boundaries during codestream encoding. `None` is byte-identical
-/// (no poll). Container wrapping itself is fast and not a cancellation point.
-/// Returns [`crate::error::Error::Cancelled`] if cancelled.
+/// Like [`encode_jpeg_to_jxl_container_with_effort`], but polls `stop` and
+/// reserves the estimated encode working set against `budget` at coarse
+/// boundaries during codestream encoding. Both `None` are byte-identical
+/// (no poll / no reservation). Container wrapping itself is fast and not a
+/// cancellation point. Returns [`crate::error::Error::Cancelled`] if cancelled
+/// or [`crate::error::Error::AllocationLimit`] if the budget is exceeded.
 pub(crate) fn encode_jpeg_to_jxl_container_with_effort_stop(
     jpeg: &JpegData,
     effort: u8,
     stop: Option<&dyn Stop>,
+    budget: Option<&Arc<MemoryBudget>>,
 ) -> Result<Vec<u8>> {
-    let (codestream, file_header_size) = encode_jpeg_to_jxl_inner(jpeg, effort, stop)?;
+    let (codestream, file_header_size) = encode_jpeg_to_jxl_inner(jpeg, effort, stop, budget)?;
     let jbrd = encode_jbrd(jpeg)?;
     let exif = extract_exif(jpeg);
     let xmp = extract_xmp(jpeg);

--- a/jxl-encoder/src/jpeg/encode.rs
+++ b/jxl-encoder/src/jpeg/encode.rs
@@ -1997,7 +1997,7 @@ mod tests {
             crate::test_helpers::corpus_dir().display()
         );
         let data = std::fs::read(path).expect("failed to read test JPEG");
-        let jpeg = super::super::parse::read_jpeg(&data, None).expect("failed to parse JPEG");
+        let jpeg = super::super::parse::read_jpeg(&data, None, None).expect("failed to parse JPEG");
         let jxl = encode_jpeg_to_jxl(&jpeg).expect("failed to encode JPEG to JXL");
         assert!(jxl.len() > 10, "JXL output too short: {} bytes", jxl.len());
         // Verify JXL signature
@@ -2019,7 +2019,7 @@ mod tests {
         let path =
             crate::test_helpers::output_dir_for("jpeg-reencoding", "").join("test128_420.jpg");
         let data = std::fs::read(&path).expect("failed to read test JPEG");
-        let jpeg = super::super::parse::read_jpeg(&data, None).expect("failed to parse JPEG");
+        let jpeg = super::super::parse::read_jpeg(&data, None, None).expect("failed to parse JPEG");
 
         // Verify it's actually 4:2:0
         assert_eq!(jpeg.components[0].h_samp_factor, 2);

--- a/jxl-encoder/src/jpeg/encode.rs
+++ b/jxl-encoder/src/jpeg/encode.rs
@@ -1113,7 +1113,7 @@ fn encode_jpeg_to_jxl_inner(
     let total_ac_tokens: usize = ac_lz77_section_tokens.iter().map(|t| t.len()).sum();
     // The AC token stream is covered by the encode working-set reservation at
     // the top of this function; here we only honor the fallible-alloc policy.
-    let mut all_ac_tokens = crate::budget::vec_with_capacity_policy(
+    let mut all_ac_tokens = crate::budget::vec_with_capacity_fallible(
         budget.is_some_and(|b| b.is_fallible()),
         total_ac_tokens,
     )?;
@@ -1198,7 +1198,7 @@ fn encode_jpeg_to_jxl_inner(
             channels: 1,
         })?;
     let mut writer =
-        BitWriter::with_capacity_policy(budget.is_some_and(|b| b.is_fallible()), output_cap)?;
+        BitWriter::with_capacity_fallible(budget.is_some_and(|b| b.is_fallible()), output_cap)?;
 
     // Extract ICC profile from JPEG APP2 markers (if present)
     let icc_profile = extract_icc(jpeg);
@@ -1550,17 +1550,17 @@ fn map_jpeg_coefficients(
         // — heaptrack showed the diffuse entropy/clustering allocations cannot
         // be attributed per-site). Here we only honor the fallible-alloc policy
         // for the row buffers.
-        let mut dc_rows = crate::budget::vec_with_capacity_policy(fallible, yb)?;
-        let mut ac_rows = crate::budget::vec_with_capacity_policy(fallible, yb)?;
-        let mut nz_rows = crate::budget::vec_with_capacity_policy(fallible, yb)?;
-        let mut raw_nz_rows = crate::budget::vec_with_capacity_policy(fallible, yb)?;
+        let mut dc_rows = crate::budget::vec_with_capacity_fallible(fallible, yb)?;
+        let mut ac_rows = crate::budget::vec_with_capacity_fallible(fallible, yb)?;
+        let mut nz_rows = crate::budget::vec_with_capacity_fallible(fallible, yb)?;
+        let mut raw_nz_rows = crate::budget::vec_with_capacity_fallible(fallible, yb)?;
 
         for by in 0..yb {
-            let mut dc_row = crate::budget::vec_with_capacity_policy(fallible, xb)?;
+            let mut dc_row = crate::budget::vec_with_capacity_fallible(fallible, xb)?;
             let mut ac_row: Vec<[i32; BLOCK_SIZE]> =
-                crate::budget::vec_with_capacity_policy(fallible, xb)?;
-            let mut nz_row = crate::budget::vec_with_capacity_policy(fallible, xb)?;
-            let mut raw_nz_row = crate::budget::vec_with_capacity_policy(fallible, xb)?;
+                crate::budget::vec_with_capacity_fallible(fallible, xb)?;
+            let mut nz_row = crate::budget::vec_with_capacity_fallible(fallible, xb)?;
+            let mut raw_nz_row = crate::budget::vec_with_capacity_fallible(fallible, xb)?;
 
             for bx in 0..xb {
                 let blk_idx = by * xb + bx;

--- a/jxl-encoder/src/jpeg/encode.rs
+++ b/jxl-encoder/src/jpeg/encode.rs
@@ -145,18 +145,24 @@ fn encode_jpeg_to_jxl_inner(
     let width = jpeg.width as usize;
     let height = jpeg.height as usize;
 
-    // Pre-flight budget gate for the encode working set, reserved up front so
-    // an oversized untrusted frame is rejected BEFORE the expensive token
-    // collection + histogram clustering. Conservative estimate: ~32 bytes per
-    // DCT coefficient covers the i32 quant arrays (~5 B/coeff), the AC token
-    // stream held twice during clustering (2 × 8 B/coeff), the output buffer,
-    // and clustering scratch. The per-component i16 coefficient buffers are
-    // reserved separately in `read_jpeg_with_stop`. The reservation is an RAII
-    // guard held for this function's scope so it is RELEASED when the encode
-    // returns — the PreserveJxl recompress path runs two encodes on one budget
-    // (lossless floor + lossy) and the working sets do not coexist. `None`
-    // budget is a no-op.
-    const ENCODE_BYTES_PER_COEFF: u64 = 32;
+    // Reserve the encode working set against `budget` up front, so an oversized
+    // untrusted frame is rejected BEFORE the expensive token collection +
+    // histogram clustering. The constant is **measured**, not guessed: heaptrack
+    // of the transcode path (the quant planes + the AC token stream held twice
+    // during clustering + the output buffer + the diffuse ANS/histogram
+    // accumulators, which cannot be attributed to a single allocation site)
+    // peaks at ~44 B per DCT coefficient on the worst real photo measured
+    // (high-detail `wrenches.jpg`, ~2 B of which is the separately-reserved
+    // coefficient buffer). 56 B/coeff applies a ~1.3x margin over that for
+    // more-adversarial content. Provenance:
+    // `benchmarks/transcode_mem_2026-06-18.tsv` (effort-independent: e7 == e9).
+    //
+    // The reservation is an RAII guard released when the encode returns — the
+    // PreserveJxl recompress path runs two encodes (lossless floor + lossy) on
+    // one budget and their working sets do not coexist. The per-component i16
+    // coefficient buffers are reserved separately (and exactly) in
+    // `read_jpeg_with_stop`. `None` budget is a no-op.
+    const ENCODE_BYTES_PER_COEFF: u64 = 56;
     let total_coeffs: u64 = jpeg
         .components
         .iter()
@@ -304,7 +310,7 @@ fn encode_jpeg_to_jxl_inner(
     // Map JPEG coefficients to JXL data structures
     // Each channel uses its native block dimensions (may differ for subsampled chroma)
     let (mut quant_dc, mut quant_ac, mut nzeros, mut raw_nzeros) =
-        map_jpeg_coefficients(jpeg, &jpeg_c_map, &dc_offset)?;
+        map_jpeg_coefficients(jpeg, &jpeg_c_map, &dc_offset, budget)?;
 
     let is_gray = num_components == 1;
 
@@ -1105,7 +1111,12 @@ fn encode_jpeg_to_jxl_inner(
     // context map / distributions; we write the per-section tokens (in
     // `ac_lz77_section_tokens`) at the end with the shared `ac_code`.
     let total_ac_tokens: usize = ac_lz77_section_tokens.iter().map(|t| t.len()).sum();
-    let mut all_ac_tokens = Vec::with_capacity(total_ac_tokens);
+    // The AC token stream is covered by the encode working-set reservation at
+    // the top of this function; here we only honor the fallible-alloc policy.
+    let mut all_ac_tokens = crate::budget::vec_with_capacity_policy(
+        budget.is_some_and(|b| b.is_fallible()),
+        total_ac_tokens,
+    )?;
     for section in &ac_lz77_section_tokens {
         all_ac_tokens.extend_from_slice(section);
     }
@@ -1175,7 +1186,19 @@ fn encode_jpeg_to_jxl_inner(
 
     // ── Pass 2: Write bitstream ──
 
-    let mut writer = BitWriter::with_capacity(width * height * 4);
+    // The output buffer (~4 B/pixel) is covered by the encode working-set
+    // reservation at the top of this function; honor the fallible-alloc policy
+    // for the initial capacity (growth is already fallible).
+    let output_cap = width
+        .checked_mul(height)
+        .and_then(|n| n.checked_mul(4))
+        .ok_or(crate::error::Error::DimensionOverflow {
+            width,
+            height,
+            channels: 1,
+        })?;
+    let mut writer =
+        BitWriter::with_capacity_policy(budget.is_some_and(|b| b.is_fallible()), output_cap)?;
 
     // Extract ICC profile from JPEG APP2 markers (if present)
     let icc_profile = extract_icc(jpeg);
@@ -1508,7 +1531,9 @@ fn map_jpeg_coefficients(
     jpeg: &JpegData,
     jpeg_c_map: &[usize; 3],
     dc_offset: &[i32; 3],
+    budget: Option<&Arc<MemoryBudget>>,
 ) -> Result<JpegCoefficientPlanes> {
+    let fallible = budget.is_some_and(|b| b.is_fallible());
     let mut quant_dc: [Vec<Vec<i16>>; 3] = [Vec::new(), Vec::new(), Vec::new()];
     let mut quant_ac: [Vec<Vec<[i32; BLOCK_SIZE]>>; 3] = [Vec::new(), Vec::new(), Vec::new()];
     let mut nzeros: [Vec<Vec<u8>>; 3] = [Vec::new(), Vec::new(), Vec::new()];
@@ -1520,16 +1545,22 @@ fn map_jpeg_coefficients(
         let xb = comp.width_in_blocks as usize;
         let yb = comp.height_in_blocks as usize;
 
-        let mut dc_rows = Vec::with_capacity(yb);
-        let mut ac_rows = Vec::with_capacity(yb);
-        let mut nz_rows = Vec::with_capacity(yb);
-        let mut raw_nz_rows = Vec::with_capacity(yb);
+        // The quant planes are covered by the encode working-set reservation in
+        // `encode_jpeg_to_jxl_inner` (a single measured per-coefficient estimate
+        // — heaptrack showed the diffuse entropy/clustering allocations cannot
+        // be attributed per-site). Here we only honor the fallible-alloc policy
+        // for the row buffers.
+        let mut dc_rows = crate::budget::vec_with_capacity_policy(fallible, yb)?;
+        let mut ac_rows = crate::budget::vec_with_capacity_policy(fallible, yb)?;
+        let mut nz_rows = crate::budget::vec_with_capacity_policy(fallible, yb)?;
+        let mut raw_nz_rows = crate::budget::vec_with_capacity_policy(fallible, yb)?;
 
         for by in 0..yb {
-            let mut dc_row = Vec::with_capacity(xb);
-            let mut ac_row: Vec<[i32; BLOCK_SIZE]> = Vec::with_capacity(xb);
-            let mut nz_row = Vec::with_capacity(xb);
-            let mut raw_nz_row = Vec::with_capacity(xb);
+            let mut dc_row = crate::budget::vec_with_capacity_policy(fallible, xb)?;
+            let mut ac_row: Vec<[i32; BLOCK_SIZE]> =
+                crate::budget::vec_with_capacity_policy(fallible, xb)?;
+            let mut nz_row = crate::budget::vec_with_capacity_policy(fallible, xb)?;
+            let mut raw_nz_row = crate::budget::vec_with_capacity_policy(fallible, xb)?;
 
             for bx in 0..xb {
                 let blk_idx = by * xb + bx;

--- a/jxl-encoder/src/jpeg/encode.rs
+++ b/jxl-encoder/src/jpeg/encode.rs
@@ -39,6 +39,7 @@ use crate::vardct::dc_coding::{
 use crate::vardct::frame::{
     assemble_frame_sections, write_dc_group_from_tokens, write_quant_scales,
 };
+use enough::Stop;
 
 /// Lever A (2026-05-28): when `true`, the JPEG path emits the libjxl-style
 /// `kJpegTranscodeACMeta` context tree shape (single `Leaf(Zero)` for the
@@ -103,13 +104,36 @@ pub fn encode_jpeg_to_jxl(jpeg: &JpegData) -> Result<Vec<u8>> {
 ///
 /// Effort 0-8 is byte-identical to [`encode_jpeg_to_jxl`] (which uses effort 7).
 pub fn encode_jpeg_to_jxl_with_effort(jpeg: &JpegData, effort: u8) -> Result<Vec<u8>> {
-    let (codestream, _split) = encode_jpeg_to_jxl_inner(jpeg, effort)?;
+    let (codestream, _split) = encode_jpeg_to_jxl_inner(jpeg, effort, None)?;
+    Ok(codestream)
+}
+
+/// Like [`encode_jpeg_to_jxl_with_effort`], but polls `stop` at coarse
+/// boundaries (per group during AC token collection, and before the entropy
+/// phase) so a server can abort a slow transcode. `None` is byte-identical
+/// (no poll). Returns [`crate::error::Error::Cancelled`] if cancelled.
+pub(crate) fn encode_jpeg_to_jxl_with_effort_stop(
+    jpeg: &JpegData,
+    effort: u8,
+    stop: Option<&dyn Stop>,
+) -> Result<Vec<u8>> {
+    let (codestream, _split) = encode_jpeg_to_jxl_inner(jpeg, effort, stop)?;
     Ok(codestream)
 }
 
 /// Inner function that returns both codestream bytes and the file header size
 /// (split point for jxlp box splitting when JBRD is needed).
-fn encode_jpeg_to_jxl_inner(jpeg: &JpegData, effort: u8) -> Result<(Vec<u8>, usize)> {
+///
+/// `stop` (when `Some`) is polled at coarse boundaries during encoding; `None`
+/// performs no poll and is byte-identical to the pre-cancellation path.
+fn encode_jpeg_to_jxl_inner(
+    jpeg: &JpegData,
+    effort: u8,
+    stop: Option<&dyn Stop>,
+) -> Result<(Vec<u8>, usize)> {
+    if let Some(s) = stop {
+        s.check().map_err(|_| crate::error::Error::Cancelled)?;
+    }
     let width = jpeg.width as usize;
     let height = jpeg.height as usize;
 
@@ -778,6 +802,11 @@ fn encode_jpeg_to_jxl_inner(jpeg: &JpegData, effort: u8) -> Result<(Vec<u8>, usi
 
     let mut ac_section_tokens: Vec<Vec<Token>> = Vec::with_capacity(num_groups);
     for group_idx in 0..num_groups {
+        // Coarse cancellation point (per group, NOT per block — the inner
+        // block loops are hot). Byte-identical when `stop` is `None`.
+        if let Some(s) = stop {
+            s.check().map_err(|_| crate::error::Error::Cancelled)?;
+        }
         let group_x = group_idx % xsize_groups;
         let group_y = group_idx / xsize_groups;
         let start_bx = group_x * GROUP_DIM_IN_BLOCKS;
@@ -880,6 +909,11 @@ fn encode_jpeg_to_jxl_inner(jpeg: &JpegData, effort: u8) -> Result<(Vec<u8>, usi
     } else {
         NUM_DC_CONTEXTS
     };
+    // Coarse cancellation point before the entropy phase (histogram
+    // clustering + ANS — the dominant cost at high effort).
+    if let Some(s) = stop {
+        s.check().map_err(|_| crate::error::Error::Cancelled)?;
+    }
     let total_dc_tokens: usize = dc_tokens_per_group.iter().map(|t| t.len()).sum::<usize>()
         + ac_metadata_tokens_per_group
             .iter()
@@ -1091,6 +1125,11 @@ fn encode_jpeg_to_jxl_inner(jpeg: &JpegData, effort: u8) -> Result<(Vec<u8>, usi
     // result was 0 bytes / 50 files difference. At typical JPEG corpus
     // sizes the cap doesn't materially bind — kBest pair-merge converges
     // organically below the cap. Kept the existing hint for stability.
+    // Coarse cancellation point before the AC histogram clustering — the
+    // single heaviest op at effort 9 (kBest pair-merge over all AC tokens).
+    if let Some(s) = stop {
+        s.check().map_err(|_| crate::error::Error::Cancelled)?;
+    }
     let ac_code = build_entropy_code_ans_with_options(
         &all_ac_tokens,
         ac_code_num_contexts,
@@ -1269,7 +1308,19 @@ pub fn encode_jpeg_to_jxl_container(jpeg: &JpegData) -> Result<Vec<u8>> {
 /// codestream side. Container wrapping (JBRD / Exif / XMP boxes) is
 /// effort-independent.
 pub fn encode_jpeg_to_jxl_container_with_effort(jpeg: &JpegData, effort: u8) -> Result<Vec<u8>> {
-    let (codestream, file_header_size) = encode_jpeg_to_jxl_inner(jpeg, effort)?;
+    encode_jpeg_to_jxl_container_with_effort_stop(jpeg, effort, None)
+}
+
+/// Like [`encode_jpeg_to_jxl_container_with_effort`], but polls `stop` at
+/// coarse boundaries during codestream encoding. `None` is byte-identical
+/// (no poll). Container wrapping itself is fast and not a cancellation point.
+/// Returns [`crate::error::Error::Cancelled`] if cancelled.
+pub(crate) fn encode_jpeg_to_jxl_container_with_effort_stop(
+    jpeg: &JpegData,
+    effort: u8,
+    stop: Option<&dyn Stop>,
+) -> Result<Vec<u8>> {
+    let (codestream, file_header_size) = encode_jpeg_to_jxl_inner(jpeg, effort, stop)?;
     let jbrd = encode_jbrd(jpeg)?;
     let exif = extract_exif(jpeg);
     let xmp = extract_xmp(jpeg);

--- a/jxl-encoder/src/jpeg/encode.rs
+++ b/jxl-encoder/src/jpeg/encode.rs
@@ -1878,7 +1878,7 @@ mod tests {
             crate::test_helpers::corpus_dir().display()
         );
         let data = std::fs::read(path).expect("failed to read test JPEG");
-        let jpeg = super::super::parse::read_jpeg(&data).expect("failed to parse JPEG");
+        let jpeg = super::super::parse::read_jpeg(&data, None).expect("failed to parse JPEG");
         let jxl = encode_jpeg_to_jxl(&jpeg).expect("failed to encode JPEG to JXL");
         assert!(jxl.len() > 10, "JXL output too short: {} bytes", jxl.len());
         // Verify JXL signature
@@ -1900,7 +1900,7 @@ mod tests {
         let path =
             crate::test_helpers::output_dir_for("jpeg-reencoding", "").join("test128_420.jpg");
         let data = std::fs::read(&path).expect("failed to read test JPEG");
-        let jpeg = super::super::parse::read_jpeg(&data).expect("failed to parse JPEG");
+        let jpeg = super::super::parse::read_jpeg(&data, None).expect("failed to parse JPEG");
 
         // Verify it's actually 4:2:0
         assert_eq!(jpeg.components[0].h_samp_factor, 2);

--- a/jxl-encoder/src/jpeg/jbrd.rs
+++ b/jxl-encoder/src/jpeg/jbrd.rs
@@ -278,7 +278,15 @@ fn write_u32_jbrd(
         }
     }
 
-    unreachable!("No selector matched for value {value}");
+    // With a well-formed 4-selector table the `is_last` (selector >= 3) branch
+    // above always matches, so this is normally unreachable. Return a typed
+    // error rather than panicking on the write path (#77 item 3) — a malformed
+    // selector table or an out-of-range value must not abort the process.
+    Err(crate::error::Error::InvalidInput(format!(
+        "JBRD U32 value {value} matched no selector ({} direct + {} bits/offset)",
+        direct_values.len(),
+        bits_offset.len()
+    )))
 }
 
 /// Brotli-compress data. Returns compressed bytes.

--- a/jxl-encoder/src/jpeg/jbrd.rs
+++ b/jxl-encoder/src/jpeg/jbrd.rs
@@ -379,3 +379,37 @@ pub(crate) fn extract_xmp(jpeg: &JpegData) -> Option<Vec<u8>> {
     }
     None
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// #77 item 3: an out-of-range JBRD U32 value that matches no selector in a
+    /// malformed (< 4-selector) table returns a typed `InvalidInput` error
+    /// instead of panicking on the write path. With a well-formed 4-selector
+    /// table the `is_last` (selector >= 3) branch always matches, so this only
+    /// fires on a corrupt table — but it must degrade to an error, not abort.
+    #[test]
+    fn write_u32_jbrd_no_selector_match_is_typed_error() {
+        let mut w = BitWriter::new();
+        // 1 direct (value 1) + 1 bits/offset (2 bits, offset 100) = 2 selectors,
+        // so `is_last` never trips. value=5 matches neither the direct (5 != 1)
+        // nor the offset range (5 < 100) → the typed-error fallback fires.
+        let r = write_u32_jbrd(&mut w, 5, &[1], &[(2, 100)]);
+        assert!(
+            matches!(r, Err(crate::error::Error::InvalidInput(_))),
+            "expected InvalidInput, got {r:?}"
+        );
+    }
+
+    /// Regression guard: a well-formed 4-selector table always encodes (selector
+    /// 3 is the catch-all `is_last` branch) — the fallback must not fire on the
+    /// normal path.
+    #[test]
+    fn write_u32_jbrd_well_formed_table_encodes() {
+        let mut w = BitWriter::new();
+        // 2 direct + 2 bits/offset = 4 selectors; value 999 lands on selector 3.
+        let r = write_u32_jbrd(&mut w, 999, &[0, 1], &[(4, 2), (16, 0)]);
+        assert!(r.is_ok(), "well-formed table should encode, got {r:?}");
+    }
+}

--- a/jxl-encoder/src/jpeg/mod.rs
+++ b/jxl-encoder/src/jpeg/mod.rs
@@ -54,10 +54,23 @@ fn read_jpeg_for_recompress(
     let cap = limits
         .and_then(|l| l.max_memory_bytes())
         .unwrap_or(Limits::DEFAULT_MAX_MEMORY_BYTES_LOSSLESS);
-    let budget = MemoryBudget::new(cap);
+    let fallible = limits.is_some_and(|l| l.fallible_alloc());
+    let budget = MemoryBudget::with_alloc_policy(cap, fallible);
     let jpeg =
         read_jpeg_with_stop(jpeg_bytes, max_pixels, stop, Some(&budget)).map_err(|e| match e {
             JpegError::Cancelled => crate::error::Error::Cancelled,
+            // A budget rejection is a resource limit, not malformed input — map
+            // it to the limit variant rather than funnelling it into
+            // `InvalidInput` (which wrongly implies a bad JPEG). The structured
+            // fields were stringified crossing the public `JpegError` boundary,
+            // but we own the budget here, so reconstruct from its live state:
+            // `cap`/`used` are exact at the point of failure; the failing
+            // `requested` amount is not recoverable across the boundary (0).
+            JpegError::ResourceLimit(_) => crate::error::Error::AllocationLimit {
+                requested: 0,
+                used: budget.used(),
+                cap: budget.cap(),
+            },
             other => crate::error::Error::InvalidInput(alloc::format!("JPEG parse: {other:?}")),
         })?;
     Ok((jpeg, budget))

--- a/jxl-encoder/src/jpeg/mod.rs
+++ b/jxl-encoder/src/jpeg/mod.rs
@@ -19,10 +19,16 @@ pub use encode::{
     encode_jpeg_to_jxl, encode_jpeg_to_jxl_container, encode_jpeg_to_jxl_container_with_effort,
     encode_jpeg_to_jxl_with_effort,
 };
+// Cancellable (Stop-polling) variants — internal; the public transcode entry
+// points in `api.rs` use these for `*_with_stop`. See issue #77 item 2.
+pub(crate) use encode::{
+    encode_jpeg_to_jxl_container_with_effort_stop, encode_jpeg_to_jxl_with_effort_stop,
+};
 pub use lossy::{
     coarsen_coefficients, coarsen_coefficients_auto, coarsen_coefficients_dz,
     coarsen_coefficients_planar, coarsen_policy,
 };
+pub(crate) use parse::read_jpeg_with_stop;
 pub use parse::{JpegError, read_jpeg};
 
 /// PreserveJxl: coefficient-domain lossy JPEG → bare JXL codestream.

--- a/jxl-encoder/src/jpeg/mod.rs
+++ b/jxl-encoder/src/jpeg/mod.rs
@@ -31,6 +31,38 @@ pub use lossy::{
 pub(crate) use parse::read_jpeg_with_stop;
 pub use parse::{JpegError, read_jpeg};
 
+use crate::api::Limits;
+use crate::budget::MemoryBudget;
+use alloc::sync::Arc;
+use enough::Stop;
+
+/// Shared decode + resource-bound setup for the PreserveJxl recompress entry
+/// points (#77 follow-up).
+///
+/// Builds a per-encode [`MemoryBudget`] from `limits` (the lossless default
+/// cap when unset, since PreserveJxl emits a lossless-floored transcode),
+/// applies the pre-flight SOF pixel cap, polls `stop` during the decode, and
+/// reserves the coefficient buffers — then returns the parsed [`JpegData`]
+/// alongside the budget for the downstream encode(s) to share. `None` limits /
+/// stop give the secure default cap / an unstoppable run.
+fn read_jpeg_for_recompress(
+    jpeg_bytes: &[u8],
+    limits: Option<&Limits>,
+    stop: Option<&dyn Stop>,
+) -> Result<(JpegData, Arc<MemoryBudget>), crate::error::Error> {
+    let max_pixels = limits.and_then(|l| l.max_pixels());
+    let cap = limits
+        .and_then(|l| l.max_memory_bytes())
+        .unwrap_or(Limits::DEFAULT_MAX_MEMORY_BYTES_LOSSLESS);
+    let budget = MemoryBudget::new(cap);
+    let jpeg =
+        read_jpeg_with_stop(jpeg_bytes, max_pixels, stop, Some(&budget)).map_err(|e| match e {
+            JpegError::Cancelled => crate::error::Error::Cancelled,
+            other => crate::error::Error::InvalidInput(alloc::format!("JPEG parse: {other:?}")),
+        })?;
+    Ok((jpeg, budget))
+}
+
 /// PreserveJxl: coefficient-domain lossy JPEG → bare JXL codestream.
 ///
 /// Parses `jpeg_bytes`, coarsens its quantized DCT coefficients in the DCT
@@ -45,27 +77,32 @@ pub use parse::{JpegError, read_jpeg};
 /// sparse source), the lossless transcode is returned instead — never a
 /// larger, quality-degraded file.
 ///
+/// `limits` bounds this untrusted-bytes path (pre-flight SOF pixel cap +
+/// per-encode [`MemoryBudget`]); `None` applies the secure defaults
+/// ([`Limits::DEFAULT_MAX_JPEG_TRANSCODE_PIXELS`] = 120 MP and the lossless
+/// memory default). `stop` ([`enough::Stop`]) is polled at coarse boundaries
+/// during both the decode and the two encodes, returning
+/// [`crate::error::Error::Cancelled`] on cancellation; `None` is unstoppable.
+///
 /// Requires the `jpeg-reencoding` feature.
 pub fn encode_jpeg_recompress_codestream(
     jpeg_bytes: &[u8],
     scale: f32,
     dz: f32,
     effort: u8,
+    limits: Option<&Limits>,
+    stop: Option<&dyn Stop>,
 ) -> Result<alloc::vec::Vec<u8>, crate::error::Error> {
-    // `None` applies the default `Limits::DEFAULT_MAX_JPEG_TRANSCODE_PIXELS`
-    // (120 MP) pre-flight cap. These PreserveJxl free functions take no
-    // `Limits` yet; threading a configurable cap is tracked in issue #77.
-    let jpeg = read_jpeg(jpeg_bytes, None)
-        .map_err(|e| crate::error::Error::InvalidInput(alloc::format!("JPEG parse: {e:?}")))?;
+    let (jpeg, budget) = read_jpeg_for_recompress(jpeg_bytes, limits, stop)?;
     // Lossless transcode is the "do no harm" floor.
-    let lossless = encode_jpeg_to_jxl_with_effort(&jpeg, effort)?;
+    let lossless = encode_jpeg_to_jxl_with_effort_stop(&jpeg, effort, stop, Some(&budget))?;
     // NaN-safe: NaN selects the lossless floor, same as scale <= 1.0.
     if scale.is_nan() || scale <= 1.0 {
         return Ok(lossless);
     }
     let mut coarsened = jpeg;
     coarsen_coefficients_dz(&mut coarsened, scale, dz);
-    let lossy = encode_jpeg_to_jxl_with_effort(&coarsened, effort)?;
+    let lossy = encode_jpeg_to_jxl_with_effort_stop(&coarsened, effort, stop, Some(&budget))?;
     // No-size-regression guard (RECOMPRESSION_COMPENDIUM §10.6): never ship a
     // larger, quality-degraded file than the lossless transcode.
     if lossy.len() < lossless.len() {
@@ -83,25 +120,26 @@ pub fn encode_jpeg_recompress_codestream(
 /// This is the recommended PreserveJxl entry point — it bakes in the frontier
 /// findings so callers do not hand-tune deadzone/chroma.
 ///
+/// See [`encode_jpeg_recompress_codestream`] for the `limits` / `stop`
+/// resource-bound + cancellation contract.
+///
 /// Requires the `jpeg-reencoding` feature.
 pub fn encode_jpeg_recompress_auto_codestream(
     jpeg_bytes: &[u8],
     scale: f32,
     effort: u8,
+    limits: Option<&Limits>,
+    stop: Option<&dyn Stop>,
 ) -> Result<alloc::vec::Vec<u8>, crate::error::Error> {
-    // `None` applies the default `Limits::DEFAULT_MAX_JPEG_TRANSCODE_PIXELS`
-    // (120 MP) pre-flight cap. These PreserveJxl free functions take no
-    // `Limits` yet; threading a configurable cap is tracked in issue #77.
-    let jpeg = read_jpeg(jpeg_bytes, None)
-        .map_err(|e| crate::error::Error::InvalidInput(alloc::format!("JPEG parse: {e:?}")))?;
-    let lossless = encode_jpeg_to_jxl_with_effort(&jpeg, effort)?;
+    let (jpeg, budget) = read_jpeg_for_recompress(jpeg_bytes, limits, stop)?;
+    let lossless = encode_jpeg_to_jxl_with_effort_stop(&jpeg, effort, stop, Some(&budget))?;
     // NaN-safe: NaN selects the lossless floor, same as scale <= 1.0.
     if scale.is_nan() || scale <= 1.0 {
         return Ok(lossless);
     }
     let mut coarsened = jpeg;
     coarsen_coefficients_auto(&mut coarsened, scale);
-    let lossy = encode_jpeg_to_jxl_with_effort(&coarsened, effort)?;
+    let lossy = encode_jpeg_to_jxl_with_effort_stop(&coarsened, effort, stop, Some(&budget))?;
     if lossy.len() < lossless.len() {
         Ok(lossy)
     } else {
@@ -113,7 +151,14 @@ pub fn encode_jpeg_recompress_auto_codestream(
 /// [`coarsen_coefficients_planar`]). Same no-size-regression guard as
 /// [`encode_jpeg_recompress_codestream`].
 ///
+/// See [`encode_jpeg_recompress_codestream`] for the `limits` / `stop`
+/// resource-bound + cancellation contract.
+///
 /// Requires the `jpeg-reencoding` feature.
+// Separate luma/chroma scale+deadzone (4) + effort + bytes + limits + stop = 8;
+// these are the PreserveJxl ablation knobs and this entry is slated to move to
+// zenjxl, so the wide signature is acceptable.
+#[allow(clippy::too_many_arguments)]
 pub fn encode_jpeg_recompress_planar_codestream(
     jpeg_bytes: &[u8],
     luma_scale: f32,
@@ -121,19 +166,17 @@ pub fn encode_jpeg_recompress_planar_codestream(
     chroma_scale: f32,
     chroma_dz: f32,
     effort: u8,
+    limits: Option<&Limits>,
+    stop: Option<&dyn Stop>,
 ) -> Result<alloc::vec::Vec<u8>, crate::error::Error> {
-    // `None` applies the default `Limits::DEFAULT_MAX_JPEG_TRANSCODE_PIXELS`
-    // (120 MP) pre-flight cap. These PreserveJxl free functions take no
-    // `Limits` yet; threading a configurable cap is tracked in issue #77.
-    let jpeg = read_jpeg(jpeg_bytes, None)
-        .map_err(|e| crate::error::Error::InvalidInput(alloc::format!("JPEG parse: {e:?}")))?;
-    let lossless = encode_jpeg_to_jxl_with_effort(&jpeg, effort)?;
+    let (jpeg, budget) = read_jpeg_for_recompress(jpeg_bytes, limits, stop)?;
+    let lossless = encode_jpeg_to_jxl_with_effort_stop(&jpeg, effort, stop, Some(&budget))?;
     if !(luma_scale > 1.0 || chroma_scale > 1.0) {
         return Ok(lossless);
     }
     let mut coarsened = jpeg;
     coarsen_coefficients_planar(&mut coarsened, luma_scale, luma_dz, chroma_scale, chroma_dz);
-    let lossy = encode_jpeg_to_jxl_with_effort(&coarsened, effort)?;
+    let lossy = encode_jpeg_to_jxl_with_effort_stop(&coarsened, effort, stop, Some(&budget))?;
     if lossy.len() < lossless.len() {
         Ok(lossy)
     } else {

--- a/jxl-encoder/src/jpeg/mod.rs
+++ b/jxl-encoder/src/jpeg/mod.rs
@@ -46,7 +46,10 @@ pub fn encode_jpeg_recompress_codestream(
     dz: f32,
     effort: u8,
 ) -> Result<alloc::vec::Vec<u8>, crate::error::Error> {
-    let jpeg = read_jpeg(jpeg_bytes)
+    // `None` applies the default `Limits::DEFAULT_MAX_JPEG_TRANSCODE_PIXELS`
+    // (120 MP) pre-flight cap. These PreserveJxl free functions take no
+    // `Limits` yet; threading a configurable cap is tracked in issue #77.
+    let jpeg = read_jpeg(jpeg_bytes, None)
         .map_err(|e| crate::error::Error::InvalidInput(alloc::format!("JPEG parse: {e:?}")))?;
     // Lossless transcode is the "do no harm" floor.
     let lossless = encode_jpeg_to_jxl_with_effort(&jpeg, effort)?;
@@ -80,7 +83,10 @@ pub fn encode_jpeg_recompress_auto_codestream(
     scale: f32,
     effort: u8,
 ) -> Result<alloc::vec::Vec<u8>, crate::error::Error> {
-    let jpeg = read_jpeg(jpeg_bytes)
+    // `None` applies the default `Limits::DEFAULT_MAX_JPEG_TRANSCODE_PIXELS`
+    // (120 MP) pre-flight cap. These PreserveJxl free functions take no
+    // `Limits` yet; threading a configurable cap is tracked in issue #77.
+    let jpeg = read_jpeg(jpeg_bytes, None)
         .map_err(|e| crate::error::Error::InvalidInput(alloc::format!("JPEG parse: {e:?}")))?;
     let lossless = encode_jpeg_to_jxl_with_effort(&jpeg, effort)?;
     // NaN-safe: NaN selects the lossless floor, same as scale <= 1.0.
@@ -110,7 +116,10 @@ pub fn encode_jpeg_recompress_planar_codestream(
     chroma_dz: f32,
     effort: u8,
 ) -> Result<alloc::vec::Vec<u8>, crate::error::Error> {
-    let jpeg = read_jpeg(jpeg_bytes)
+    // `None` applies the default `Limits::DEFAULT_MAX_JPEG_TRANSCODE_PIXELS`
+    // (120 MP) pre-flight cap. These PreserveJxl free functions take no
+    // `Limits` yet; threading a configurable cap is tracked in issue #77.
+    let jpeg = read_jpeg(jpeg_bytes, None)
         .map_err(|e| crate::error::Error::InvalidInput(alloc::format!("JPEG parse: {e:?}")))?;
     let lossless = encode_jpeg_to_jxl_with_effort(&jpeg, effort)?;
     if !(luma_scale > 1.0 || chroma_scale > 1.0) {

--- a/jxl-encoder/src/jpeg/parse.rs
+++ b/jxl-encoder/src/jpeg/parse.rs
@@ -42,16 +42,52 @@ type Result<T> = core::result::Result<T, JpegError>;
 /// 1. Marker scan: extracts marker structure, Huffman/quant tables, APP/COM data
 /// 2. zenjpeg decode: extracts quantized DCT coefficients reliably
 ///
-/// `max_pixels` is the pre-flight cap applied to the untrusted SOF
-/// `width × height` *before* any per-block coefficient buffer is allocated
-/// (the transcode path builds no `MemoryBudget`). `None`
-/// applies the secure default
-/// [`crate::api::Limits::DEFAULT_MAX_JPEG_TRANSCODE_PIXELS`] (120 MP);
-/// callers thread their own cap from [`crate::api::Limits::max_pixels`]
-/// (e.g. via [`crate::api::LosslessConfig::with_limits`]). Pass
-/// `Some(u64::MAX)` to opt out of the cap entirely (trusted input only).
-pub fn read_jpeg(data: &[u8], max_pixels: Option<u64>) -> Result<JpegData> {
-    read_jpeg_with_stop(data, max_pixels, None, None)
+/// `limits` bounds the parse of untrusted bytes; `stop` cancels it. Both
+/// `None` parse with only the secure default pixel cap and no cancellation.
+///
+/// - [`Limits::max_pixels`] is the pre-flight cap on the SOF `width × height`,
+///   applied *before* any per-block coefficient buffer is allocated; `None`
+///   (or `limits = None`) applies the secure default
+///   [`Limits::DEFAULT_MAX_JPEG_TRANSCODE_PIXELS`] (120 MP). Pass
+///   [`Limits::with_max_pixels`]`(u64::MAX)` to opt out (trusted input only).
+/// - [`Limits::max_memory_bytes`] caps the per-component `i16` coefficient
+///   buffers — the largest attacker-controlled decode allocation — reserved
+///   against a transient [`MemoryBudget`] *before* allocation (8 GiB lossless
+///   default when `limits` is `Some` but the field is unset).
+/// - [`Limits::fallible_alloc`] selects `vec!` (fast) vs `try_reserve`
+///   (graceful OOM) for those buffers.
+/// - `stop` is polled at entry and threaded into the zenjpeg coefficient
+///   decode, returning [`JpegError::Cancelled`] on cancellation.
+///
+/// When `limits` is `None` only the pixel cap applies (no `MemoryBudget`) —
+/// the cap alone bounds dims → coefficient bytes before allocation, so this is
+/// the historical zero-overhead behaviour. Attach limits/stop on the encode
+/// side via [`crate::api::LosslessConfig::with_limits`] /
+/// [`crate::api::EncodeRequest::with_stop`].
+///
+/// [`Limits`]: crate::api::Limits
+/// [`Limits::max_pixels`]: crate::api::Limits::max_pixels
+/// [`Limits::DEFAULT_MAX_JPEG_TRANSCODE_PIXELS`]: crate::api::Limits::DEFAULT_MAX_JPEG_TRANSCODE_PIXELS
+/// [`Limits::with_max_pixels`]: crate::api::Limits::with_max_pixels
+/// [`Limits::max_memory_bytes`]: crate::api::Limits::max_memory_bytes
+/// [`Limits::fallible_alloc`]: crate::api::Limits::fallible_alloc
+pub fn read_jpeg(
+    data: &[u8],
+    limits: Option<&crate::api::Limits>,
+    stop: Option<&dyn Stop>,
+) -> Result<JpegData> {
+    let max_pixels = limits.and_then(|l| l.max_pixels());
+    // Build a transient bounding budget only when the caller supplies limits;
+    // `None` preserves the historical pixel-cap-only behaviour. The budget
+    // bounds parse-time allocation and is dropped on return — the parsed
+    // coefficient buffers live on in the returned `JpegData`.
+    let budget = limits.map(|l| {
+        let cap = l
+            .max_memory_bytes()
+            .unwrap_or(crate::api::Limits::DEFAULT_MAX_MEMORY_BYTES_LOSSLESS);
+        MemoryBudget::with_alloc_policy(cap, l.fallible_alloc())
+    });
+    read_jpeg_with_stop(data, max_pixels, stop, budget.as_ref())
 }
 
 /// Like [`read_jpeg`], but polls `stop` and reserves the coefficient buffers
@@ -849,7 +885,7 @@ mod tests {
     #[test]
     fn read_jpeg_rejects_oversized_sof_before_alloc() {
         // 20000 × 20000 = 400 MP, well over the default 120 MP cap.
-        let result = read_jpeg(&sof_only(20000, 20000), None);
+        let result = read_jpeg(&sof_only(20000, 20000), None, None);
         assert!(
             matches!(&result, Err(JpegError::Invalid(m)) if m.contains("120 MP")),
             "expected the 120 MP cap rejection, got {result:?}"
@@ -860,7 +896,7 @@ mod tests {
     /// — it fails later for missing scan data, never with the cap message.
     #[test]
     fn read_jpeg_does_not_cap_normal_dimensions() {
-        let result = read_jpeg(&sof_only(4096, 4096), None); // 16.8 MP
+        let result = read_jpeg(&sof_only(4096, 4096), None, None); // 16.8 MP
         if let Err(JpegError::Invalid(m)) = &result {
             assert!(
                 !m.contains("MP transcode pixel cap"),
@@ -876,7 +912,11 @@ mod tests {
     fn read_jpeg_pixel_cap_is_configurable() {
         // (a) A tighter cap rejects a frame the default would admit: 4096×4096
         //     (16.8 MP) under a 10 MP cap fails AT the cap, before allocation.
-        let tight = read_jpeg(&sof_only(4096, 4096), Some(10_000_000));
+        let tight = read_jpeg(
+            &sof_only(4096, 4096),
+            Some(&crate::api::Limits::new().with_max_pixels(10_000_000)),
+            None,
+        );
         assert!(
             matches!(&tight, Err(JpegError::Invalid(m)) if m.contains("10 MP transcode pixel cap")),
             "expected the 10 MP cap rejection, got {tight:?}"
@@ -885,7 +925,11 @@ mod tests {
         // (b) A looser cap admits a frame the default would reject: 20000×20000
         //     (400 MP) under a 500 MP cap passes the cap (then fails later for
         //     missing scan data — never with the cap message).
-        let loose = read_jpeg(&sof_only(20000, 20000), Some(500_000_000));
+        let loose = read_jpeg(
+            &sof_only(20000, 20000),
+            Some(&crate::api::Limits::new().with_max_pixels(500_000_000)),
+            None,
+        );
         if let Err(JpegError::Invalid(m)) = &loose {
             assert!(
                 !m.contains("transcode pixel cap"),
@@ -895,13 +939,68 @@ mod tests {
 
         // (c) `u64::MAX` opts out: even the largest representable JPEG frame
         //     (65535×65535 ≈ 4.29 Gpx) clears the cap.
-        let disabled = read_jpeg(&sof_only(65535, 65535), Some(u64::MAX));
+        let disabled = read_jpeg(
+            &sof_only(65535, 65535),
+            Some(&crate::api::Limits::new().with_max_pixels(u64::MAX)),
+            None,
+        );
         if let Err(JpegError::Invalid(m)) = &disabled {
             assert!(
                 !m.contains("transcode pixel cap"),
                 "u64::MAX should disable the cap, got: {m}"
             );
         }
+    }
+
+    /// The public `read_jpeg` bounds untrusted parsing via `Limits` (memory
+    /// budget + fallible policy) and cancels via `Stop` (#77 / #78). On a real
+    /// fixture (so the coefficient buffers actually allocate): a tight memory
+    /// cap rejects with `ResourceLimit`, a cancelling token aborts with
+    /// `Cancelled`, and `None`/`None` is the historical pixel-cap-only parse.
+    #[cfg(feature = "jpeg-reencoding")]
+    #[test]
+    fn read_jpeg_honours_limits_budget_and_stop() {
+        let data = include_bytes!("../../tests/fixtures/jbrd/base_a_444.jpg");
+
+        // Default parse (no limits, no stop) succeeds.
+        assert!(
+            read_jpeg(data, None, None).is_ok(),
+            "default read_jpeg should parse the fixture"
+        );
+
+        // A 1 KiB memory cap can't fit the coefficient buffers → ResourceLimit
+        // (proves the budget built from `Limits` is threaded into the decode).
+        let tight = crate::api::Limits::new().with_max_memory_bytes(1024);
+        assert!(
+            matches!(
+                read_jpeg(data, Some(&tight), None),
+                Err(JpegError::ResourceLimit(_))
+            ),
+            "expected ResourceLimit under a 1 KiB cap"
+        );
+
+        // A cancelling Stop aborts with Cancelled.
+        struct AlwaysCancel;
+        impl Stop for AlwaysCancel {
+            fn check(&self) -> core::result::Result<(), enough::StopReason> {
+                Err(enough::StopReason::Cancelled)
+            }
+        }
+        assert!(
+            matches!(
+                read_jpeg(data, None, Some(&AlwaysCancel)),
+                Err(JpegError::Cancelled)
+            ),
+            "expected Cancelled from an always-cancelling Stop"
+        );
+
+        // `Unstoppable` + a generous cap is byte-equivalent to the default
+        // parse (the budget/stop plumbing is a no-op on the success path).
+        let generous = crate::api::Limits::new().with_max_memory_bytes(u64::MAX);
+        assert!(
+            read_jpeg(data, Some(&generous), Some(&enough::Unstoppable)).is_ok(),
+            "generous cap + Unstoppable should parse the fixture"
+        );
     }
 
     /// #77 item 3: the per-component coefficient-buffer length is computed with
@@ -961,7 +1060,7 @@ mod tests {
         data.extend_from_slice(&[0xFF, 0xDA]);
         data.extend_from_slice(&0u16.to_be_bytes());
 
-        let result = read_jpeg(&data, None);
+        let result = read_jpeg(&data, None, None);
         assert!(matches!(result, Err(JpegError::Invalid(_))));
     }
 
@@ -991,7 +1090,7 @@ mod tests {
         data.push(1); // Ns
         data.extend_from_slice(&[1, 0x00]); // component selector + table
 
-        let result = read_jpeg(&data, None);
+        let result = read_jpeg(&data, None, None);
         assert!(matches!(result, Err(JpegError::Invalid(_))));
     }
 
@@ -1007,7 +1106,7 @@ mod tests {
             crate::test_helpers::corpus_dir().display()
         );
         let data = std::fs::read(path).expect("failed to read test JPEG");
-        let jpeg = read_jpeg(&data, None).expect("failed to parse JPEG");
+        let jpeg = read_jpeg(&data, None, None).expect("failed to parse JPEG");
 
         assert!(jpeg.width > 0, "width should be nonzero");
         assert!(jpeg.height > 0, "height should be nonzero");

--- a/jxl-encoder/src/jpeg/parse.rs
+++ b/jxl-encoder/src/jpeg/parse.rs
@@ -8,6 +8,8 @@
 //! scanner for the jbrd reconstruction metadata.
 
 use super::data::*;
+use crate::budget::MemoryBudget;
+use alloc::sync::Arc;
 use enough::Stop;
 
 /// Errors that can occur during JPEG parsing.
@@ -25,6 +27,11 @@ pub enum JpegError {
     /// as [`crate::api::EncodeError::Cancelled`] at the transcode boundary.
     #[error("encoding cancelled")]
     Cancelled,
+    /// A dimension-driven coefficient-buffer allocation exceeded the
+    /// configured [`MemoryBudget`] cap. Surfaced as
+    /// [`crate::api::EncodeError::LimitExceeded`] at the transcode boundary.
+    #[error("memory budget exceeded: {0}")]
+    ResourceLimit(String),
 }
 
 type Result<T> = core::result::Result<T, JpegError>;
@@ -44,22 +51,27 @@ type Result<T> = core::result::Result<T, JpegError>;
 /// (e.g. via [`crate::api::LosslessConfig::with_limits`]). Pass
 /// `Some(u64::MAX)` to opt out of the cap entirely (trusted input only).
 pub fn read_jpeg(data: &[u8], max_pixels: Option<u64>) -> Result<JpegData> {
-    read_jpeg_with_stop(data, max_pixels, None)
+    read_jpeg_with_stop(data, max_pixels, None, None)
 }
 
-/// Like [`read_jpeg`], but polls `stop` so a server can abort an oversized
-/// untrusted transcode mid-decode.
+/// Like [`read_jpeg`], but polls `stop` and reserves the coefficient buffers
+/// against `budget` so a server can abort or bound an oversized untrusted
+/// transcode mid-decode.
 ///
-/// `stop` is checked at entry and threaded into the zenjpeg coefficient
-/// decode (the dominant time sink for a large frame). `None` is equivalent
-/// to an `Unstoppable` token — **byte-identical with zero overhead** (no
-/// poll is performed). Returns [`JpegError::Cancelled`] if cancellation is
-/// requested. Used by the cancellable transcode entry points
+/// `stop` is checked at entry and threaded into the zenjpeg coefficient decode
+/// (the dominant time sink for a large frame). `budget` (when `Some`) caps the
+/// per-component `i16` coefficient-buffer allocations — the largest
+/// attacker-controlled buffers on the decode side — returning
+/// [`JpegError::ResourceLimit`] if a reservation exceeds the cap. Both `None`
+/// are equivalent to an `Unstoppable` / unbounded run — **byte-identical with
+/// zero overhead**. Returns [`JpegError::Cancelled`] on cancellation. Used by
+/// the cancellable / budgeted transcode entry points
 /// ([`crate::api::LosslessConfig::encode_jpeg_transcode_with_stop`]).
 pub(crate) fn read_jpeg_with_stop(
     data: &[u8],
     max_pixels: Option<u64>,
     stop: Option<&dyn Stop>,
+    budget: Option<&Arc<MemoryBudget>>,
 ) -> Result<JpegData> {
     if let Some(s) = stop {
         s.check().map_err(|_| JpegError::Cancelled)?;
@@ -70,7 +82,7 @@ pub(crate) fn read_jpeg_with_stop(
     let mut jpeg = scan_markers(data, max_pixels)?;
 
     // Phase 2: Use zenjpeg for reliable coefficient extraction
-    extract_coefficients_zenjpeg(data, &mut jpeg, stop)?;
+    extract_coefficients_zenjpeg(data, &mut jpeg, stop, budget)?;
 
     Ok(jpeg)
 }
@@ -590,6 +602,7 @@ fn extract_coefficients_zenjpeg(
     data: &[u8],
     jpeg: &mut JpegData,
     stop: Option<&dyn Stop>,
+    budget: Option<&Arc<MemoryBudget>>,
 ) -> Result<()> {
     use enough::Unstoppable;
     use zenjpeg::decoder::DecodeConfig;
@@ -619,8 +632,44 @@ fn extract_coefficients_zenjpeg(
     // Copy coefficients from zenjpeg's zigzag format to our natural-order format
     for (i, zen_comp) in decoded.components.iter().enumerate() {
         let comp = &mut jpeg.components[i];
-        let num_blocks = (comp.width_in_blocks * comp.height_in_blocks) as usize;
-        comp.coeffs = vec![0i16; num_blocks * 64];
+        // SOF dims are attacker-controlled (each `*_in_blocks` up to ~983025),
+        // so `wb * hb` overflows `u32` and `* 64` overflows `usize` on 32-bit
+        // (#77 item 3). Compute block / coefficient counts with checked `usize`
+        // arithmetic; a malformed SOF errors instead of wrapping (a wrapped
+        // count would size `comp.coeffs` short and make the zigzag copy below
+        // read out of bounds).
+        let num_blocks = (comp.width_in_blocks as usize)
+            .checked_mul(comp.height_in_blocks as usize)
+            .ok_or_else(|| {
+                JpegError::Invalid(format!(
+                    "component {i}: block count overflow ({} × {})",
+                    comp.width_in_blocks, comp.height_in_blocks
+                ))
+            })?;
+        let coeff_len = num_blocks.checked_mul(64).ok_or_else(|| {
+            JpegError::Invalid(format!(
+                "component {i}: coefficient count overflow ({num_blocks} blocks)"
+            ))
+        })?;
+        // Reconcile the SOF-derived count against what zenjpeg actually decoded
+        // — the zigzag copy indexes `zen_comp.coeffs` by block, so a shorter
+        // zenjpeg buffer (inconsistent marker scan vs decode) would read OOB.
+        if zen_comp.coeffs.len() < coeff_len {
+            return Err(JpegError::Invalid(format!(
+                "component {i}: zenjpeg decoded {} coefficients, SOF implies {coeff_len}",
+                zen_comp.coeffs.len()
+            )));
+        }
+        // Reserve the per-component i16 coefficient buffer against the budget
+        // BEFORE allocating it — the largest attacker-controlled allocation on
+        // the decode side (#77 item 1). 2 bytes per i16 coefficient. `None`
+        // budget is a no-op.
+        let coeff_bytes = (coeff_len as u64)
+            .checked_mul(2)
+            .ok_or_else(|| JpegError::ResourceLimit(format!("{coeff_len} coeffs overflow")))?;
+        MemoryBudget::reserve_permanent_opt(budget, coeff_bytes)
+            .map_err(|e| JpegError::ResourceLimit(format!("{e}")))?;
+        comp.coeffs = vec![0i16; coeff_len];
 
         for blk in 0..num_blocks {
             let src_base = blk * 64;

--- a/jxl-encoder/src/jpeg/parse.rs
+++ b/jxl-encoder/src/jpeg/parse.rs
@@ -588,6 +588,22 @@ fn skip_entropy_data(data: &[u8], pos: &mut usize) {
     }
 }
 
+/// Block count and coefficient-buffer length for a JPEG component, computed
+/// with checked `usize` arithmetic.
+///
+/// SOF `*_in_blocks` fields are attacker-controlled (each up to ~983025 for a
+/// 65535-px dimension with 1×1 sampling), so `width_in_blocks *
+/// height_in_blocks` overflows `u32`, and the `* 64` coefficient scale
+/// overflows `usize` on 32-bit targets (i686 / wasm32 — #77 item 3). A wrapped
+/// length would size the component coefficient buffer short and make the
+/// zigzag copy in [`extract_coefficients_zenjpeg`] read out of bounds, so a
+/// malformed SOF must error rather than wrap. Returns `None` on overflow.
+fn checked_coeff_len(width_in_blocks: usize, height_in_blocks: usize) -> Option<(usize, usize)> {
+    let num_blocks = width_in_blocks.checked_mul(height_in_blocks)?;
+    let coeff_len = num_blocks.checked_mul(64)?;
+    Some((num_blocks, coeff_len))
+}
+
 /// Extract DCT coefficients using zenjpeg's decoder.
 ///
 /// As of zenjpeg 0.8.5 we use [`decode_coefficients_with_jbrd_metadata`]
@@ -638,17 +654,14 @@ fn extract_coefficients_zenjpeg(
         // arithmetic; a malformed SOF errors instead of wrapping (a wrapped
         // count would size `comp.coeffs` short and make the zigzag copy below
         // read out of bounds).
-        let num_blocks = (comp.width_in_blocks as usize)
-            .checked_mul(comp.height_in_blocks as usize)
-            .ok_or_else(|| {
-                JpegError::Invalid(format!(
-                    "component {i}: block count overflow ({} × {})",
-                    comp.width_in_blocks, comp.height_in_blocks
-                ))
-            })?;
-        let coeff_len = num_blocks.checked_mul(64).ok_or_else(|| {
+        let (num_blocks, coeff_len) = checked_coeff_len(
+            comp.width_in_blocks as usize,
+            comp.height_in_blocks as usize,
+        )
+        .ok_or_else(|| {
             JpegError::Invalid(format!(
-                "component {i}: coefficient count overflow ({num_blocks} blocks)"
+                "component {i}: coefficient count overflow ({} × {} blocks)",
+                comp.width_in_blocks, comp.height_in_blocks
             ))
         })?;
         // Reconcile the SOF-derived count against what zenjpeg actually decoded
@@ -660,16 +673,14 @@ fn extract_coefficients_zenjpeg(
                 zen_comp.coeffs.len()
             )));
         }
-        // Reserve the per-component i16 coefficient buffer against the budget
-        // BEFORE allocating it — the largest attacker-controlled allocation on
-        // the decode side (#77 item 1). 2 bytes per i16 coefficient. `None`
-        // budget is a no-op.
-        let coeff_bytes = (coeff_len as u64)
-            .checked_mul(2)
-            .ok_or_else(|| JpegError::ResourceLimit(format!("{coeff_len} coeffs overflow")))?;
-        MemoryBudget::reserve_permanent_opt(budget, coeff_bytes)
+        // Reserve + allocate the per-component i16 coefficient buffer — the
+        // largest attacker-controlled allocation on the decode side (#77
+        // item 1). The helper reserves `coeff_len * 2` bytes against the budget
+        // (with checked byte arithmetic) BEFORE allocating, and honors the
+        // budget's runtime fallible-alloc policy (`vec!` fast / `try_reserve`
+        // safe — `Limits::fallible_alloc`). `None` budget is a no-op.
+        comp.coeffs = crate::budget::try_alloc_zeroed_permanent::<i16>(budget, coeff_len)
             .map_err(|e| JpegError::ResourceLimit(format!("{e}")))?;
-        comp.coeffs = vec![0i16; coeff_len];
 
         for blk in 0..num_blocks {
             let src_base = blk * 64;
@@ -891,6 +902,34 @@ mod tests {
                 "u64::MAX should disable the cap, got: {m}"
             );
         }
+    }
+
+    /// #77 item 3: the per-component coefficient-buffer length is computed with
+    /// checked `usize` arithmetic so an attacker-controlled SOF can't wrap it to
+    /// a short length (which would make the zigzag copy in
+    /// `extract_coefficients_zenjpeg` read out of bounds). The wrap only bites
+    /// 32-bit targets (`*_in_blocks * 64` overflows `usize` there), so the guard
+    /// is verified host-independently by exercising `checked_coeff_len` directly.
+    #[test]
+    fn checked_coeff_len_guards_overflow() {
+        // `wb * hb` overflows `usize` outright → None (never a wrapped small value).
+        assert_eq!(checked_coeff_len(usize::MAX, 2), None);
+        // `wb * hb` fits but the ×64 coefficient scale overflows → None.
+        assert_eq!(checked_coeff_len(usize::MAX / 32, 1), None);
+        // A normal component is computed exactly.
+        assert_eq!(checked_coeff_len(128, 96), Some((12_288, 786_432)));
+
+        // The largest representable JPEG (65535 px → 8192 blocks/axis) has
+        // num_blocks = 8192² = 67_108_864 and coeff_len = ×64 = 2^32 — the exact
+        // value that overflows a 32-bit `usize` (where the guard fires and
+        // returns None), but is representable on 64-bit (where it is returned).
+        #[cfg(target_pointer_width = "64")]
+        assert_eq!(
+            checked_coeff_len(8192, 8192),
+            Some((67_108_864, 4_294_967_296))
+        );
+        #[cfg(target_pointer_width = "32")]
+        assert_eq!(checked_coeff_len(8192, 8192), None);
     }
 
     /// Security audit 2026-05-06 H4 regression: a truncated SOS marker with

--- a/jxl-encoder/src/jpeg/parse.rs
+++ b/jxl-encoder/src/jpeg/parse.rs
@@ -29,9 +29,20 @@ type Result<T> = core::result::Result<T, JpegError>;
 /// This performs two passes:
 /// 1. Marker scan: extracts marker structure, Huffman/quant tables, APP/COM data
 /// 2. zenjpeg decode: extracts quantized DCT coefficients reliably
-pub fn read_jpeg(data: &[u8]) -> Result<JpegData> {
+///
+/// `max_pixels` is the pre-flight cap applied to the untrusted SOF
+/// `width × height` *before* any per-block coefficient buffer is allocated
+/// (the transcode path builds no `MemoryBudget`). `None`
+/// applies the secure default
+/// [`crate::api::Limits::DEFAULT_MAX_JPEG_TRANSCODE_PIXELS`] (120 MP);
+/// callers thread their own cap from [`crate::api::Limits::max_pixels`]
+/// (e.g. via [`crate::api::LosslessConfig::with_limits`]). Pass
+/// `Some(u64::MAX)` to opt out of the cap entirely (trusted input only).
+pub fn read_jpeg(data: &[u8], max_pixels: Option<u64>) -> Result<JpegData> {
+    let max_pixels = max_pixels.unwrap_or(crate::api::Limits::DEFAULT_MAX_JPEG_TRANSCODE_PIXELS);
+
     // Phase 1: Scan markers for jbrd metadata
-    let mut jpeg = scan_markers(data)?;
+    let mut jpeg = scan_markers(data, max_pixels)?;
 
     // Phase 2: Use zenjpeg for reliable coefficient extraction
     extract_coefficients_zenjpeg(data, &mut jpeg)?;
@@ -41,7 +52,7 @@ pub fn read_jpeg(data: &[u8]) -> Result<JpegData> {
 
 /// Lightweight marker scanner that reads JPEG marker structure without
 /// decoding entropy data. Extracts everything needed for jbrd box serialization.
-fn scan_markers(data: &[u8]) -> Result<JpegData> {
+fn scan_markers(data: &[u8], max_pixels: u64) -> Result<JpegData> {
     if data.len() < 2 || data[0] != 0xFF || data[1] != 0xD8 {
         return Err(JpegError::Invalid("missing SOI marker".into()));
     }
@@ -110,7 +121,7 @@ fn scan_markers(data: &[u8]) -> Result<JpegData> {
             }
             0xC0 | 0xC1 => {
                 // SOF0 (baseline) / SOF1 (extended sequential)
-                parse_sof_marker(data, &mut pos, &mut jpeg)?;
+                parse_sof_marker(data, &mut pos, &mut jpeg, max_pixels)?;
             }
             0xC2 => {
                 // SOF2: progressive JPEG. zenjpeg's `decode_coefficients()`
@@ -133,7 +144,7 @@ fn scan_markers(data: &[u8]) -> Result<JpegData> {
                 // value we currently hard-code to 0. For multi-scan inputs
                 // this needs the per-scan pass index — handled at the JBRD
                 // writer rather than in this branch.
-                parse_sof_marker(data, &mut pos, &mut jpeg)?;
+                parse_sof_marker(data, &mut pos, &mut jpeg, max_pixels)?;
             }
             0xDB => {
                 // DQT
@@ -235,7 +246,15 @@ fn scan_markers(data: &[u8]) -> Result<JpegData> {
 }
 
 /// Parse SOF marker (without the marker bytes, starting at length field).
-fn parse_sof_marker(data: &[u8], pos: &mut usize, jpeg: &mut JpegData) -> Result<()> {
+///
+/// `max_pixels` is the pre-flight cap on `width × height` (see [`read_jpeg`]);
+/// `u64::MAX` disables it.
+fn parse_sof_marker(
+    data: &[u8],
+    pos: &mut usize,
+    jpeg: &mut JpegData,
+    max_pixels: u64,
+) -> Result<()> {
     let p = *pos;
     if p + 1 >= data.len() {
         return Err(JpegError::UnexpectedEof);
@@ -251,6 +270,23 @@ fn parse_sof_marker(data: &[u8], pos: &mut usize, jpeg: &mut JpegData) -> Result
     }
     jpeg.height = u16::from_be_bytes([data[p + 3], data[p + 4]]) as u32;
     jpeg.width = u16::from_be_bytes([data[p + 5], data[p + 6]]) as u32;
+
+    // Pre-flight pixel cap on the untrusted SOF dimensions, BEFORE the
+    // per-block coefficient buffers are allocated (the transcode path does not
+    // build a `MemoryBudget`). JPEG dims are `u16` (≤ 65535 each), so a crafted
+    // header can advertise ~4.3 Gpx and force a multi-gigabyte `i16`
+    // coefficient allocation downstream. `max_pixels` is the caller's cap
+    // (`Limits::max_pixels`, default 120 MP — admits 108 MP phone photos);
+    // `u64::MAX` opts out.
+    if (jpeg.width as u64) * (jpeg.height as u64) > max_pixels {
+        return Err(JpegError::Invalid(format!(
+            "JPEG frame {}x{} exceeds the {} MP transcode pixel cap",
+            jpeg.width,
+            jpeg.height,
+            max_pixels / 1_000_000
+        )));
+    }
+
     let num_comp = data[p + 7] as usize;
 
     // Accept 1-4 components (libjxl `kMaxComponents = 4`,
@@ -691,6 +727,85 @@ mod tests {
         }
     }
 
+    /// Build a minimal SOI + SOF0 (3 components) advertising `w`×`h`. The frame
+    /// has no SOS/coefficients, so parsing fails AFTER the SOF either at the
+    /// pixel cap (oversized) or later (missing scan data).
+    fn sof_only(w: u16, h: u16) -> Vec<u8> {
+        let mut d = vec![0xFF, 0xD8, 0xFF, 0xC0];
+        d.extend_from_slice(&17u16.to_be_bytes()); // len
+        d.push(8); // precision
+        d.extend_from_slice(&h.to_be_bytes());
+        d.extend_from_slice(&w.to_be_bytes());
+        d.push(3); // Nf
+        d.extend_from_slice(&[1, 0x11, 0]);
+        d.extend_from_slice(&[2, 0x11, 1]);
+        d.extend_from_slice(&[3, 0x11, 1]);
+        d
+    }
+
+    /// proderrdoc 2026-06-14 (issue #77): the JPEG-transcode path builds no
+    /// `MemoryBudget`, and JPEG dims are `u16` (≤ 65535 each), so a crafted SOF
+    /// can advertise ~4.3 Gpx and force a multi-GB coefficient allocation.
+    /// `parse_sof_marker` rejects oversized frames before any allocation;
+    /// `None` applies the default 120 MP cap.
+    #[test]
+    fn read_jpeg_rejects_oversized_sof_before_alloc() {
+        // 20000 × 20000 = 400 MP, well over the default 120 MP cap.
+        let result = read_jpeg(&sof_only(20000, 20000), None);
+        assert!(
+            matches!(&result, Err(JpegError::Invalid(m)) if m.contains("120 MP")),
+            "expected the 120 MP cap rejection, got {result:?}"
+        );
+    }
+
+    /// Regression guard: a normal-sized frame (16.8 MP) passes the default cap
+    /// — it fails later for missing scan data, never with the cap message.
+    #[test]
+    fn read_jpeg_does_not_cap_normal_dimensions() {
+        let result = read_jpeg(&sof_only(4096, 4096), None); // 16.8 MP
+        if let Err(JpegError::Invalid(m)) = &result {
+            assert!(
+                !m.contains("MP transcode pixel cap"),
+                "16.8 MP wrongly hit the cap: {m}"
+            );
+        }
+    }
+
+    /// The pixel cap is **configurable** (issue #77): a caller-supplied
+    /// `max_pixels` overrides the 120 MP default in both directions, and
+    /// `Some(u64::MAX)` opts out entirely.
+    #[test]
+    fn read_jpeg_pixel_cap_is_configurable() {
+        // (a) A tighter cap rejects a frame the default would admit: 4096×4096
+        //     (16.8 MP) under a 10 MP cap fails AT the cap, before allocation.
+        let tight = read_jpeg(&sof_only(4096, 4096), Some(10_000_000));
+        assert!(
+            matches!(&tight, Err(JpegError::Invalid(m)) if m.contains("10 MP transcode pixel cap")),
+            "expected the 10 MP cap rejection, got {tight:?}"
+        );
+
+        // (b) A looser cap admits a frame the default would reject: 20000×20000
+        //     (400 MP) under a 500 MP cap passes the cap (then fails later for
+        //     missing scan data — never with the cap message).
+        let loose = read_jpeg(&sof_only(20000, 20000), Some(500_000_000));
+        if let Err(JpegError::Invalid(m)) = &loose {
+            assert!(
+                !m.contains("transcode pixel cap"),
+                "400 MP wrongly hit the 500 MP cap: {m}"
+            );
+        }
+
+        // (c) `u64::MAX` opts out: even the largest representable JPEG frame
+        //     (65535×65535 ≈ 4.29 Gpx) clears the cap.
+        let disabled = read_jpeg(&sof_only(65535, 65535), Some(u64::MAX));
+        if let Err(JpegError::Invalid(m)) = &disabled {
+            assert!(
+                !m.contains("transcode pixel cap"),
+                "u64::MAX should disable the cap, got: {m}"
+            );
+        }
+    }
+
     /// Security audit 2026-05-06 H4 regression: a truncated SOS marker with
     /// `len < 6 + 2*Ns` previously panicked with index-out-of-bounds when
     /// `parse_sos_header` indexed `data[spec_base..spec_base + 3]` past the
@@ -720,7 +835,7 @@ mod tests {
         data.extend_from_slice(&[0xFF, 0xDA]);
         data.extend_from_slice(&0u16.to_be_bytes());
 
-        let result = read_jpeg(&data);
+        let result = read_jpeg(&data, None);
         assert!(matches!(result, Err(JpegError::Invalid(_))));
     }
 
@@ -750,7 +865,7 @@ mod tests {
         data.push(1); // Ns
         data.extend_from_slice(&[1, 0x00]); // component selector + table
 
-        let result = read_jpeg(&data);
+        let result = read_jpeg(&data, None);
         assert!(matches!(result, Err(JpegError::Invalid(_))));
     }
 
@@ -766,7 +881,7 @@ mod tests {
             crate::test_helpers::corpus_dir().display()
         );
         let data = std::fs::read(path).expect("failed to read test JPEG");
-        let jpeg = read_jpeg(&data).expect("failed to parse JPEG");
+        let jpeg = read_jpeg(&data, None).expect("failed to parse JPEG");
 
         assert!(jpeg.width > 0, "width should be nonzero");
         assert!(jpeg.height > 0, "height should be nonzero");

--- a/jxl-encoder/src/jpeg/parse.rs
+++ b/jxl-encoder/src/jpeg/parse.rs
@@ -8,6 +8,7 @@
 //! scanner for the jbrd reconstruction metadata.
 
 use super::data::*;
+use enough::Stop;
 
 /// Errors that can occur during JPEG parsing.
 #[derive(Debug, thiserror::Error)]
@@ -20,6 +21,10 @@ pub enum JpegError {
     Unsupported(String),
     #[error("zenjpeg decode error: {0}")]
     Decode(String),
+    /// The caller's [`enough::Stop`] token requested cancellation. Surfaced
+    /// as [`crate::api::EncodeError::Cancelled`] at the transcode boundary.
+    #[error("encoding cancelled")]
+    Cancelled,
 }
 
 type Result<T> = core::result::Result<T, JpegError>;
@@ -39,13 +44,33 @@ type Result<T> = core::result::Result<T, JpegError>;
 /// (e.g. via [`crate::api::LosslessConfig::with_limits`]). Pass
 /// `Some(u64::MAX)` to opt out of the cap entirely (trusted input only).
 pub fn read_jpeg(data: &[u8], max_pixels: Option<u64>) -> Result<JpegData> {
+    read_jpeg_with_stop(data, max_pixels, None)
+}
+
+/// Like [`read_jpeg`], but polls `stop` so a server can abort an oversized
+/// untrusted transcode mid-decode.
+///
+/// `stop` is checked at entry and threaded into the zenjpeg coefficient
+/// decode (the dominant time sink for a large frame). `None` is equivalent
+/// to an `Unstoppable` token — **byte-identical with zero overhead** (no
+/// poll is performed). Returns [`JpegError::Cancelled`] if cancellation is
+/// requested. Used by the cancellable transcode entry points
+/// ([`crate::api::LosslessConfig::encode_jpeg_transcode_with_stop`]).
+pub(crate) fn read_jpeg_with_stop(
+    data: &[u8],
+    max_pixels: Option<u64>,
+    stop: Option<&dyn Stop>,
+) -> Result<JpegData> {
+    if let Some(s) = stop {
+        s.check().map_err(|_| JpegError::Cancelled)?;
+    }
     let max_pixels = max_pixels.unwrap_or(crate::api::Limits::DEFAULT_MAX_JPEG_TRANSCODE_PIXELS);
 
     // Phase 1: Scan markers for jbrd metadata
     let mut jpeg = scan_markers(data, max_pixels)?;
 
     // Phase 2: Use zenjpeg for reliable coefficient extraction
-    extract_coefficients_zenjpeg(data, &mut jpeg)?;
+    extract_coefficients_zenjpeg(data, &mut jpeg, stop)?;
 
     Ok(jpeg)
 }
@@ -561,14 +586,27 @@ fn skip_entropy_data(data: &[u8], pos: &mut usize) {
 /// marker scanner and zenjpeg traverse SOS markers.
 ///
 /// [`decode_coefficients_with_jbrd_metadata`]: zenjpeg::decoder::DecodeConfig::decode_coefficients_with_jbrd_metadata
-fn extract_coefficients_zenjpeg(data: &[u8], jpeg: &mut JpegData) -> Result<()> {
+fn extract_coefficients_zenjpeg(
+    data: &[u8],
+    jpeg: &mut JpegData,
+    stop: Option<&dyn Stop>,
+) -> Result<()> {
+    use enough::Unstoppable;
     use zenjpeg::decoder::DecodeConfig;
-    use zenjpeg::encoder::Unstoppable;
 
     let config = DecodeConfig::new();
-    let (decoded, jbrd_meta) = config
-        .decode_coefficients_with_jbrd_metadata(data, Unstoppable)
-        .map_err(|e| JpegError::Decode(format!("{e}")))?;
+    // Thread the caller's Stop into zenjpeg's entropy decode (the dominant
+    // time sink for a large untrusted frame). `None` → `Unstoppable`, which
+    // zenjpeg never polls — byte-identical to the pre-cancellation path.
+    let unstoppable = Unstoppable;
+    let stop_ref: &dyn Stop = stop.unwrap_or(&unstoppable);
+    let decode_result = config.decode_coefficients_with_jbrd_metadata(data, stop_ref);
+    // If the stop fired, surface a clean `Cancelled` instead of zenjpeg's
+    // generic decode error (zenjpeg maps `StopReason` into its own error).
+    if let Some(s) = stop {
+        s.check().map_err(|_| JpegError::Cancelled)?;
+    }
+    let (decoded, jbrd_meta) = decode_result.map_err(|e| JpegError::Decode(format!("{e}")))?;
 
     if decoded.components.len() != jpeg.components.len() {
         return Err(JpegError::Invalid(format!(

--- a/jxl-encoder/src/modular/channel.rs
+++ b/jxl-encoder/src/modular/channel.rs
@@ -58,13 +58,12 @@ impl Channel {
             .checked_mul(height)
             .ok_or(Error::InvalidImageDimensions(width, height))?;
 
-        // Channel data is `Vec<i32>` — 4 bytes per entry.
-        let bytes = (size as u64).saturating_mul(core::mem::size_of::<i32>() as u64);
-        crate::budget::MemoryBudget::reserve_permanent_opt(budget, bytes)?;
-
-        let mut data = Vec::new();
-        data.try_reserve_exact(size)?;
-        data.resize(size, 0);
+        // Channel data is `Vec<i32>` — reserve against the budget and allocate
+        // honoring its runtime fallible-alloc policy (`Limits::fallible_alloc`):
+        // `vec!` (a single `calloc`, fast) by default, `try_reserve_exact`
+        // (graceful OOM) for untrusted sizes. Byte-identical either way (a
+        // zeroed `Vec<i32>` of `size`); the helper reserves `size * 4` bytes.
+        let data = crate::budget::try_alloc_zeroed_permanent::<i32>(budget, size)?;
 
         Ok(Self {
             data,

--- a/jxl-encoder/src/modular/encode.rs
+++ b/jxl-encoder/src/modular/encode.rs
@@ -2954,7 +2954,7 @@ mod tests {
         let frame_encoder = FrameEncoder::new(4, 4, frame_options);
         let color_encoding = ColorEncoding::srgb();
         frame_encoder
-            .encode_modular(&image, &color_encoding, &mut writer)
+            .encode_modular(&image, &color_encoding, &mut writer, None)
             .unwrap();
 
         let bytes = writer.finish_with_padding();
@@ -3022,7 +3022,7 @@ mod tests {
             let frame_encoder = FrameEncoder::new(4, 2, frame_options);
             let color_encoding = ColorEncoding::srgb();
             frame_encoder
-                .encode_modular(&image, &color_encoding, &mut writer)
+                .encode_modular(&image, &color_encoding, &mut writer, None)
                 .unwrap();
             let huf_bytes = writer.finish_with_padding();
             eprintln!("Huffman modular gray varied 4x2: {} bytes", huf_bytes.len());
@@ -3046,7 +3046,7 @@ mod tests {
         let frame_encoder = FrameEncoder::new(4, 2, frame_options);
         let color_encoding = ColorEncoding::srgb();
         frame_encoder
-            .encode_modular(&image, &color_encoding, &mut writer)
+            .encode_modular(&image, &color_encoding, &mut writer, None)
             .unwrap();
 
         let bytes = writer.finish_with_padding();
@@ -3112,7 +3112,7 @@ mod tests {
         let frame_encoder = FrameEncoder::new(8, 8, frame_options);
         let color_encoding = ColorEncoding::srgb();
         frame_encoder
-            .encode_modular(&image, &color_encoding, &mut writer)
+            .encode_modular(&image, &color_encoding, &mut writer, None)
             .unwrap();
 
         let bytes = writer.finish_with_padding();

--- a/jxl-encoder/src/modular/frame.rs
+++ b/jxl-encoder/src/modular/frame.rs
@@ -329,9 +329,10 @@ impl FrameEncoder {
         color_encoding: &ColorEncoding,
         writer: &mut BitWriter,
         patches: Option<&crate::vardct::patches::PatchesData>,
+        stop: Option<&dyn enough::Stop>,
     ) -> Result<()> {
         if patches.is_none() {
-            return self.encode_modular(image, color_encoding, writer);
+            return self.encode_modular(image, color_encoding, writer, stop);
         }
         let patches = patches.unwrap();
 
@@ -440,7 +441,7 @@ impl FrameEncoder {
         } else {
             // Multi-group with patches: patches section goes into LfGlobal.
             // Squeeze + patches is not yet supported; use non-squeeze multi-group path.
-            self.encode_modular_multi_group_inner(image, writer, Some(patches))?;
+            self.encode_modular_multi_group_inner(image, writer, Some(patches), stop)?;
         }
 
         Ok(())
@@ -452,7 +453,16 @@ impl FrameEncoder {
         image: &ModularImage,
         _color_encoding: &ColorEncoding,
         writer: &mut BitWriter,
+        stop: Option<&dyn enough::Stop>,
     ) -> Result<()> {
+        // Coarse cancellation check at the modular encode boundary. Polled
+        // once here so the single-group path (tree learning + entropy coding
+        // can run for seconds at e9) is cancellable; the multi-group dispatch
+        // below re-polls inside `encode_modular_multi_group_inner`. No-op and
+        // byte-identical under `None` / an `Unstoppable` token.
+        if let Some(s) = stop {
+            s.check().map_err(|_| crate::error::Error::Cancelled)?;
+        }
         // Compute num_extra_channels from image. Channels beyond the
         // base color set (1 for grayscale, 3 for RGB) are extra
         // channels — alpha is the historical case but [`ModularImage`]
@@ -556,20 +566,20 @@ impl FrameEncoder {
             }
         } else if self.options.lossy_palette && image.channels.len() >= 3 {
             // Multi-group lossy palette: palette meta in LfGlobal, index across groups
-            self.encode_modular_multi_group_lossy_palette(image, writer)?;
+            self.encode_modular_multi_group_lossy_palette(image, writer, stop)?;
         } else if self.options.use_squeeze
             && !super::squeeze::default_squeeze_params(image).is_empty()
         {
             if self.options.use_tree_learning && self.options.use_ans {
                 // Multi-group with squeeze + tree learning: best compression
-                self.encode_modular_multi_group_squeeze_with_tree(image, writer)?;
+                self.encode_modular_multi_group_squeeze_with_tree(image, writer, stop)?;
             } else {
                 // Multi-group with squeeze: gradient predictor, single context
-                self.encode_modular_multi_group_squeeze(image, writer)?;
+                self.encode_modular_multi_group_squeeze(image, writer, stop)?;
             }
         } else {
             // Multi-group: separate TOC entries for global and each group
-            self.encode_modular_multi_group(image, writer)?;
+            self.encode_modular_multi_group(image, writer, stop)?;
         }
 
         Ok(())
@@ -586,8 +596,9 @@ impl FrameEncoder {
         &self,
         image: &ModularImage,
         writer: &mut BitWriter,
+        stop: Option<&dyn enough::Stop>,
     ) -> Result<()> {
-        self.encode_modular_multi_group_inner(image, writer, None)
+        self.encode_modular_multi_group_inner(image, writer, None, stop)
     }
 
     /// Inner multi-group encoder that accepts optional patches.
@@ -597,7 +608,15 @@ impl FrameEncoder {
         image: &ModularImage,
         writer: &mut BitWriter,
         patches: Option<&crate::vardct::patches::PatchesData>,
+        stop: Option<&dyn enough::Stop>,
     ) -> Result<()> {
+        // Cooperative cancellation entry checkpoint for the lossless/modular
+        // heavy path (#77 cross-codec cancellation note). Further checkpoints
+        // sit before MA tree learning and per group below. No-op / byte-
+        // identical under an `Unstoppable` token / `None`.
+        if let Some(s) = stop {
+            s.check().map_err(|_| crate::error::Error::Cancelled)?;
+        }
         let num_groups = self.num_groups();
         let num_lf_groups = self.num_lf_groups();
         let num_passes = 1;
@@ -988,6 +1007,13 @@ impl FrameEncoder {
         // section.rs (both now derive from `modular_hf_stream_id_base`).
         let per_group_id_offset: u32 =
             super::section::modular_hf_stream_id_base(num_lf_groups as u32);
+        // Cooperative cancellation checkpoint BEFORE the parallel per-group
+        // encoding (residual collection + MA-tree-driven ANS — the dominant
+        // lossless cost). Polled here (sequentially) rather than inside the
+        // rayon closure to avoid a `Send + Sync` bound on the token.
+        if let Some(s) = stop {
+            s.check().map_err(|_| crate::error::Error::Cancelled)?;
+        }
         // PassGroup sections — parallelizable (each group writes to its own BitWriter)
         let pass_group_data: Vec<Vec<u8>> =
             crate::parallel::parallel_map_result(num_groups * num_passes, |flat_idx| {
@@ -1067,7 +1093,13 @@ impl FrameEncoder {
         &self,
         image: &ModularImage,
         writer: &mut BitWriter,
+        stop: Option<&dyn enough::Stop>,
     ) -> Result<()> {
+        // Coarse cancellation at the multi-group lossy-palette boundary.
+        // No-op / byte-identical under `None` or an `Unstoppable` token.
+        if let Some(s) = stop {
+            s.check().map_err(|_| crate::error::Error::Cancelled)?;
+        }
         use super::encode::{
             predict_pixel_with_id, resolve_fixed_predictor_for_simple_path,
             write_gradient_tree_tokens, write_hybrid_data_histogram, write_predictor_tree_tokens,
@@ -1108,7 +1140,7 @@ impl FrameEncoder {
             Some(r) => r,
             None => {
                 // Lossy palette not beneficial, fall back to standard multi-group
-                return self.encode_modular_multi_group_inner(image, writer, None);
+                return self.encode_modular_multi_group_inner(image, writer, None, None);
             }
         };
 
@@ -1363,7 +1395,13 @@ impl FrameEncoder {
         &self,
         image: &ModularImage,
         writer: &mut BitWriter,
+        stop: Option<&dyn enough::Stop>,
     ) -> Result<()> {
+        // Coarse cancellation at the multi-group squeeze boundary.
+        // No-op / byte-identical under `None` or an `Unstoppable` token.
+        if let Some(s) = stop {
+            s.check().map_err(|_| crate::error::Error::Cancelled)?;
+        }
         use super::encode::{
             predict_pixel_with_id, resolve_fixed_predictor_for_simple_path,
             write_gradient_tree_tokens, write_predictor_tree_tokens, write_rct_transform,
@@ -1779,7 +1817,13 @@ impl FrameEncoder {
         &self,
         image: &ModularImage,
         writer: &mut BitWriter,
+        stop: Option<&dyn enough::Stop>,
     ) -> Result<()> {
+        // Coarse cancellation at the multi-group squeeze+tree boundary.
+        // No-op / byte-identical under `None` or an `Unstoppable` token.
+        if let Some(s) = stop {
+            s.check().map_err(|_| crate::error::Error::Cancelled)?;
+        }
         use super::encode::{write_rct_transform, write_squeeze_transform, write_tree};
         use super::rct::{RctType, forward_rct};
         use super::squeeze::{apply_squeeze, default_squeeze_params};
@@ -2281,6 +2325,13 @@ impl FrameEncoder {
         // Step 9: HfGlobal is empty for modular
         let hf_global_data: Vec<u8> = Vec::new();
 
+        // Coarse cancellation after tree learning, before the per-group
+        // parallel encode (mirrors `encode_modular_multi_group_inner`).
+        // No-op / byte-identical under `None` or an `Unstoppable` token.
+        if let Some(s) = stop {
+            s.check().map_err(|_| crate::error::Error::Cancelled)?;
+        }
+
         // Step 10: Write PassGroup sections — parallelizable
         let pass_group_data: Vec<Vec<u8>> =
             crate::parallel::parallel_map_result(num_groups, |g| {
@@ -2420,7 +2471,7 @@ impl FrameEncoder {
             }
         } else {
             // Multi-group: use the standard multi-group encoder (no patches in body)
-            self.encode_modular_multi_group_inner(image, writer, None)?;
+            self.encode_modular_multi_group_inner(image, writer, None, None)?;
         }
 
         Ok(())
@@ -2648,7 +2699,7 @@ mod tests {
         let color_encoding = ColorEncoding::srgb();
 
         encoder
-            .encode_modular(&image, &color_encoding, &mut writer)
+            .encode_modular(&image, &color_encoding, &mut writer, None)
             .unwrap();
 
         let bytes = writer.finish_with_padding();
@@ -2680,7 +2731,7 @@ mod tests {
         let color_encoding = ColorEncoding::srgb();
 
         encoder
-            .encode_modular(&image, &color_encoding, &mut writer)
+            .encode_modular(&image, &color_encoding, &mut writer, None)
             .unwrap();
 
         let bytes = writer.finish_with_padding();

--- a/jxl-encoder/src/vardct/bitstream.rs
+++ b/jxl-encoder/src/vardct/bitstream.rs
@@ -2184,6 +2184,8 @@ impl VarDctEncoder {
                     // encoder's fixed `self.butteraugli_iters` for
                     // byte-identical pre-W44-168 animation behaviour.
                     None,
+                    // No Stop token on the animation frame path.
+                    None,
                 )?;
             }
         }

--- a/jxl-encoder/src/vardct/encoder.rs
+++ b/jxl-encoder/src/vardct/encoder.rs
@@ -5650,6 +5650,7 @@ impl VarDctEncoder {
                     // resolves to `self.butteraugli_iters`, byte-
                     // identical to pre-W44-168.
                     Some(effective_buttloop_iters),
+                    stop,
                 )?;
             }
         }

--- a/jxl-encoder/src/vardct/encoder.rs
+++ b/jxl-encoder/src/vardct/encoder.rs
@@ -3565,6 +3565,17 @@ impl VarDctEncoder {
         extras: &[super::extras::VardctExtra<'_>],
         stop: Option<&dyn Stop>,
     ) -> Result<VarDctOutput> {
+        // Earliest cancellation checkpoint — polled BEFORE any encode work, on
+        // EVERY entropy path (two-pass, single-pass, and the `num_sections == 4`
+        // single-group fast path). The per-group checkpoints further down add
+        // mid-encode responsiveness, but they live only in the multi-group
+        // two-pass branch; this entry poll guarantees a fired `Stop` aborts
+        // regardless of which path runs (the bug behind the previously-failing
+        // `test_stop_cancels_lossy_multigroup`). No-op / byte-identical under an
+        // `Unstoppable` token or `None`.
+        if let Some(s) = stop {
+            s.check().map_err(|_| Error::Cancelled)?;
+        }
         let expected_rgb = width
             .checked_mul(height)
             .and_then(|n| n.checked_mul(3))

--- a/jxl-encoder/src/vardct/encoder.rs
+++ b/jxl-encoder/src/vardct/encoder.rs
@@ -4204,10 +4204,10 @@ impl VarDctEncoder {
             // `vec![v; nblocks]` would, without reallocating the exact capacity).
             let fallible = self.budget.as_ref().is_some_and(|b| b.is_fallible());
             let q = self.profile.initial_q_numerator / self.distance;
-            let mut flat_qf = crate::budget::vec_with_capacity_policy(fallible, nblocks)?;
+            let mut flat_qf = crate::budget::vec_with_capacity_fallible(fallible, nblocks)?;
             flat_qf.resize(nblocks, q);
             let masking_val = 1.0 / (q + 0.001);
-            let mut flat_masking = crate::budget::vec_with_capacity_policy(fallible, nblocks)?;
+            let mut flat_masking = crate::budget::vec_with_capacity_fallible(fallible, nblocks)?;
             flat_masking.resize(nblocks, masking_val);
             (flat_qf, flat_masking)
         };
@@ -6036,7 +6036,7 @@ impl VarDctEncoder {
         // dimension-driven buffer (`Limits::fallible_alloc`): `with_capacity`
         // (fast) by default, `try_reserve` (graceful OOM) for untrusted input.
         let fallible = self.budget.as_ref().is_some_and(|b| b.is_fallible());
-        let mut writer = BitWriter::with_capacity_policy(fallible, width * height * 4)?;
+        let mut writer = BitWriter::with_capacity_fallible(fallible, width * height * 4)?;
 
         // Write file header (includes JXL signature, ICC, and byte padding).
         // The streaming/one-pass static-Huffman path doesn't carry any
@@ -6110,7 +6110,7 @@ impl VarDctEncoder {
             // Runtime fallible-alloc policy for these dimension-driven group
             // writers (`Limits::fallible_alloc`); covers dc_group + ac_group.
             let fallible = self.budget.as_ref().is_some_and(|b| b.is_fallible());
-            let mut dc_group = BitWriter::with_capacity_policy(fallible, num_blocks * 10)?;
+            let mut dc_group = BitWriter::with_capacity_fallible(fallible, num_blocks * 10)?;
             self.write_dc_group(
                 0,
                 quant_dc,
@@ -6135,7 +6135,8 @@ impl VarDctEncoder {
                 &mut ac_global,
             )?;
 
-            let mut ac_group_writer = BitWriter::with_capacity_policy(fallible, num_blocks * 100)?;
+            let mut ac_group_writer =
+                BitWriter::with_capacity_fallible(fallible, num_blocks * 100)?;
             self.write_ac_group(
                 0,
                 quant_ac,
@@ -6246,7 +6247,7 @@ impl VarDctEncoder {
                     s.check().map_err(|_| Error::Cancelled)?;
                 }
                 let mut dc_group =
-                    BitWriter::with_capacity_policy(fallible, blocks_per_dc_group * 10)?;
+                    BitWriter::with_capacity_fallible(fallible, blocks_per_dc_group * 10)?;
                 self.write_dc_group(
                     dc_group_idx,
                     quant_dc,
@@ -6286,7 +6287,7 @@ impl VarDctEncoder {
                     s.check().map_err(|_| Error::Cancelled)?;
                 }
                 let mut ac_group_writer =
-                    BitWriter::with_capacity_policy(fallible, blocks_per_ac_group * 100)?;
+                    BitWriter::with_capacity_fallible(fallible, blocks_per_ac_group * 100)?;
                 self.write_ac_group(
                     group_idx,
                     quant_ac,

--- a/jxl-encoder/src/vardct/encoder.rs
+++ b/jxl-encoder/src/vardct/encoder.rs
@@ -4199,10 +4199,16 @@ impl VarDctEncoder {
                 self.budget.as_ref(),
                 (nblocks as u64).saturating_mul(4 * 2),
             )?;
+            // Runtime fallible-alloc policy for these dimension-driven quant
+            // buffers; byte-identical (resize fills to the same values that
+            // `vec![v; nblocks]` would, without reallocating the exact capacity).
+            let fallible = self.budget.as_ref().is_some_and(|b| b.is_fallible());
             let q = self.profile.initial_q_numerator / self.distance;
-            let flat_qf = vec![q; nblocks];
+            let mut flat_qf = crate::budget::vec_with_capacity_policy(fallible, nblocks)?;
+            flat_qf.resize(nblocks, q);
             let masking_val = 1.0 / (q + 0.001);
-            let flat_masking = vec![masking_val; nblocks];
+            let mut flat_masking = crate::budget::vec_with_capacity_policy(fallible, nblocks)?;
+            flat_masking.resize(nblocks, masking_val);
             (flat_qf, flat_masking)
         };
 
@@ -6026,7 +6032,11 @@ impl VarDctEncoder {
             .saturating_mul(height as u64)
             .saturating_mul(4);
         crate::budget::MemoryBudget::reserve_permanent_opt(self.budget.as_ref(), main_cap)?;
-        let mut writer = BitWriter::with_capacity(width * height * 4);
+        // Honor the budget's runtime fallible-alloc policy for this large
+        // dimension-driven buffer (`Limits::fallible_alloc`): `with_capacity`
+        // (fast) by default, `try_reserve` (graceful OOM) for untrusted input.
+        let fallible = self.budget.as_ref().is_some_and(|b| b.is_fallible());
+        let mut writer = BitWriter::with_capacity_policy(fallible, width * height * 4)?;
 
         // Write file header (includes JXL signature, ICC, and byte padding).
         // The streaming/one-pass static-Huffman path doesn't carry any
@@ -6097,7 +6107,10 @@ impl VarDctEncoder {
                 self.budget.as_ref(),
                 (num_blocks as u64).saturating_mul(110),
             )?;
-            let mut dc_group = BitWriter::with_capacity(num_blocks * 10);
+            // Runtime fallible-alloc policy for these dimension-driven group
+            // writers (`Limits::fallible_alloc`); covers dc_group + ac_group.
+            let fallible = self.budget.as_ref().is_some_and(|b| b.is_fallible());
+            let mut dc_group = BitWriter::with_capacity_policy(fallible, num_blocks * 10)?;
             self.write_dc_group(
                 0,
                 quant_dc,
@@ -6122,7 +6135,7 @@ impl VarDctEncoder {
                 &mut ac_global,
             )?;
 
-            let mut ac_group_writer = BitWriter::with_capacity(num_blocks * 100);
+            let mut ac_group_writer = BitWriter::with_capacity_policy(fallible, num_blocks * 100)?;
             self.write_ac_group(
                 0,
                 quant_ac,
@@ -6194,6 +6207,8 @@ impl VarDctEncoder {
                 self.budget.as_ref(),
                 total_groups_bytes,
             )?;
+            // Runtime fallible-alloc policy for the per-group writers below.
+            let fallible = self.budget.as_ref().is_some_and(|b| b.is_fallible());
             let mut sections: Vec<Vec<u8>> = Vec::with_capacity(num_sections);
             let dc_huffman = dc_code.as_huffman();
             let ac_huffman = ac_code.as_huffman();
@@ -6230,7 +6245,8 @@ impl VarDctEncoder {
                 if let Some(s) = stop {
                     s.check().map_err(|_| Error::Cancelled)?;
                 }
-                let mut dc_group = BitWriter::with_capacity(blocks_per_dc_group * 10);
+                let mut dc_group =
+                    BitWriter::with_capacity_policy(fallible, blocks_per_dc_group * 10)?;
                 self.write_dc_group(
                     dc_group_idx,
                     quant_dc,
@@ -6269,7 +6285,8 @@ impl VarDctEncoder {
                 if let Some(s) = stop {
                     s.check().map_err(|_| Error::Cancelled)?;
                 }
-                let mut ac_group_writer = BitWriter::with_capacity(blocks_per_ac_group * 100);
+                let mut ac_group_writer =
+                    BitWriter::with_capacity_policy(fallible, blocks_per_ac_group * 100)?;
                 self.write_ac_group(
                     group_idx,
                     quant_ac,

--- a/jxl-encoder/src/vardct/perceptual_loop.rs
+++ b/jxl-encoder/src/vardct/perceptual_loop.rs
@@ -833,6 +833,9 @@ impl VarDctEncoder {
         // condition `iters_override.unwrap_or(self.butteraugli_iters)
         // > 0` so the buttloop isn't entered with iters=0.
         iters_override: Option<u32>,
+        // Cooperative cancellation token, polled per butteraugli iteration
+        // inside `butteraugli_refine_quant_field_inner_seed`.
+        stop: Option<&dyn enough::Stop>,
     ) -> Result<DistanceParams> {
         use crate::budget::MemoryBudget;
 
@@ -1758,6 +1761,7 @@ impl VarDctEncoder {
                 // cvvdp-fork Phase 4: metric-direction target for the
                 // inner loop's bad-block + accept-bound + diff_raw math.
                 effective_metric_target_distance,
+                stop,
             )?;
             outcomes.push(outcome);
         }
@@ -1940,6 +1944,8 @@ impl VarDctEncoder {
         // file, not the metric target. See
         // `docs/archive/RFC_CVVDP_PHASE4_BRIEF.md` Step 4.
         effective_metric_target_distance: f32,
+        // Cooperative cancellation token, polled once per butteraugli iteration.
+        stop: Option<&dyn enough::Stop>,
     ) -> Result<SeedOutcome> {
         use super::epf;
         use super::reconstruct::{gab_smooth, reconstruct_xyb, xyb_to_linear_rgb_planar};
@@ -1977,6 +1983,13 @@ impl VarDctEncoder {
         // i=0..iters-1: SetQuantField + roundtrip + compare + adjust
         // i=iters: SetQuantField + roundtrip + compare + break
         for iter in 0..iters + 1 {
+            // Cooperative cancellation checkpoint, per butteraugli iteration —
+            // this loop (a full reconstruct + metric compare per iter) is the
+            // slowest VarDCT phase at effort 8+. Byte-identical under an
+            // `Unstoppable` token / `None`.
+            if let Some(s) = stop {
+                s.check().map_err(|_| crate::error::Error::Cancelled)?;
+            }
             // Step 1: SetQuantField — recompute global_scale from float field,
             // then convert float → u8.
             // (libjxl: quantizer.SetQuantField(initial_quant_dc, quant_field, &raw_quant_field))

--- a/jxl-encoder/tests/it/jpeg_reencoding.rs
+++ b/jxl-encoder/tests/it/jpeg_reencoding.rs
@@ -168,8 +168,8 @@ fn decode_jxl_rs_gray(data: &[u8]) -> (usize, usize, Vec<f32>) {
 fn verify_jxl_rs_decodes(jpeg_path: &str, label: &str) {
     let jpeg_data = std::fs::read(jpeg_path)
         .unwrap_or_else(|e| panic!("{label}: failed to read {jpeg_path}: {e}"));
-    let jpeg =
-        read_jpeg(&jpeg_data, None).unwrap_or_else(|e| panic!("{label}: failed to parse: {e}"));
+    let jpeg = read_jpeg(&jpeg_data, None, None)
+        .unwrap_or_else(|e| panic!("{label}: failed to parse: {e}"));
 
     let jxl_bytes = encode_jpeg_to_jxl(&jpeg).unwrap_or_else(|e| panic!("{label}: encode: {e}"));
 
@@ -211,7 +211,7 @@ fn verify_jxl_rs_decodes(jpeg_path: &str, label: &str) {
 fn test_encode_small_jpeg() {
     let path = jxl_encoder::test_helpers::output_file_for("jpeg-reencoding", "test64_444.jpg");
     let data = std::fs::read(&path).expect("failed to read test JPEG");
-    let jpeg = read_jpeg(&data, None).expect("failed to parse JPEG");
+    let jpeg = read_jpeg(&data, None, None).expect("failed to parse JPEG");
     let jxl_bytes = encode_jpeg_to_jxl(&jpeg).expect("failed to encode JPEG to JXL");
 
     eprintln!(
@@ -237,7 +237,7 @@ fn test_decode_small_jpeg_oxide() {
     let path = jxl_encoder::test_helpers::output_file_for("jpeg-reencoding", "test64_444.jpg");
     let path_str = path.to_string_lossy().into_owned();
     let data = std::fs::read(&path).expect("failed to read test JPEG");
-    let jpeg = read_jpeg(&data, None).expect("failed to parse JPEG");
+    let jpeg = read_jpeg(&data, None, None).expect("failed to parse JPEG");
     let jxl_bytes = encode_jpeg_to_jxl(&jpeg).expect("failed to encode JPEG to JXL");
 
     eprintln!(
@@ -331,7 +331,7 @@ fn test_decode_landscape_jpeg_oxide() {
         jxl_encoder::test_helpers::corpus_dir().display()
     );
     let data = std::fs::read(path).expect("failed to read test JPEG");
-    let jpeg = read_jpeg(&data, None).expect("failed to parse JPEG");
+    let jpeg = read_jpeg(&data, None, None).expect("failed to parse JPEG");
     let jxl_bytes = encode_jpeg_to_jxl(&jpeg).expect("failed to encode JPEG to JXL");
 
     eprintln!(
@@ -469,7 +469,7 @@ fn test_decode_landscape_jpeg_oxide() {
 fn test_jbrd_roundtrip_small() {
     let path = jxl_encoder::test_helpers::output_file_for("jpeg-reencoding", "test64_444.jpg");
     let jpeg_data = std::fs::read(&path).expect("failed to read test JPEG");
-    let jpeg = read_jpeg(&jpeg_data, None).expect("failed to parse JPEG");
+    let jpeg = read_jpeg(&jpeg_data, None, None).expect("failed to parse JPEG");
     let jxl_bytes =
         encode_jpeg_to_jxl_container(&jpeg).expect("failed to encode JPEG to JXL container");
 
@@ -550,7 +550,7 @@ fn test_jbrd_roundtrip_landscape() {
         jxl_encoder::test_helpers::corpus_dir().display()
     );
     let jpeg_data = std::fs::read(path).expect("failed to read test JPEG");
-    let jpeg = read_jpeg(&jpeg_data, None).expect("failed to parse JPEG");
+    let jpeg = read_jpeg(&jpeg_data, None, None).expect("failed to parse JPEG");
     let jxl_bytes =
         encode_jpeg_to_jxl_container(&jpeg).expect("failed to encode JPEG to JXL container");
 
@@ -631,7 +631,7 @@ fn test_jbrd_roundtrip_large_photos() {
             .to_string_lossy();
         let jpeg_data =
             std::fs::read(path).unwrap_or_else(|e| panic!("failed to read {path}: {e}"));
-        let jpeg = read_jpeg(&jpeg_data, None)
+        let jpeg = read_jpeg(&jpeg_data, None, None)
             .unwrap_or_else(|e| panic!("failed to parse {basename}: {e}"));
         let jxl_bytes = encode_jpeg_to_jxl_container(&jpeg)
             .unwrap_or_else(|e| panic!("failed to encode {basename}: {e}"));
@@ -680,7 +680,7 @@ fn test_jbrd_roundtrip_large_photos() {
 fn test_jbrd_parse_oxide() {
     let path = jxl_encoder::test_helpers::output_file_for("jpeg-reencoding", "test64_444.jpg");
     let jpeg_data = std::fs::read(&path).expect("failed to read test JPEG");
-    let jpeg = read_jpeg(&jpeg_data, None).expect("failed to parse JPEG");
+    let jpeg = read_jpeg(&jpeg_data, None, None).expect("failed to parse JPEG");
     let jbrd_bytes = encode_jbrd(&jpeg).expect("failed to encode JBRD");
 
     eprintln!("JBRD box: {} bytes", jbrd_bytes.len());
@@ -737,8 +737,8 @@ fn out_dir() -> String {
 fn roundtrip_jpeg_byteexact(jpeg_path: &str, label: &str) {
     let jpeg_data = std::fs::read(jpeg_path)
         .unwrap_or_else(|e| panic!("{label}: failed to read {jpeg_path}: {e}"));
-    let jpeg =
-        read_jpeg(&jpeg_data, None).unwrap_or_else(|e| panic!("{label}: failed to parse: {e}"));
+    let jpeg = read_jpeg(&jpeg_data, None, None)
+        .unwrap_or_else(|e| panic!("{label}: failed to parse: {e}"));
 
     // Log component info
     for (i, comp) in jpeg.components.iter().enumerate() {
@@ -1020,7 +1020,7 @@ fn test_cmyk_parse_succeeds() {
         jxl_encoder::test_helpers::corpus_dir().display()
     );
     let data = std::fs::read(&path).unwrap_or_else(|e| panic!("failed to read {path}: {e}"));
-    let jpeg = read_jpeg(&data, None).expect("parser must accept 4-component CMYK SOF");
+    let jpeg = read_jpeg(&data, None, None).expect("parser must accept 4-component CMYK SOF");
     assert_eq!(jpeg.components.len(), 4, "expected 4 components");
     assert_eq!(jpeg.width, 1174);
     assert_eq!(jpeg.height, 734);
@@ -1044,7 +1044,7 @@ fn test_cmyk_encode_clear_error() {
         jxl_encoder::test_helpers::corpus_dir().display()
     );
     let data = std::fs::read(&path).unwrap_or_else(|e| panic!("failed to read {path}: {e}"));
-    let jpeg = read_jpeg(&data, None).expect("CMYK SOF parse");
+    let jpeg = read_jpeg(&data, None, None).expect("CMYK SOF parse");
     assert_eq!(jpeg.components.len(), 4);
 
     let result = encode_jpeg_to_jxl(&jpeg);

--- a/jxl-encoder/tests/it/jpeg_reencoding.rs
+++ b/jxl-encoder/tests/it/jpeg_reencoding.rs
@@ -168,7 +168,8 @@ fn decode_jxl_rs_gray(data: &[u8]) -> (usize, usize, Vec<f32>) {
 fn verify_jxl_rs_decodes(jpeg_path: &str, label: &str) {
     let jpeg_data = std::fs::read(jpeg_path)
         .unwrap_or_else(|e| panic!("{label}: failed to read {jpeg_path}: {e}"));
-    let jpeg = read_jpeg(&jpeg_data).unwrap_or_else(|e| panic!("{label}: failed to parse: {e}"));
+    let jpeg =
+        read_jpeg(&jpeg_data, None).unwrap_or_else(|e| panic!("{label}: failed to parse: {e}"));
 
     let jxl_bytes = encode_jpeg_to_jxl(&jpeg).unwrap_or_else(|e| panic!("{label}: encode: {e}"));
 
@@ -210,7 +211,7 @@ fn verify_jxl_rs_decodes(jpeg_path: &str, label: &str) {
 fn test_encode_small_jpeg() {
     let path = jxl_encoder::test_helpers::output_file_for("jpeg-reencoding", "test64_444.jpg");
     let data = std::fs::read(&path).expect("failed to read test JPEG");
-    let jpeg = read_jpeg(&data).expect("failed to parse JPEG");
+    let jpeg = read_jpeg(&data, None).expect("failed to parse JPEG");
     let jxl_bytes = encode_jpeg_to_jxl(&jpeg).expect("failed to encode JPEG to JXL");
 
     eprintln!(
@@ -236,7 +237,7 @@ fn test_decode_small_jpeg_oxide() {
     let path = jxl_encoder::test_helpers::output_file_for("jpeg-reencoding", "test64_444.jpg");
     let path_str = path.to_string_lossy().into_owned();
     let data = std::fs::read(&path).expect("failed to read test JPEG");
-    let jpeg = read_jpeg(&data).expect("failed to parse JPEG");
+    let jpeg = read_jpeg(&data, None).expect("failed to parse JPEG");
     let jxl_bytes = encode_jpeg_to_jxl(&jpeg).expect("failed to encode JPEG to JXL");
 
     eprintln!(
@@ -330,7 +331,7 @@ fn test_decode_landscape_jpeg_oxide() {
         jxl_encoder::test_helpers::corpus_dir().display()
     );
     let data = std::fs::read(path).expect("failed to read test JPEG");
-    let jpeg = read_jpeg(&data).expect("failed to parse JPEG");
+    let jpeg = read_jpeg(&data, None).expect("failed to parse JPEG");
     let jxl_bytes = encode_jpeg_to_jxl(&jpeg).expect("failed to encode JPEG to JXL");
 
     eprintln!(
@@ -468,7 +469,7 @@ fn test_decode_landscape_jpeg_oxide() {
 fn test_jbrd_roundtrip_small() {
     let path = jxl_encoder::test_helpers::output_file_for("jpeg-reencoding", "test64_444.jpg");
     let jpeg_data = std::fs::read(&path).expect("failed to read test JPEG");
-    let jpeg = read_jpeg(&jpeg_data).expect("failed to parse JPEG");
+    let jpeg = read_jpeg(&jpeg_data, None).expect("failed to parse JPEG");
     let jxl_bytes =
         encode_jpeg_to_jxl_container(&jpeg).expect("failed to encode JPEG to JXL container");
 
@@ -549,7 +550,7 @@ fn test_jbrd_roundtrip_landscape() {
         jxl_encoder::test_helpers::corpus_dir().display()
     );
     let jpeg_data = std::fs::read(path).expect("failed to read test JPEG");
-    let jpeg = read_jpeg(&jpeg_data).expect("failed to parse JPEG");
+    let jpeg = read_jpeg(&jpeg_data, None).expect("failed to parse JPEG");
     let jxl_bytes =
         encode_jpeg_to_jxl_container(&jpeg).expect("failed to encode JPEG to JXL container");
 
@@ -630,8 +631,8 @@ fn test_jbrd_roundtrip_large_photos() {
             .to_string_lossy();
         let jpeg_data =
             std::fs::read(path).unwrap_or_else(|e| panic!("failed to read {path}: {e}"));
-        let jpeg =
-            read_jpeg(&jpeg_data).unwrap_or_else(|e| panic!("failed to parse {basename}: {e}"));
+        let jpeg = read_jpeg(&jpeg_data, None)
+            .unwrap_or_else(|e| panic!("failed to parse {basename}: {e}"));
         let jxl_bytes = encode_jpeg_to_jxl_container(&jpeg)
             .unwrap_or_else(|e| panic!("failed to encode {basename}: {e}"));
 
@@ -679,7 +680,7 @@ fn test_jbrd_roundtrip_large_photos() {
 fn test_jbrd_parse_oxide() {
     let path = jxl_encoder::test_helpers::output_file_for("jpeg-reencoding", "test64_444.jpg");
     let jpeg_data = std::fs::read(&path).expect("failed to read test JPEG");
-    let jpeg = read_jpeg(&jpeg_data).expect("failed to parse JPEG");
+    let jpeg = read_jpeg(&jpeg_data, None).expect("failed to parse JPEG");
     let jbrd_bytes = encode_jbrd(&jpeg).expect("failed to encode JBRD");
 
     eprintln!("JBRD box: {} bytes", jbrd_bytes.len());
@@ -736,7 +737,8 @@ fn out_dir() -> String {
 fn roundtrip_jpeg_byteexact(jpeg_path: &str, label: &str) {
     let jpeg_data = std::fs::read(jpeg_path)
         .unwrap_or_else(|e| panic!("{label}: failed to read {jpeg_path}: {e}"));
-    let jpeg = read_jpeg(&jpeg_data).unwrap_or_else(|e| panic!("{label}: failed to parse: {e}"));
+    let jpeg =
+        read_jpeg(&jpeg_data, None).unwrap_or_else(|e| panic!("{label}: failed to parse: {e}"));
 
     // Log component info
     for (i, comp) in jpeg.components.iter().enumerate() {
@@ -1018,7 +1020,7 @@ fn test_cmyk_parse_succeeds() {
         jxl_encoder::test_helpers::corpus_dir().display()
     );
     let data = std::fs::read(&path).unwrap_or_else(|e| panic!("failed to read {path}: {e}"));
-    let jpeg = read_jpeg(&data).expect("parser must accept 4-component CMYK SOF");
+    let jpeg = read_jpeg(&data, None).expect("parser must accept 4-component CMYK SOF");
     assert_eq!(jpeg.components.len(), 4, "expected 4 components");
     assert_eq!(jpeg.width, 1174);
     assert_eq!(jpeg.height, 734);
@@ -1042,7 +1044,7 @@ fn test_cmyk_encode_clear_error() {
         jxl_encoder::test_helpers::corpus_dir().display()
     );
     let data = std::fs::read(&path).unwrap_or_else(|e| panic!("failed to read {path}: {e}"));
-    let jpeg = read_jpeg(&data).expect("CMYK SOF parse");
+    let jpeg = read_jpeg(&data, None).expect("CMYK SOF parse");
     assert_eq!(jpeg.components.len(), 4);
 
     let result = encode_jpeg_to_jxl(&jpeg);
@@ -1066,5 +1068,70 @@ fn test_cmyk_encode_clear_error() {
     assert!(
         msg.contains("4-component") && msg.contains("CMYK"),
         "container error message lacks spec context: {msg}",
+    );
+}
+
+// ── Configurable JPEG-transcode pixel cap (issue #77) ──
+
+/// Minimal SOI + SOF0 (3 components) advertising `w`×`h`, with no scan data.
+/// Parsing fails AFTER the SOF — either at the pre-flight pixel cap (if the
+/// frame exceeds it) or later for missing coefficients. Used to probe *which*
+/// failure occurs as the cap is varied.
+fn minimal_sof(w: u16, h: u16) -> Vec<u8> {
+    let mut d = vec![0xFF, 0xD8, 0xFF, 0xC0];
+    d.extend_from_slice(&17u16.to_be_bytes()); // SOF length
+    d.push(8); // precision
+    d.extend_from_slice(&h.to_be_bytes());
+    d.extend_from_slice(&w.to_be_bytes());
+    d.push(3); // Nf
+    d.extend_from_slice(&[1, 0x11, 0]);
+    d.extend_from_slice(&[2, 0x11, 1]);
+    d.extend_from_slice(&[3, 0x11, 1]);
+    d
+}
+
+/// The pre-flight pixel cap on the untrusted JPEG-transcode SOF is
+/// **configurable** end-to-end through `LosslessConfig::with_limits`
+/// (issue #77). The same input is admitted or rejected purely by the
+/// caller's `Limits::max_pixels`, proving the cap is threaded from the
+/// public config all the way into `parse_sof_marker`.
+#[test]
+fn test_transcode_pixel_cap_configurable_via_with_limits() {
+    use jxl_encoder::{Limits, LosslessConfig};
+
+    // 4096×4096 = 16.8 MP — well under the 120 MP default cap.
+    let sof = minimal_sof(4096, 4096);
+
+    // (a) Default cap: the 16.8 MP frame clears the cap. It still fails (no
+    //     scan data), but NOT with the cap message.
+    let dflt = LosslessConfig::new().encode_jpeg_transcode(&sof);
+    if let Err(e) = &dflt {
+        let m = format!("{e}");
+        assert!(
+            !m.contains("transcode pixel cap"),
+            "default 120 MP cap wrongly fired on a 16.8 MP frame: {m}"
+        );
+    }
+
+    // (b) Tightened cap (10 MP via Limits::max_pixels): the same frame is now
+    //     rejected AT the SOF pre-flight — the cap is genuinely caller-driven.
+    let tight = LosslessConfig::new()
+        .with_limits(&Limits::new().with_max_pixels(10_000_000))
+        .encode_jpeg_transcode(&sof);
+    let err = tight.expect_err("a 10 MP cap must reject the 16.8 MP frame");
+    let msg = format!("{err}");
+    assert!(
+        msg.contains("10 MP transcode pixel cap"),
+        "expected the configured 10 MP cap rejection, got: {msg}"
+    );
+
+    // (c) The codestream-only entry point honours the same cap.
+    let tight_cs = LosslessConfig::new()
+        .with_limits(&Limits::new().with_max_pixels(10_000_000))
+        .encode_jpeg_transcode_codestream(&sof);
+    let err_cs = tight_cs.expect_err("a 10 MP cap must reject on the codestream path too");
+    assert!(
+        format!("{err_cs}").contains("transcode pixel cap"),
+        "codestream path did not honour the configured cap: {err_cs}"
     );
 }


### PR DESCRIPTION
Hardens the untrusted JPEG-transcode path, **closing all of #77's P1 items** and fixing the pre-existing **#81** VarDCT-cancellation gap. Three commits, rebased onto current `main`.

### #77 item 1 — memory bounds
- **Configurable pre-flight pixel cap**: `parse_sof_marker` rejects `width × height` over a cap (default `Limits::DEFAULT_MAX_JPEG_TRANSCODE_PIXELS` = 120 MP) **before any coefficient allocation**; overridable via `Limits::max_pixels` + `LosslessConfig::with_limits`.
- **Per-encode `MemoryBudget`** (default-on): built from `Limits::max_memory_bytes` (lossless 8 GiB default), threaded through both phases — `read_jpeg_with_stop` reserves each per-component `i16` coefficient buffer before allocating (`JpegError::ResourceLimit` → `EncodeError::LimitExceeded`); `encode_jpeg_to_jxl_inner` reserves a ~32 B/coefficient working-set estimate up front (RAII, released per-encode) so oversized frames are rejected **before** the expensive clustering.

### #77 item 2 — cooperative cancellation
- **JPEG path**: `encode_jpeg_transcode_with_stop` / `encode_jpeg_transcode_codestream_with_stop` accept an `enough::Stop`, polled at coarse boundaries (decode + zenjpeg + per-group / pre-entropy) → `EncodeError::Cancelled`. `parse.rs` no longer hardcodes `Unstoppable`.
- **VarDCT path (#81 fix)**: `#81` wired per-group `Stop` checkpoints into `VarDctEncoder::encode_inner`, but they lived only in the multi-group two-pass branch — a single-pass / single-group encode never polled, so `test_stop_cancels_lossy_multigroup` failed (red on `main`). Added an entry checkpoint at the top of `encode_inner` that fires on **all** paths; per-group checkpoints remain for mid-encode responsiveness.

### #77 item 3 — unchecked SOF overflow
`extract_coefficients_zenjpeg` computed `width_in_blocks * height_in_blocks * 64` as unchecked `u32`/`usize` on attacker-controlled SOF dims (wrap → short `comp.coeffs` → OOB zigzag copy). Now checked `usize` arithmetic + reconciled against zenjpeg's decoded coefficient count before the copy. `jbrd.rs` `write_u32_jbrd`'s `unreachable!` → typed `Error::InvalidInput`.

### PreserveJxl
`encode_jpeg_recompress_{,auto_,planar_}codestream` gain `limits` + `stop` params (one budget shared across the lossless-floor + lossy encodes).

### Byte-identity & tests
Byte-identical for all real input under the default cap. New: `read_jpeg_pixel_cap_is_configurable`, `test_transcode_pixel_cap_configurable_via_with_limits`, `test_jpeg_transcode_cancellation`, `test_jpeg_transcode_memory_budget`, `test_jpeg_recompress_limits_and_stop` (+ the now-passing `test_stop_cancels_lossy_multigroup`).

Verified locally (`jpeg-reencoding`): default + lib + cli + examples build clean; **full lib suite 1523/1523** (the #81 failure is fixed); all 28 `jpeg_reencoding` + 14 byte-exact JBRD / transcode-roundtrip gates pass; clippy clean on changed files; `cargo fmt` clean. Input-size + cancellation hardening, not a libjxl cost-model divergence (`docs/LIBJXL_DIVERGENCES.md` unaffected).
