### PR TITLE
docs(jxl-encoder-cli): output-overwrite + -d/-q precedence + lossless clarification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -221,6 +221,19 @@
   section documenting what `Limits::default()` bounds (the 4 GiB lossy /
   8 GiB lossless soft memory cap). README-only; every symbol verified
   against source.
+- **`jxl-encoder-cli` README: stated three unstated `cjxl-rs` behaviors
+  found by an insulated external-developer test** (reader given only the
+  CLI README, no source — the README ran first-try otherwise). Added a
+  Notes block under Usage: (1) the output file is **overwritten silently**
+  if it exists (`write_output` uses `File::create` —
+  `jxl-encoder-cli/src/main.rs:2396`; same on the streaming-output paths
+  at `:2166` / `:2253`; no `--force` flag exists); (2) when both `-d` and
+  `-q` are passed, **`-d` wins** (`-q` is only the fallback — main.rs:754;
+  no clap `conflicts_with`, so it is silent, not an error); (3)
+  **`--lossless` and `-d 0` are equivalent** — both fold to distance 0.0
+  (main.rs:754) and route to the `LosslessConfig` modular path (main.rs:1433
+  `distance > 0.0` is false → modular at main.rs:1813), i.e. true
+  mathematical lossless either way. README-only; verified against source.
 
 ### Fixed
 - **`estimate_peak_memory_bytes` under-reported the lossless path ~14×.**

--- a/jxl-encoder-cli/README.md
+++ b/jxl-encoder-cli/README.md
@@ -29,6 +29,11 @@ cjxl-rs input.png output.jxl -q 90
 
 Reads PNG (including APNG animation). Writes bare JXL codestream or container format (when metadata or animation is present).
 
+Notes:
+- The output file is **overwritten silently** if it already exists — there is no `--force` / overwrite prompt.
+- If both `-d` and `-q` are given, `-d` wins (`-q` is only the fallback when `-d` is absent); they are not mutually exclusive.
+- `--lossless` and `-d 0` are equivalent — both select the modular path for true mathematical lossless. Either works.
+
 ## Flags
 
 | Flag | Default | Description |


### PR DESCRIPTION
## What

An insulated "external developer" test of the **published `jxl-encoder-cli` 0.2.0 README** (binary `cjxl-rs`) — reader given only the README, no source — found it excellent: correct binary name, arg order, all flags with defaults + direction; the documented commands run first-try. It surfaced **three unstated behaviors**. This PR states them in a tight Notes block under Usage (the README is already good; this is additive).

## The three behaviors (each VERIFIED against the CLI source)

1. **Output overwrite** — `cjxl-rs in.png out.jxl` **silently overwrites** an existing `out.jxl`. `write_output` uses `File::create` (`jxl-encoder-cli/src/main.rs:2396`), as do the streaming-output paths (`:2166`, `:2253`). There is no `--force` / `-y` flag in the `Args` struct.
2. **`-d` vs `-q` precedence** — when both are passed, **`-d` wins**; `-q` is only the fallback. Distance resolves at `main.rs:754`: `if lossless || distance == Some(0.0) → 0.0; else if let Some(d) = distance → d; else quality_to_distance(quality)`. Neither flag has a clap `conflicts_with`, so passing both is silent (not an error).
3. **`--lossless` vs `-d 0`** — **equivalent**. Both fold to distance `0.0` (`main.rs:754`), and the lossy/lossless dispatch routes `distance == 0.0` (i.e. NOT `> 0.0`) to the `LosslessConfig` modular path (`main.rs:1433` is false → modular branch at `main.rs:1813`). Either yields true mathematical lossless.

## Scope

README-only, plus a CHANGELOG entry under the existing `### Documentation` section (sibling to the prior insulated-dev README docfix, #84). No code or behavior change. Found via an insulated external-dev usability test.