### PR TITLE
feat(cancel): wire the dead Stop token into the lossy encode loop (refs #77)

### DIFF
--- a/jxl-encoder/src/api.rs
+++ b/jxl-encoder/src/api.rs
@@ -10101,7 +10101,7 @@ impl<'a> EncodeRequest<'a> {
         };
 
         let output = enc
-            .encode_with_extras(encode_w, encode_h, &encode_rgb, &extras_vec)
+            .encode_with_extras_stop(encode_w, encode_h, &encode_rgb, &extras_vec, self.stop)
             .map_err(EncodeError::from)?;
 
         #[cfg(feature = "butteraugli-loop")]
@@ -15768,6 +15768,42 @@ mod tests {
             .with_stop(&Unstoppable)
             .encode(&pixels);
         assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_stop_cancels_lossy_multigroup() {
+        // A 512x512 image is multi-group (2x2 AC groups + a DC group), so the
+        // per-group cancellation checkpoint in the VarDCT entropy phase runs.
+        // An always-cancelling Stop must abort the encode with `Cancelled`.
+        let (w, h) = (512u32, 512u32);
+        let mut pixels = vec![0u8; (w * h * 3) as usize];
+        for (i, p) in pixels.iter_mut().enumerate() {
+            *p = (i.wrapping_mul(2_654_435_761) >> 13) as u8;
+        }
+
+        struct AlwaysCancel;
+        impl enough::Stop for AlwaysCancel {
+            fn check(&self) -> core::result::Result<(), enough::StopReason> {
+                Err(enough::StopReason::Cancelled)
+            }
+        }
+
+        let cancelled = LossyConfig::new(1.0)
+            .encode_request(w, h, PixelLayout::Rgb8)
+            .with_stop(&AlwaysCancel)
+            .encode(&pixels);
+        assert!(
+            matches!(&cancelled, Err(e) if matches!(e.error(), EncodeError::Cancelled)),
+            "expected EncodeError::Cancelled, got {cancelled:?}"
+        );
+
+        // Unstoppable on the same input must still succeed — the checkpoint is
+        // a no-op on the success path.
+        let ok = LossyConfig::new(1.0)
+            .encode_request(w, h, PixelLayout::Rgb8)
+            .with_stop(&enough::Unstoppable)
+            .encode(&pixels);
+        assert!(ok.is_ok(), "Unstoppable lossy encode failed: {ok:?}");
     }
 
     #[test]

--- a/jxl-encoder/src/vardct/encoder.rs
+++ b/jxl-encoder/src/vardct/encoder.rs
@@ -21,6 +21,7 @@ use crate::debug_log;
 use crate::debug_rect;
 use crate::error::{Error, Result};
 use crate::headers::frame_header::FrameHeader;
+use enough::Stop;
 
 // Re-export types from entropy_code sub-module.
 pub(crate) use super::entropy_code::{BuiltEntropyCode, force_strategy_map};
@@ -3295,8 +3296,24 @@ impl VarDctEncoder {
         linear_rgb: &[f32],
         alpha: Option<&[u8]>,
     ) -> Result<VarDctOutput> {
+        self.encode_with_stop(width, height, linear_rgb, alpha, None)
+    }
+
+    /// Like [`encode`](Self::encode) but polls `stop` at coarse (per-group)
+    /// boundaries during entropy coding, returning [`Error::Cancelled`] if
+    /// cancellation is requested. With `None` (or an `Unstoppable` token) the
+    /// emitted bytes are identical to [`encode`](Self::encode) — the poll is a
+    /// no-op on the success path.
+    pub fn encode_with_stop(
+        &self,
+        width: usize,
+        height: usize,
+        linear_rgb: &[f32],
+        alpha: Option<&[u8]>,
+        stop: Option<&dyn Stop>,
+    ) -> Result<VarDctOutput> {
         match alpha {
-            None => self.encode_with_extras(width, height, linear_rgb, &[]),
+            None => self.encode_with_extras_stop(width, height, linear_rgb, &[], stop),
             Some(buf) => {
                 // Build a default-alpha ExtraChannel view borrowing the caller's
                 // buffer. `with_alpha` honours the encoder's `alpha_associated`
@@ -3321,7 +3338,7 @@ impl VarDctEncoder {
                         expected_alpha
                     )));
                 }
-                self.encode_inner(width, height, linear_rgb, &[ec])
+                self.encode_inner(width, height, linear_rgb, &[ec], stop)
             }
         }
     }
@@ -3346,6 +3363,20 @@ impl VarDctEncoder {
         height: usize,
         linear_rgb: &[f32],
         extras: &[crate::api::ExtraChannel<'_>],
+    ) -> Result<VarDctOutput> {
+        self.encode_with_extras_stop(width, height, linear_rgb, extras, None)
+    }
+
+    /// Like [`encode_with_extras`](Self::encode_with_extras) but polls `stop`
+    /// at coarse (per-group) boundaries during entropy coding. With `None`
+    /// (or an `Unstoppable` token) the emitted bytes are identical.
+    pub fn encode_with_extras_stop(
+        &self,
+        width: usize,
+        height: usize,
+        linear_rgb: &[f32],
+        extras: &[crate::api::ExtraChannel<'_>],
+        stop: Option<&dyn Stop>,
     ) -> Result<VarDctOutput> {
         // Materialize the internal `VardctExtra` views, validating
         // dimensions + bit depth + dim_shift up-front before any work.
@@ -3373,7 +3404,7 @@ impl VarDctEncoder {
         }
 
         self.check_alpha_squeeze_supported(&views, Some((width, height)))?;
-        self.encode_inner(width, height, linear_rgb, &views)
+        self.encode_inner(width, height, linear_rgb, &views, stop)
     }
 
     /// Chunk-2.b gate (multi-group + dim_shift consolidation).
@@ -3532,6 +3563,7 @@ impl VarDctEncoder {
         height: usize,
         linear_rgb: &[f32],
         extras: &[super::extras::VardctExtra<'_>],
+        stop: Option<&dyn Stop>,
     ) -> Result<VarDctOutput> {
         let expected_rgb = width
             .checked_mul(height)
@@ -6181,6 +6213,11 @@ impl VarDctEncoder {
             // DC group sections
             let blocks_per_dc_group = (256 / 8) * (256 / 8); // 1024 blocks per DC group
             for dc_group_idx in 0..num_dc_groups {
+                // Coarse cancellation checkpoint (per DC group). No-op on the
+                // success path, so byte output is identical under Unstoppable.
+                if let Some(s) = stop {
+                    s.check().map_err(|_| Error::Cancelled)?;
+                }
                 let mut dc_group = BitWriter::with_capacity(blocks_per_dc_group * 10);
                 self.write_dc_group(
                     dc_group_idx,
@@ -6215,6 +6252,11 @@ impl VarDctEncoder {
             // AC group sections
             let blocks_per_ac_group = (256 / 8) * (256 / 8); // 1024 blocks per AC group
             for group_idx in 0..num_groups {
+                // Coarse cancellation checkpoint (per AC group). No-op on the
+                // success path, so byte output is identical under Unstoppable.
+                if let Some(s) = stop {
+                    s.check().map_err(|_| Error::Cancelled)?;
+                }
                 let mut ac_group_writer = BitWriter::with_capacity(blocks_per_ac_group * 100);
                 self.write_ac_group(
                     group_idx,


### PR DESCRIPTION
## What

`LossyConfig`/`EncodeRequest::with_stop()` stored a `&dyn Stop` cancellation token, but **nothing ever checked it** — there were zero `stop.check()` call sites in the encoder, so `with_stop()` was silently a no-op. This wires the token into the lossy VarDCT encode loop (refs #77).

## How

- `VarDctEncoder` gains `encode_with_stop` / `encode_with_extras_stop`. The existing `encode` / `encode_with_extras` **delegate to them with `None`**, so their public signatures are unchanged (non-breaking).
- `encode_inner` takes `Option<&dyn Stop>` and polls it **once per DC group and once per AC group** — coarse boundaries, *not* per-block/per-coefficient (those are hot loops; an `At<>`-bearing or Drop-bearing check there would cost on the Ok path too). On cancellation it returns `Error::Cancelled` → mapped to `EncodeError::Cancelled` at the boundary.
- The one-shot lossy path (`encode_lossy`) passes `self.stop`. Streaming `finish_inner` passes `None` (streaming cancellation is a follow-up — `LossyEncoder` is an owned struct with no lifetime to hold the borrowed token).

## Byte-safety

**Byte-identical on the success path by construction.** The poll is `if let Some(s) = stop { s.check()… }?`, skipped entirely when `stop` is `None`. Every existing fixture (none call `with_stop`) passes `None`, so emitted bytes are unchanged. The moved `encode_with_extras` body is verbatim apart from the threaded `stop` argument.

## Test

`test_stop_cancels_lossy_multigroup`: a 512×512 (multi-group) lossy encode with an always-cancelling `Stop` returns `Cancelled`; the same input under `Unstoppable` succeeds. (The pre-existing `test_stop_cancellation` only checked the `Unstoppable` no-op.)

## ⚠️ Verification status — CI must confirm byte-locks

`cargo build --lib -p jxl-encoder` is **green**. I could **not** build the full test harness locally: `brotli 8.0.3` fails to compile under `rustc 1.96.0` in a clean `cargo test` build in my environment (`StandardAlloc: alloc::Allocator<T>` errors — a pre-existing local toolchain issue, unrelated to this change; the primary checkout has brotli cached and CI builds it fine per the recent hash-locks-48/48 records).

**CI must confirm**: `hash_lock_features` stays green (the by-construction argument says it will) and `test_stop_cancels_lossy_multigroup` passes. Please don't merge until CI is green.

## Follow-ups (#77 stays open)

- Streaming-path token (`LossyEncoder` needs a lifetime or a finish-time stop param).
- Analysis-phase checkpoints (AQ / AC-strategy search / butteraugli loop) for finer cancellation latency at e8+.
- Lossless (modular) path.
