### PR TITLE
ci: --locked to restore the test/byte-lock gate (fixes #82)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,10 +49,10 @@ jobs:
           prefix-key: v1-rust
 
       - name: Build workspace
-        run: cargo build --workspace --release
+        run: cargo build --workspace --locked --release
 
       - name: Run tests
-        run: cargo test --workspace --release
+        run: cargo test --workspace --locked --release
 
       # Belt-and-suspenders: ensure the no_std + alloc path keeps
       # compiling. `jxl-encoder-simd` is `#![no_std]` unconditionally
@@ -62,7 +62,7 @@ jobs:
       # downstream builds.
       - name: Build (no-std, no-default-features)
         if: matrix.os == 'ubuntu-latest'
-        run: cargo build -p jxl-encoder --no-default-features
+        run: cargo build -p jxl-encoder --locked --no-default-features
 
   # ==========================================================================
   # Native ARM64 + macOS Intel testing
@@ -95,11 +95,11 @@ jobs:
           prefix-key: v1-rust
 
       - name: Build workspace
-        run: cargo build --workspace --release
+        run: cargo build --workspace --locked --release
 
       - name: Run tests
         if: matrix.run_tests
-        run: cargo test --workspace --release
+        run: cargo test --workspace --locked --release
 
   # ==========================================================================
   # Cross-compiled testing with QEMU emulation (32-bit targets)
@@ -185,13 +185,13 @@ jobs:
       - name: Build for WASM
         env:
           RUSTFLAGS: ${{ matrix.rustflags }}
-        run: cargo build --workspace --exclude zenjxl-tuning-runner --release --no-default-features --features "std" --target wasm32-wasip1
+        run: cargo build --workspace --exclude zenjxl-tuning-runner --locked --release --no-default-features --features "std" --target wasm32-wasip1
 
       - name: Test jxl-encoder-simd (SIMD-vs-scalar tests)
         env:
           RUSTFLAGS: ${{ matrix.rustflags }}
           CARGO_TARGET_WASM32_WASIP1_RUNNER: "wasmtime run --dir=."
-        run: cargo test -p jxl-encoder-simd --release --target wasm32-wasip1 --lib
+        run: cargo test -p jxl-encoder-simd --locked --release --target wasm32-wasip1 --lib
 
   # ==========================================================================
   # Code Coverage
@@ -260,10 +260,10 @@ jobs:
           prefix-key: v1-rust
 
       - name: Clippy (default features)
-        run: cargo clippy --workspace -- -D warnings
+        run: cargo clippy --workspace --locked -- -D warnings
 
       - name: Clippy (zensim-loop)
-        run: cargo clippy --workspace --features zensim-loop -- -D warnings
+        run: cargo clippy --workspace --locked --features zensim-loop -- -D warnings
 
 
   # ==========================================================================


### PR DESCRIPTION
## Fixes #82 — restores the test/byte-lock gate

The full test suite stopped compiling on `main` (~2026-06-14 06:37) with ~36× `error[E0277]: StandardAlloc: alloc::Allocator<T>`. Root cause (full diagnosis in #82): `alloc-stdlib 0.2.2`'s loose `alloc-no-stdlib = ">=2.0.4, <4.0.0"` range now resolves to the **newly-published `alloc-no-stdlib 3.0.0`**, while `brotli 8.0.3` pins `alloc-no-stdlib = "2.0"` (`<3.0`). Without `--locked`, `cargo build/test --workspace` re-resolves into that split — `StandardAlloc` impls the 3.0.0 trait, brotli expects the 2.0.4 trait.

## Fix

Add `--locked` to all 9 `cargo build`/`test`/`clippy` invocations in `ci.yml`. The committed `Cargo.lock` is already consistent — `cargo metadata --locked` resolves `alloc-no-stdlib` to **exactly 2.0.4** (verified locally) — so honoring it fixes the split. Also reproducible-build best practice.

## Verification

This PR's own CI runs the `--locked` workflow from this branch, so a green `Build x64` / `Build native` / `Coverage` here **is** the proof that the test gate is restored (brotli compiles, `hash_lock_features` + the byte-locks run again). No source/manifest/lockfile change — `ci.yml` only.

Unblocks byte-lock verification for every open PR (including #81).
