### PR TITLE
docs(jxl-encoder): correct effective_max_memory_bytes/budget docs for the path-aware lossless 8 GiB default

### DIFF
--- a/jxl-encoder/src/api.rs
+++ b/jxl-encoder/src/api.rs
@@ -1322,12 +1322,15 @@ impl<'a> ImageMetadata<'a> {
 ///   here, but never a higher one. The encoder saturates at the lower of
 ///   `Limits.max_quant_loop_iters` (or its default) and the validator
 ///   max.
-/// - [`Self::max_memory_bytes`] — when `None`, the encoder applies
-///   [`Self::DEFAULT_MAX_MEMORY_BYTES`] (≈ 4 GB) as a soft cap so that an
-///   image proxy without explicit `Limits` configuration still has a
-///   working-set ceiling. Set to `Some(u64::MAX)` to opt out of the soft
-///   cap explicitly (this surfaces in logs as "user explicitly disabled
-///   memory limit").
+/// - [`Self::max_memory_bytes`] — when `None`, the encoder applies a
+///   path-aware soft cap so that an image proxy without explicit `Limits`
+///   configuration still has a working-set ceiling:
+///   [`Self::DEFAULT_MAX_MEMORY_BYTES`] (≈ 4 GiB) for lossy,
+///   [`Self::DEFAULT_MAX_MEMORY_BYTES_LOSSLESS`] (8 GiB) for lossless
+///   (lossless tree-learning is a heavier memory regime). Both are fixed
+///   ceilings — deliberately not scaled with image dimensions. Set to
+///   `Some(u64::MAX)` to opt out of the soft cap explicitly (this surfaces
+///   in logs as "user explicitly disabled memory limit").
 #[derive(Clone, Debug, Default)]
 pub struct Limits {
     max_width: Option<u64>,
@@ -1405,8 +1408,10 @@ impl Limits {
 
     /// Set maximum memory bytes the encoder may allocate.
     ///
-    /// When unset, the encoder applies
-    /// [`Self::DEFAULT_MAX_MEMORY_BYTES`] (~4 GB) as a soft cap. Pass
+    /// When unset, the encoder applies a path-aware soft cap:
+    /// [`Self::DEFAULT_MAX_MEMORY_BYTES`] (~4 GiB) for lossy,
+    /// [`Self::DEFAULT_MAX_MEMORY_BYTES_LOSSLESS`] (8 GiB) for lossless
+    /// (lossless tree-learning is a heavier memory regime). Pass
     /// `u64::MAX` explicitly to disable the cap (with the understanding
     /// that an unbounded working set on a hostile input can OOM the
     /// process).
@@ -1439,16 +1444,24 @@ impl Limits {
         self.max_pixels
     }
 
-    /// Get maximum memory bytes, if set. When `None`,
-    /// [`Self::effective_max_memory_bytes`] gives the soft default the
-    /// encoder will actually enforce.
+    /// Get maximum memory bytes, if set. When `None`, the encoder applies
+    /// the path-aware soft default — see [`Self::effective_max_memory_bytes`]
+    /// for the caveat about which value that is.
     pub fn max_memory_bytes(&self) -> Option<u64> {
         self.max_memory_bytes
     }
 
-    /// The cap the encoder will actually apply: explicit
-    /// `max_memory_bytes` if set, else
-    /// [`Self::DEFAULT_MAX_MEMORY_BYTES`].
+    /// The explicit `max_memory_bytes` if set, else the **lossy** soft
+    /// default [`Self::DEFAULT_MAX_MEMORY_BYTES`] (≈ 4 GiB).
+    ///
+    /// NOTE: this is not path-aware. When `max_memory_bytes` is unset, the
+    /// encoder enforces the path-aware default from
+    /// [`Self::default_max_memory_bytes`] — which is
+    /// [`Self::DEFAULT_MAX_MEMORY_BYTES_LOSSLESS`] (8 GiB) on the lossless
+    /// path (lossless tree-learning is a heavier memory regime). This getter
+    /// always reports the lossy value, so for an unset limit it understates
+    /// the cap a lossless encode actually runs under. Pass `is_lossless` to
+    /// [`Self::default_max_memory_bytes`] for the value the encoder uses.
     pub fn effective_max_memory_bytes(&self) -> u64 {
         self.max_memory_bytes
             .unwrap_or(Self::DEFAULT_MAX_MEMORY_BYTES)

--- a/jxl-encoder/src/budget.rs
+++ b/jxl-encoder/src/budget.rs
@@ -12,7 +12,10 @@
 //! taken branch per allocation site.
 //!
 //! The cap comes from [`Limits::max_memory_bytes`] when the caller sets
-//! one, or from [`Limits::DEFAULT_MAX_MEMORY_BYTES`] otherwise.
+//! one, or from the path-aware default [`Limits::default_max_memory_bytes`]
+//! otherwise — [`Limits::DEFAULT_MAX_MEMORY_BYTES`] (4 GiB) on the lossy
+//! path, [`Limits::DEFAULT_MAX_MEMORY_BYTES_LOSSLESS`] (8 GiB) on the
+//! lossless path.
 //!
 //! ## Coverage
 //!


### PR DESCRIPTION
Doc-only, non-breaking. Fixes DOC/CODE drift left behind when the default memory cap became path-aware (lossy 4 GiB, lossless 8 GiB).

The encoder enforces `Limits::default_max_memory_bytes(is_lossless)` — 4 GiB on lossy, **8 GiB on lossless** (`DEFAULT_MAX_MEMORY_BYTES_LOSSLESS`, src/api.rs ~8331) — but several docs still described only the 4 GiB lossy default.

## Fixes (all in `jxl-encoder/src/`)
- **`Limits::effective_max_memory_bytes()`** (api.rs) — doc said "the cap the encoder will actually apply". It is *not* path-aware: it always returns the lossy `DEFAULT_MAX_MEMORY_BYTES` (4 GiB), so for an unset limit it understates the cap a lossless encode runs under. Doc now says it reports the **lossy** soft default and points callers at `default_max_memory_bytes(is_lossless)` for the enforced value. (No signature/behavior change — the method still returns the 4 GiB const.)
- **`Limits::max_memory_bytes()` getter** — its "`effective_max_memory_bytes` gives the soft default the encoder will actually enforce" cross-ref updated to note the path-aware caveat.
- **`Limits` struct doc** + **`with_max_memory_bytes` doc** — both mentioned only 4 GiB; now state both the 4 GiB lossy and 8 GiB lossless soft caps (mirroring the README resource-limits section, which was already correct), noting both are fixed ceilings.
- **`budget.rs` module doc** — "or from `Limits::DEFAULT_MAX_MEMORY_BYTES` otherwise" now names the path-aware `default_max_memory_bytes` and the 8 GiB lossless const.

No doctest affected — the touched docs have no code fences, only intra-doc links to existing public items.