### PR TITLE
Wire fallible-alloc + budget through encoder buffers that can exceed 1 MB

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -118,6 +118,27 @@
   budget-less sample structs) intentionally stay infallible — wiring those
   would be a hot-path method-signature refactor with perf risk and little
   fallibility benefit.
+- **Fallible-alloc + budget policy extended to the remaining >1 MB
+  dimension-driven buffers.** Beyond the dominant allocations wired above, the
+  encoder's other heap buffers that can exceed ~1 MB at realistic sizes now
+  route through `vec_with_capacity_fallible` / the budget policy (byte-identical
+  on the default infallible path): DC-token buffers (`dc_coding` WP + the three
+  region collectors, `dc_tree_learn` tree-variable/tree/learn-and-collect, and
+  the `bitstream` DC-group tokenizers — the per-DC-group fan-out moved from
+  `parallel_map` to `parallel_map_result`), modular multi-group residual
+  buffers (`frame.rs` palette + squeeze closures), the VarDCT patches-dispatch
+  mask repack, the `splines` screenshot-detection Y buffer
+  (`looks_like_screenshot` is now `Result<bool>`), the `lf_frame` DC planes,
+  the JPEG-preprocessing `resampling` box/sharper downsamplers + alpha, the
+  `extras` alpha-squeeze plane, and the `patches` reference-frame channel
+  buffers. Budget is threaded as `Option<&Arc<MemoryBudget>>` (or `self.budget`
+  on `VarDctEncoder`/`FrameEncoder` methods). Three sites intentionally stay
+  infallible (honest-stop): `encoder` `median_mask1x1`/`percentile_mask1x1` (a
+  `bool`-predicate cascade through `pixel_loss_auto_should_skip`), the
+  `patches` BFS detection queue, and the `lz77` optimal-parse token buffer
+  (no budget infrastructure) — all reachable only via deep multi-hop refactors
+  with little marginal safety. Verified byte-identical (hash-locks 48/48; full
+  1986-test suite) and clippy `-D warnings` clean (default + jpeg + zensim).
 - **Checked SOF-derived overflow in the JPEG coefficient parser (#77 item 3).**
   `extract_coefficients_zenjpeg` computed `width_in_blocks * height_in_blocks`
   (and `* 64`) as unchecked `u32` / `usize` on attacker-controlled SOF dims —

--- a/jxl-encoder/src/api.rs
+++ b/jxl-encoder/src/api.rs
@@ -10224,24 +10224,34 @@ impl<'a> EncodeRequest<'a> {
         let (encode_rgb, encode_alpha, encode_w, encode_h) =
             if effective_resampling > 1 && !cfg.already_downsampled {
                 let (down_rgb, dw, dh) = if effective_resampling == 2 {
-                    crate::vardct::resampling::sharper_downsample_2x_rgb(&linear_rgb, w, h)
+                    crate::vardct::resampling::sharper_downsample_2x_rgb(
+                        &linear_rgb,
+                        w,
+                        h,
+                        Some(budget),
+                    )?
                 } else {
                     crate::vardct::resampling::box_downsample_rgb(
                         &linear_rgb,
                         w,
                         h,
                         effective_resampling,
-                    )
+                        Some(budget),
+                    )?
                 };
-                let down_alpha = alpha.as_ref().map(|a| {
-                    let (a_down, _, _) = crate::vardct::resampling::box_downsample_alpha_u8(
-                        a,
-                        w,
-                        h,
-                        effective_resampling,
-                    );
-                    a_down
-                });
+                let down_alpha = match alpha.as_ref() {
+                    Some(a) => {
+                        let (a_down, _, _) = crate::vardct::resampling::box_downsample_alpha_u8(
+                            a,
+                            w,
+                            h,
+                            effective_resampling,
+                            Some(budget),
+                        )?;
+                        Some(a_down)
+                    }
+                    None => None,
+                };
                 (down_rgb, down_alpha, dw as usize, dh as usize)
             } else {
                 (linear_rgb, alpha, w, h)
@@ -11392,24 +11402,34 @@ impl LossyEncoder {
 
             let (encode_rgb, encode_alpha, encode_w, encode_h) = if effective_resampling > 1 {
                 let (down_rgb, dw, dh) = if effective_resampling == 2 {
-                    crate::vardct::resampling::sharper_downsample_2x_rgb(&linear_rgb, w, h)
+                    crate::vardct::resampling::sharper_downsample_2x_rgb(
+                        &linear_rgb,
+                        w,
+                        h,
+                        Some(&budget),
+                    )?
                 } else {
                     crate::vardct::resampling::box_downsample_rgb(
                         &linear_rgb,
                         w,
                         h,
                         effective_resampling,
-                    )
+                        Some(&budget),
+                    )?
                 };
-                let down_alpha = alpha.as_ref().map(|a| {
-                    let (a_down, _, _) = crate::vardct::resampling::box_downsample_alpha_u8(
-                        a,
-                        w,
-                        h,
-                        effective_resampling,
-                    );
-                    a_down
-                });
+                let down_alpha = match alpha.as_ref() {
+                    Some(a) => {
+                        let (a_down, _, _) = crate::vardct::resampling::box_downsample_alpha_u8(
+                            a,
+                            w,
+                            h,
+                            effective_resampling,
+                            Some(&budget),
+                        )?;
+                        Some(a_down)
+                    }
+                    None => None,
+                };
                 (down_rgb, down_alpha, dw as usize, dh as usize)
             } else {
                 (linear_rgb, alpha, w, h)

--- a/jxl-encoder/src/jpeg/encode.rs
+++ b/jxl-encoder/src/jpeg/encode.rs
@@ -566,7 +566,8 @@ fn encode_jpeg_to_jxl_inner(
                 end_bx,
                 end_by,
                 &channel_shifts,
-            );
+                budget,
+            )?;
             for tok in t.iter_mut() {
                 tok.set_context(dc_remap[tok.context() as usize]);
             }
@@ -579,7 +580,8 @@ fn encode_jpeg_to_jxl_inner(
                 end_bx,
                 end_by,
                 &channel_shifts,
-            )
+                budget,
+            )?
         } else {
             collect_dc_tokens_region(
                 &quant_dc,
@@ -588,7 +590,8 @@ fn encode_jpeg_to_jxl_inner(
                 end_bx,
                 end_by,
                 &channel_shifts,
-            )
+                budget,
+            )?
         };
         let md_tokens = if let Some((_, _, _, _, ref ac_map)) = wp_dc_state {
             // WP-DC path uses the gradient-style AC-metadata collector (same

--- a/jxl-encoder/src/modular/frame.rs
+++ b/jxl-encoder/src/modular/frame.rs
@@ -1177,28 +1177,36 @@ impl FrameEncoder {
 
         // Step 3: Collect ALL residuals (palette_meta + all groups) for histogram
         // Honours `--modular-predictor` for the no-tree-learning fallback path.
-        let collect_channel_residuals = |channel: &super::channel::Channel| -> Vec<u32> {
-            let w = channel.width();
-            let h = channel.height();
-            let mut residuals = Vec::with_capacity(w * h);
-            for y in 0..h {
-                for x in 0..w {
-                    let pixel = channel.get(x, y);
-                    let prediction = predict_pixel_with_id(channel, x, y, predictor_id);
-                    residuals.push(pack_signed(pixel - prediction));
+        // The per-channel residual buffer is dimension-driven, so route it
+        // through the runtime fallible-alloc policy; byte-identical when
+        // infallible.
+        let residual_budget = self.budget.as_ref();
+        let collect_channel_residuals =
+            |channel: &super::channel::Channel| -> crate::error::Result<Vec<u32>> {
+                let w = channel.width();
+                let h = channel.height();
+                let mut residuals = crate::budget::vec_with_capacity_fallible(
+                    residual_budget.is_some_and(|b| b.is_fallible()),
+                    w * h,
+                )?;
+                for y in 0..h {
+                    for x in 0..w {
+                        let pixel = channel.get(x, y);
+                        let prediction = predict_pixel_with_id(channel, x, y, predictor_id);
+                        residuals.push(pack_signed(pixel - prediction));
+                    }
                 }
-            }
-            residuals
-        };
+                Ok(residuals)
+            };
 
         // Palette meta-channel residuals (goes to LfGlobal)
-        let palette_residuals = collect_channel_residuals(&palette_meta);
+        let palette_residuals = collect_channel_residuals(&palette_meta)?;
 
         // All residuals: palette_meta + all group spatial channels
         let mut all_residuals = palette_residuals.clone();
         for group_image in &group_images {
             for channel in &group_image.channels {
-                all_residuals.extend(collect_channel_residuals(channel));
+                all_residuals.extend(collect_channel_residuals(channel)?);
             }
         }
 
@@ -1336,7 +1344,7 @@ impl FrameEncoder {
                 // Collect and encode spatial channel residuals for this group
                 let mut section_residuals: Vec<u32> = Vec::new();
                 for channel in &group_image.channels {
-                    section_residuals.extend(collect_channel_residuals(channel));
+                    section_residuals.extend(collect_channel_residuals(channel)?);
                 }
                 encode_residuals(&section_residuals, &mut group_writer, &entropy_state)?;
 
@@ -1504,24 +1512,32 @@ impl FrameEncoder {
 
         // Step 3: Collect residuals from ALL channels for histogram building
         // Honours `--modular-predictor` for the squeeze multi-group fallback.
-        let collect_channel_residuals = |channel: &super::channel::Channel| -> Vec<u32> {
-            let w = channel.width();
-            let h = channel.height();
-            let mut residuals = Vec::with_capacity(w * h);
-            for y in 0..h {
-                for x in 0..w {
-                    let pixel = channel.get(x, y);
-                    let prediction = predict_pixel_with_id(channel, x, y, predictor_id);
-                    residuals.push(pack_signed(pixel - prediction));
+        // The per-channel residual buffer is dimension-driven, so route it
+        // through the runtime fallible-alloc policy; byte-identical when
+        // infallible.
+        let residual_budget = self.budget.as_ref();
+        let collect_channel_residuals =
+            |channel: &super::channel::Channel| -> crate::error::Result<Vec<u32>> {
+                let w = channel.width();
+                let h = channel.height();
+                let mut residuals = crate::budget::vec_with_capacity_fallible(
+                    residual_budget.is_some_and(|b| b.is_fallible()),
+                    w * h,
+                )?;
+                for y in 0..h {
+                    for x in 0..w {
+                        let pixel = channel.get(x, y);
+                        let prediction = predict_pixel_with_id(channel, x, y, predictor_id);
+                        residuals.push(pack_signed(pixel - prediction));
+                    }
                 }
-            }
-            residuals
-        };
+                Ok(residuals)
+            };
 
         // 3a: Global channel residuals (full channels)
         let mut all_residuals: Vec<u32> = Vec::new();
         for i in 0..global_cutoff {
-            all_residuals.extend(collect_channel_residuals(&squeezed.channels[i]));
+            all_residuals.extend(collect_channel_residuals(&squeezed.channels[i])?);
         }
 
         // 3b: LfGroup channel residuals (cropped to each DC group rect)
@@ -1539,7 +1555,7 @@ impl FrameEncoder {
                 let lg_x = lg % num_lf_groups_x;
                 let lg_y = lg / num_lf_groups_x;
                 if let Some(cropped) = ch.extract_grid_cell(lg_x, lg_y, lf_group_dim) {
-                    let residuals = collect_channel_residuals(&cropped);
+                    let residuals = collect_channel_residuals(&cropped)?;
                     all_residuals.extend(&residuals);
                     lg_channels.push(residuals);
                 }
@@ -1560,7 +1576,7 @@ impl FrameEncoder {
                 let gx = g % num_groups_x;
                 let gy = g / num_groups_x;
                 if let Some(cropped) = ch.extract_grid_cell(gx, gy, group_dim) {
-                    let residuals = collect_channel_residuals(&cropped);
+                    let residuals = collect_channel_residuals(&cropped)?;
                     all_residuals.extend(&residuals);
                     g_channels.push(residuals);
                 }
@@ -1677,7 +1693,7 @@ impl FrameEncoder {
         // Write global channel residuals
         let mut global_residuals: Vec<u32> = Vec::new();
         for i in 0..global_cutoff {
-            global_residuals.extend(collect_channel_residuals(&squeezed.channels[i]));
+            global_residuals.extend(collect_channel_residuals(&squeezed.channels[i])?);
         }
         encode_residuals(&global_residuals, &mut lf_global_writer, &entropy_state)?;
 

--- a/jxl-encoder/src/vardct/bitstream.rs
+++ b/jxl-encoder/src/vardct/bitstream.rs
@@ -11,7 +11,7 @@ use super::ac_group::{
 use super::ac_strategy::AcStrategyMap;
 use super::chroma_from_luma::CflMap;
 use super::common::*;
-use super::dc_coding::{collect_ac_metadata_tokens_region, collect_dc_tokens_wp};
+use super::dc_coding::collect_ac_metadata_tokens_region;
 use super::encoder::{BuiltEntropyCode, VarDctEncoder};
 use super::frame::{DistanceParams, write_quant_scales, write_toc};
 use super::noise::{NoiseParams, write_noise_params};
@@ -198,7 +198,7 @@ fn tokenize_dc_group_lf_frame(
     ac_strategy: &AcStrategyMap,
     sharpness_map: Option<&[u8]>,
     ac_meta_ctx_map: &[u32],
-) -> (Vec<Token>, Vec<Token>) {
+) -> crate::error::Result<(Vec<Token>, Vec<Token>)> {
     let dc_gx = dc_group_idx % xsize_dc_groups;
     let dc_gy = dc_group_idx / xsize_dc_groups;
     let start_bx = dc_gx * DC_GROUP_DIM_IN_BLOCKS;
@@ -229,7 +229,7 @@ fn tokenize_dc_group_lf_frame(
         })
         .collect();
 
-    (dc_tokens, md_tokens)
+    Ok((dc_tokens, md_tokens))
 }
 
 /// Tokenize a single DC group (WP DC mode: both DC and AC metadata tokens).
@@ -247,7 +247,8 @@ fn tokenize_dc_group_wp(
     wp_dc_tree: &super::dc_tree_learn::DcTree,
     dc_ctx_remap: &[u32],
     ac_meta_ctx_map: &[u32],
-) -> (Vec<Token>, Vec<Token>) {
+    budget: Option<&alloc::sync::Arc<crate::budget::MemoryBudget>>,
+) -> crate::error::Result<(Vec<Token>, Vec<Token>)> {
     let dc_gx = dc_group_idx % xsize_dc_groups;
     let dc_gy = dc_group_idx / xsize_dc_groups;
     let start_bx = dc_gx * DC_GROUP_DIM_IN_BLOCKS;
@@ -257,8 +258,12 @@ fn tokenize_dc_group_wp(
     let region_xsize = end_bx - start_bx;
     let region_ysize = end_by - start_by;
 
-    // Collect DC tokens using Weighted Predictor + kWPFixedDC tree
-    let dc_tokens = collect_dc_tokens_wp(quant_dc, wp_dc_tree, start_bx, start_by, end_bx, end_by);
+    // Collect DC tokens using Weighted Predictor + kWPFixedDC tree.
+    // Route through the budget-aware variant so the region-driven token buffer
+    // honors the runtime fallible-alloc policy; byte-identical when infallible.
+    let dc_tokens = super::dc_coding::collect_dc_tokens_wp_with_budget(
+        quant_dc, wp_dc_tree, start_bx, start_by, end_bx, end_by, budget,
+    )?;
     let md_tokens = collect_ac_metadata_tokens_region(
         region_xsize,
         region_ysize,
@@ -287,7 +292,7 @@ fn tokenize_dc_group_wp(
         })
         .collect();
 
-    (dc_tokens, md_tokens)
+    Ok((dc_tokens, md_tokens))
 }
 
 /// Tokenize a single DC group (LearnTree DC mode: both DC and AC metadata tokens).
@@ -315,7 +320,8 @@ fn tokenize_dc_group_learned(
     learned_dc_tree: &super::dc_tree_learn::DcTree,
     dc_ctx_remap: &[u32],
     ac_meta_ctx_map: &[u32],
-) -> (Vec<Token>, Vec<Token>) {
+    budget: Option<&alloc::sync::Arc<crate::budget::MemoryBudget>>,
+) -> crate::error::Result<(Vec<Token>, Vec<Token>)> {
     let dc_gx = dc_group_idx % xsize_dc_groups;
     let dc_gy = dc_group_idx / xsize_dc_groups;
     let start_bx = dc_gx * DC_GROUP_DIM_IN_BLOCKS;
@@ -338,7 +344,8 @@ fn tokenize_dc_group_learned(
         start_by,
         end_bx,
         end_by,
-    );
+        budget,
+    )?;
     let md_tokens = collect_ac_metadata_tokens_region(
         region_xsize,
         region_ysize,
@@ -367,7 +374,7 @@ fn tokenize_dc_group_learned(
         })
         .collect();
 
-    (dc_tokens, md_tokens)
+    Ok((dc_tokens, md_tokens))
 }
 
 /// Tokenize a single AC group, returning per-pass token Vecs.
@@ -2441,6 +2448,7 @@ impl VarDctEncoder {
                 self.use_ans,
                 self.effort,
                 &mut writer,
+                self.budget.as_ref(),
             )?;
             writer.zero_pad_to_byte();
             Some(dc_quant)
@@ -2723,7 +2731,8 @@ impl VarDctEncoder {
                 0,
                 xsize_blocks,
                 ysize_blocks,
-            );
+                self.budget.as_ref(),
+            )?;
             for t in a_dc_tokens.iter_mut() {
                 t.set_context(a_dc_remap[t.context() as usize]);
             }
@@ -2925,8 +2934,13 @@ impl VarDctEncoder {
         type AcGroupTokens = (usize, Vec<Vec<Token>>);
         type DcGroupTokenResult = (Vec<Token>, Vec<Token>, Vec<AcGroupTokens>);
 
+        // Snapshot the budget as a `Copy` `Option<&Arc<…>>` so the parallel
+        // closure can thread it into the DC-token collectors without capturing
+        // `&self`. `parallel_map_result` short-circuits on the first
+        // allocation failure; the infallible path stays byte-identical.
+        let dc_budget = self.budget.as_ref();
         let dc_group_results: Vec<DcGroupTokenResult> =
-            crate::parallel::parallel_map(num_dc_groups, |dc_group_idx| {
+            crate::parallel::parallel_map_result(num_dc_groups, |dc_group_idx| {
                 let dc_gx = dc_group_idx % xsize_dc_groups;
                 let dc_gy = dc_group_idx / xsize_dc_groups;
 
@@ -2946,7 +2960,8 @@ impl VarDctEncoder {
                             learned_tree,
                             dc_ctx_remap,
                             &ac_meta_ctx_map,
-                        )
+                            dc_budget,
+                        )?
                     } else if let Some((wp_dc_tree, dc_ctx_remap)) = wp_dc_state.as_ref() {
                         tokenize_dc_group_wp(
                             dc_group_idx,
@@ -2961,7 +2976,8 @@ impl VarDctEncoder {
                             wp_dc_tree,
                             dc_ctx_remap,
                             &ac_meta_ctx_map,
-                        )
+                            dc_budget,
+                        )?
                     } else {
                         tokenize_dc_group_lf_frame(
                             dc_group_idx,
@@ -2973,7 +2989,7 @@ impl VarDctEncoder {
                             ac_strategy,
                             sharpness_map,
                             &ac_meta_ctx_map,
-                        )
+                        )?
                     };
 
                 // 2) AC-coefficient tokens for each contained AC group.
@@ -3015,8 +3031,8 @@ impl VarDctEncoder {
                     }
                 }
 
-                (dc_tokens, ac_meta_tokens, ac_group_tokens)
-            });
+                crate::error::Result::Ok((dc_tokens, ac_meta_tokens, ac_group_tokens))
+            })?;
 
         // ── Aggregate per-DC-group results into whole-image vectors ──
         //

--- a/jxl-encoder/src/vardct/dc_coding.rs
+++ b/jxl-encoder/src/vardct/dc_coding.rs
@@ -343,7 +343,12 @@ pub(crate) fn collect_dc_tokens_wp_with_budget(
         return Ok(Vec::new());
     }
 
-    let mut tokens = Vec::with_capacity(region_width * region_height * 3);
+    // Honor the budget's runtime fallible-alloc policy for this dimension-driven
+    // DC-token buffer (`Limits::fallible_alloc`); byte-identical when infallible.
+    let mut tokens = crate::budget::vec_with_capacity_fallible(
+        budget.is_some_and(|b| b.is_fallible()),
+        region_width * region_height * 3,
+    )?;
 
     // Encode in channel order: Y (1), X (0), B (2)
     // Each channel gets a FRESH WP state (matches libjxl per-channel processing)
@@ -449,6 +454,7 @@ pub(crate) fn collect_dc_tokens_wp_with_budget(
 /// `speed_tier >= kSquirrel` (cjxl effort 7); this is the per-channel,
 /// subsampling-aware analog we wire into the JPEG path.
 #[cfg(feature = "jpeg-reencoding")]
+#[allow(clippy::too_many_arguments)]
 pub fn collect_dc_tokens_wp_region_jpeg(
     quant_dc: &[Vec<Vec<i16>>; 3],
     wp_tree: &super::dc_tree_learn::DcTree,
@@ -457,16 +463,22 @@ pub fn collect_dc_tokens_wp_region_jpeg(
     end_bx: usize,
     end_by: usize,
     channel_shifts: &[(usize, usize); 3],
-) -> Vec<Token> {
+    budget: Option<&alloc::sync::Arc<crate::budget::MemoryBudget>>,
+) -> crate::error::Result<Vec<Token>> {
     use crate::modular::predictor::{Neighbors, WeightedPredictorState};
 
     let region_width = end_bx.saturating_sub(start_bx);
     let region_height = end_by.saturating_sub(start_by);
     if region_width == 0 || region_height == 0 {
-        return Vec::new();
+        return Ok(Vec::new());
     }
 
-    let mut tokens = Vec::with_capacity(region_width * region_height * 3);
+    // Honor the budget's runtime fallible-alloc policy for this dimension-driven
+    // DC-token buffer (`Limits::fallible_alloc`); byte-identical when infallible.
+    let mut tokens = crate::budget::vec_with_capacity_fallible(
+        budget.is_some_and(|b| b.is_fallible()),
+        region_width * region_height * 3,
+    )?;
 
     // Channel order Y(1), X(0), B(2) — matches collect_dc_tokens_region and
     // collect_dc_tokens_wp.
@@ -551,7 +563,7 @@ pub fn collect_dc_tokens_wp_region_jpeg(
         }
     }
 
-    tokens
+    Ok(tokens)
 }
 
 /// Collect DC tokens for a specific region (gradient predictor path).
@@ -570,15 +582,21 @@ pub fn collect_dc_tokens_region(
     end_bx: usize,
     end_by: usize,
     channel_shifts: &[(usize, usize); 3],
-) -> Vec<Token> {
+    budget: Option<&alloc::sync::Arc<crate::budget::MemoryBudget>>,
+) -> crate::error::Result<Vec<Token>> {
     let region_width = end_bx - start_bx;
     let region_height = end_by - start_by;
 
     if region_width == 0 || region_height == 0 {
-        return Vec::new();
+        return Ok(Vec::new());
     }
 
-    let mut tokens = Vec::with_capacity(region_width * region_height * 3);
+    // Honor the budget's runtime fallible-alloc policy for this dimension-driven
+    // DC-token buffer (`Limits::fallible_alloc`); byte-identical when infallible.
+    let mut tokens = crate::budget::vec_with_capacity_fallible(
+        budget.is_some_and(|b| b.is_fallible()),
+        region_width * region_height * 3,
+    )?;
 
     for &c in &[1, 0, 2] {
         let (hs, vs) = channel_shifts[c];
@@ -618,7 +636,7 @@ pub fn collect_dc_tokens_region(
         }
     }
 
-    tokens
+    Ok(tokens)
 }
 
 /// Collect DC tokens for a region using the JPEG-transcode context-tree's
@@ -641,15 +659,21 @@ pub fn collect_dc_tokens_region_jpeg_transcode(
     end_bx: usize,
     end_by: usize,
     channel_shifts: &[(usize, usize); 3],
-) -> Vec<Token> {
+    budget: Option<&alloc::sync::Arc<crate::budget::MemoryBudget>>,
+) -> crate::error::Result<Vec<Token>> {
     let region_width = end_bx - start_bx;
     let region_height = end_by - start_by;
 
     if region_width == 0 || region_height == 0 {
-        return Vec::new();
+        return Ok(Vec::new());
     }
 
-    let mut tokens = Vec::with_capacity(region_width * region_height * 3);
+    // Honor the budget's runtime fallible-alloc policy for this dimension-driven
+    // DC-token buffer (`Limits::fallible_alloc`); byte-identical when infallible.
+    let mut tokens = crate::budget::vec_with_capacity_fallible(
+        budget.is_some_and(|b| b.is_fallible()),
+        region_width * region_height * 3,
+    )?;
 
     for &c in &[1, 0, 2] {
         let (hs, vs) = channel_shifts[c];
@@ -693,7 +717,7 @@ pub fn collect_dc_tokens_region_jpeg_transcode(
         }
     }
 
-    tokens
+    Ok(tokens)
 }
 
 /// Collect AC metadata tokens for a specific region (without writing).

--- a/jxl-encoder/src/vardct/dc_tree_learn.rs
+++ b/jxl-encoder/src/vardct/dc_tree_learn.rs
@@ -2476,7 +2476,8 @@ pub fn collect_dc_tokens_with_tree_variable(
     start_by: usize,
     end_bx: usize,
     end_by: usize,
-) -> Vec<crate::entropy_coding::token::Token> {
+    budget: Option<&alloc::sync::Arc<crate::budget::MemoryBudget>>,
+) -> crate::error::Result<Vec<crate::entropy_coding::token::Token>> {
     use crate::entropy_coding::token::Token;
     use crate::modular::predictor::{Neighbors, Predictor, WeightedPredictorState};
 
@@ -2484,10 +2485,15 @@ pub fn collect_dc_tokens_with_tree_variable(
     let region_height = end_by - start_by;
 
     if region_width == 0 || region_height == 0 {
-        return Vec::new();
+        return Ok(Vec::new());
     }
 
-    let mut tokens = Vec::with_capacity(region_width * region_height * 3);
+    // Honor the budget's runtime fallible-alloc policy for this dimension-driven
+    // DC-token buffer (`Limits::fallible_alloc`); byte-identical when infallible.
+    let mut tokens = crate::budget::vec_with_capacity_fallible(
+        budget.is_some_and(|b| b.is_fallible()),
+        region_width * region_height * 3,
+    )?;
 
     // Encode in channel order: Y (1), X (0), B (2). Fresh WP state per channel.
     for (enc_idx, &c) in [1usize, 0, 2].iter().enumerate() {
@@ -2596,7 +2602,7 @@ pub fn collect_dc_tokens_with_tree_variable(
         }
     }
 
-    tokens
+    Ok(tokens)
 }
 
 /// Traverse the learned tree to get (context_id, predictor) for a DC value.
@@ -2630,17 +2636,23 @@ pub fn collect_dc_tokens_with_tree(
     start_by: usize,
     end_bx: usize,
     end_by: usize,
-) -> Vec<crate::entropy_coding::token::Token> {
+    budget: Option<&alloc::sync::Arc<crate::budget::MemoryBudget>>,
+) -> crate::error::Result<Vec<crate::entropy_coding::token::Token>> {
     use crate::entropy_coding::token::Token;
 
     let region_width = end_bx - start_bx;
     let region_height = end_by - start_by;
 
     if region_width == 0 || region_height == 0 {
-        return Vec::new();
+        return Ok(Vec::new());
     }
 
-    let mut tokens = Vec::with_capacity(region_width * region_height * 3);
+    // Honor the budget's runtime fallible-alloc policy for this dimension-driven
+    // DC-token buffer (`Limits::fallible_alloc`); byte-identical when infallible.
+    let mut tokens = crate::budget::vec_with_capacity_fallible(
+        budget.is_some_and(|b| b.is_fallible()),
+        region_width * region_height * 3,
+    )?;
 
     // Encode in channel order: Y (1), X (0), B (2)
     for (enc_idx, &c) in [1usize, 0, 2].iter().enumerate() {
@@ -2720,7 +2732,7 @@ pub fn collect_dc_tokens_with_tree(
         }
     }
 
-    tokens
+    Ok(tokens)
 }
 
 // ──────────────────────────────────────────────────────────────────
@@ -2871,11 +2883,12 @@ pub fn learn_and_collect_dc_tokens(
     start_by: usize,
     end_bx: usize,
     end_by: usize,
-) -> (
+    budget: Option<&alloc::sync::Arc<crate::budget::MemoryBudget>>,
+) -> crate::error::Result<(
     DcTree,
     Vec<crate::entropy_coding::token::Token>,
     DcTreeStats,
-) {
+)> {
     // First pass: gather samples
     let mut samples = DcTreeSamples::new();
 
@@ -2890,7 +2903,8 @@ pub fn learn_and_collect_dc_tokens(
     let (tree, num_contexts) = learn_dc_tree(&samples, max_token);
 
     // Collect tokens using learned tree
-    let tokens = collect_dc_tokens_with_tree(quant_dc, &tree, start_bx, start_by, end_bx, end_by);
+    let tokens =
+        collect_dc_tokens_with_tree(quant_dc, &tree, start_bx, start_by, end_bx, end_by, budget)?;
 
     let stats = DcTreeStats {
         num_contexts,
@@ -2898,7 +2912,7 @@ pub fn learn_and_collect_dc_tokens(
         bits_saved: 0.0, // TODO: estimate actual savings
     };
 
-    (tree, tokens, stats)
+    Ok((tree, tokens, stats))
 }
 
 /// Extract a region of DC values for sample gathering.

--- a/jxl-encoder/src/vardct/encoder.rs
+++ b/jxl-encoder/src/vardct/encoder.rs
@@ -1450,19 +1450,24 @@ fn patches_dispatch_block_mask_median(
     width: usize,
     height: usize,
     stride: usize,
-) -> Option<f32> {
+    budget: Option<&alloc::sync::Arc<crate::budget::MemoryBudget>>,
+) -> crate::error::Result<Option<f32>> {
     if width < 8 || height < 8 {
-        return None;
+        return Ok(None);
     }
     // Re-pack the (possibly strided) Y plane into a contiguous buffer
     // because `compute_mask1x1` assumes `stride == width` (callers in
     // `encode_inner` already pass `padded_width` directly as both
     // width AND stride, so the contiguous fast-path almost always
-    // wins).
+    // wins). The strided repack is dimension-driven, so route it through
+    // the runtime fallible-alloc policy; byte-identical when infallible.
     let y_contig: Vec<f32> = if stride == width {
         xyb_y[..width * height].to_vec()
     } else {
-        let mut buf = Vec::with_capacity(width * height);
+        let mut buf = crate::budget::vec_with_capacity_fallible(
+            budget.is_some_and(|b| b.is_fallible()),
+            width * height,
+        )?;
         for y in 0..height {
             let row_start = y * stride;
             buf.extend_from_slice(&xyb_y[row_start..row_start + width]);
@@ -1473,7 +1478,7 @@ fn patches_dispatch_block_mask_median(
     let blocks_per_row = width / 8;
     let blocks_per_col = height / 8;
     if blocks_per_row == 0 || blocks_per_col == 0 {
-        return None;
+        return Ok(None);
     }
     let n_blocks = blocks_per_row * blocks_per_col;
     let mut block_means: Vec<f32> = Vec::with_capacity(n_blocks);
@@ -1507,7 +1512,7 @@ fn patches_dispatch_block_mask_median(
     block_means.select_nth_unstable_by(mid, |a, b| {
         a.partial_cmp(b).unwrap_or(core::cmp::Ordering::Equal)
     });
-    Some(block_means[mid])
+    Ok(Some(block_means[mid]))
 }
 
 /// Return the median value of the unpadded region `[0, width) × [0, height)`
@@ -3548,8 +3553,14 @@ impl VarDctEncoder {
         let shifted_q = |shift: u32| -> u32 {
             self.compute_extra_pixel_quantizer_shifted(bits, alpha.info.ec_type, shift)
         };
-        let pipeline =
-            super::extras::build_alpha_squeeze_pipeline(alpha, width, height, shift0_q, shifted_q)?;
+        let pipeline = super::extras::build_alpha_squeeze_pipeline(
+            alpha,
+            width,
+            height,
+            shift0_q,
+            shifted_q,
+            self.budget.as_ref(),
+        )?;
         Ok(Some(pipeline))
     }
 
@@ -3829,9 +3840,15 @@ impl VarDctEncoder {
                     // than 8×8 in either dim) falls back to "run scan"
                     // because that's the safe / byte-identical
                     // direction.
-                    patches_dispatch_block_mask_median(&xyb_y, width, height, padded_width)
-                        .map(|m| m > PATCHES_DISPATCH_BLOCK_MASK_THRESHOLD)
-                        .unwrap_or(true)
+                    patches_dispatch_block_mask_median(
+                        &xyb_y,
+                        width,
+                        height,
+                        padded_width,
+                        self.budget.as_ref(),
+                    )?
+                    .map(|m| m > PATCHES_DISPATCH_BLOCK_MASK_THRESHOLD)
+                    .unwrap_or(true)
                 }
             };
         let mut patches_data = if should_scan_patches {
@@ -3958,7 +3975,13 @@ impl VarDctEncoder {
             // synthetic as screenshot-class, while admitting all 5
             // CLIC2025-1024 photos (photo median ~56 vs screenshot/synth
             // median 100).
-            if super::splines::looks_like_screenshot(&xyb_y, width, height, padded_width) {
+            if super::splines::looks_like_screenshot(
+                &xyb_y,
+                width,
+                height,
+                padded_width,
+                self.budget.as_ref(),
+            )? {
                 None
             } else {
                 // Pass distance through so the per-spline cost-benefit gate

--- a/jxl-encoder/src/vardct/extras.rs
+++ b/jxl-encoder/src/vardct/extras.rs
@@ -284,6 +284,7 @@ pub(crate) fn build_alpha_squeeze_pipeline(
     image_height: usize,
     shift0_quantizer: u32,
     shifted_quantizer: impl Fn(u32) -> u32,
+    budget: Option<&alloc::sync::Arc<crate::budget::MemoryBudget>>,
 ) -> Result<AlphaSqueezePipeline> {
     use crate::modular::channel::ModularImage;
     use crate::modular::squeeze::{apply_squeeze, default_squeeze_params};
@@ -294,7 +295,12 @@ pub(crate) fn build_alpha_squeeze_pipeline(
     let ch_h = image_height >> alpha.info.dim_shift;
     debug_assert!(ch_w > 0 && ch_h > 0, "alpha squeeze: empty channel");
 
-    let mut data: alloc::vec::Vec<i32> = alloc::vec::Vec::with_capacity(ch_w * ch_h);
+    // Dimension-driven alpha plane — honor the runtime fallible-alloc policy;
+    // byte-identical when infallible.
+    let mut data: alloc::vec::Vec<i32> = crate::budget::vec_with_capacity_fallible(
+        budget.is_some_and(|b| b.is_fallible()),
+        ch_w * ch_h,
+    )?;
     for y in 0..ch_h {
         for x in 0..ch_w {
             data.push(alpha.data.sample(y * ch_w + x));
@@ -418,6 +424,7 @@ mod squeeze_pipeline_tests {
             // (halves per shift) without pulling in the real
             // constants.
             |shift| (100u32 >> shift).max(1),
+            None,
         )
         .expect("squeeze pipeline build");
         assert!(
@@ -465,7 +472,7 @@ mod squeeze_pipeline_tests {
             data: VardctExtraBuf::U8(&pixels),
         };
         let pipe =
-            build_alpha_squeeze_pipeline(&extra, 400, 267, 7, |shift| (7u32 >> shift).max(1))
+            build_alpha_squeeze_pipeline(&extra, 400, 267, 7, |shift| (7u32 >> shift).max(1), None)
                 .expect("build");
         let part = pipe.partition(super::super::common::GROUP_DIM);
         assert!(
@@ -509,9 +516,15 @@ mod squeeze_pipeline_tests {
             info: &info,
             data: VardctExtraBuf::U8(&pixels),
         };
-        let pipe =
-            build_alpha_squeeze_pipeline(&extra, 1024, 1024, 7, |shift| (7u32 >> shift).max(1))
-                .expect("build");
+        let pipe = build_alpha_squeeze_pipeline(
+            &extra,
+            1024,
+            1024,
+            7,
+            |shift| (7u32 >> shift).max(1),
+            None,
+        )
+        .expect("build");
         let part = pipe.partition(super::super::common::GROUP_DIM);
         assert!(
             !part.hf_group_indices.is_empty(),
@@ -556,7 +569,7 @@ mod squeeze_pipeline_tests {
             info: &info,
             data: VardctExtraBuf::U8(&pixels),
         };
-        let pipe = build_alpha_squeeze_pipeline(&extra, 8, 8, 7, |_| 1).expect("build");
+        let pipe = build_alpha_squeeze_pipeline(&extra, 8, 8, 7, |_| 1, None).expect("build");
         assert!(
             pipe.squeeze_params.is_empty(),
             "≤8×8 input must skip squeeze"

--- a/jxl-encoder/src/vardct/lf_frame.rs
+++ b/jxl-encoder/src/vardct/lf_frame.rs
@@ -131,6 +131,9 @@ fn round_hafz(val: f32) -> i32 {
 /// * `ysize_blocks` - Number of 8x8 blocks vertically
 /// * `use_ans` - Whether to use ANS entropy coding
 /// * `effort` - Effort level (1-12; e10/e11/e12 extends libjxl kTortoise=9)
+/// * `budget` - Optional allocation budget; threads the runtime fallible-alloc
+///   policy through the dimension-driven DC plane buffers
+#[allow(clippy::too_many_arguments)]
 pub(crate) fn encode_lf_frame(
     float_dc: &[Vec<f32>; 3],
     main_distance: f32,
@@ -139,6 +142,7 @@ pub(crate) fn encode_lf_frame(
     use_ans: bool,
     effort: u8,
     writer: &mut BitWriter,
+    budget: Option<&alloc::sync::Arc<crate::budget::MemoryBudget>>,
 ) -> Result<([Vec<f32>; 3], [f32; 3])> {
     // Full-precision enc_factors: lossy compression happens via Squeeze + modular
     // quantization (tree leaf multipliers), not via coarser enc_factors. This
@@ -153,6 +157,9 @@ pub(crate) fn encode_lf_frame(
     }
 
     let n = xsize_blocks * ysize_blocks;
+    // Honor the budget's runtime fallible-alloc policy for these dimension-driven
+    // DC plane buffers (`Limits::fallible_alloc`); byte-identical when infallible.
+    let fallible = budget.is_some_and(|b| b.is_fallible());
 
     // Convert float DC to [Y, X, B-Y] integers.
     //
@@ -166,9 +173,9 @@ pub(crate) fn encode_lf_frame(
     // The decoder's ConvertModularXYBToF32Stage does:
     //   output_b = (ch2 + ch0) * scale_b = (B_quant - Y_quant + Y_quant) * scale_b = B_quant * scale_b
     // So the Y terms cancel and B is recovered correctly.
-    let mut ch_y_data = Vec::with_capacity(n);
-    let mut ch_x_data = Vec::with_capacity(n);
-    let mut ch_by_data = Vec::with_capacity(n);
+    let mut ch_y_data = crate::budget::vec_with_capacity_fallible(fallible, n)?;
+    let mut ch_x_data = crate::budget::vec_with_capacity_fallible(fallible, n)?;
+    let mut ch_by_data = crate::budget::vec_with_capacity_fallible(fallible, n)?;
 
     for ((&dc_x, &dc_y), &dc_b) in float_dc[0]
         .iter()
@@ -196,9 +203,9 @@ pub(crate) fn encode_lf_frame(
     //   decoded_X = x_int * dc_quant[0]
     //   decoded_B = (by_int + y_int) * dc_quant[2]
     let decoded_dc = {
-        let mut dc_x = Vec::with_capacity(n);
-        let mut dc_y = Vec::with_capacity(n);
-        let mut dc_b = Vec::with_capacity(n);
+        let mut dc_x = crate::budget::vec_with_capacity_fallible(fallible, n)?;
+        let mut dc_y = crate::budget::vec_with_capacity_fallible(fallible, n)?;
+        let mut dc_b = crate::budget::vec_with_capacity_fallible(fallible, n)?;
         for i in 0..n {
             dc_y.push(ch_y_data[i] as f32 * factors.dc_quant[1]);
             dc_x.push(ch_x_data[i] as f32 * factors.dc_quant[0]);

--- a/jxl-encoder/src/vardct/patches.rs
+++ b/jxl-encoder/src/vardct/patches.rs
@@ -2705,8 +2705,11 @@ pub(crate) fn encode_reference_frame_rgb(
     use crate::modular::channel::{Channel, ModularImage};
 
     let mut channels = Vec::with_capacity(3);
+    let fallible = budget.is_some_and(|b| b.is_fallible());
     for c in 0..3 {
-        let mut data = Vec::with_capacity(n);
+        // Dimension-driven reference-frame channel — honor the runtime
+        // fallible-alloc policy; byte-identical when infallible.
+        let mut data = crate::budget::vec_with_capacity_fallible(fallible, n)?;
         for i in 0..n {
             data.push(safe_round_to_i32(patches.ref_image[c][i] * max_val));
         }
@@ -2900,20 +2903,24 @@ pub(crate) fn encode_reference_frame(
     // Build modular channels in decoder order: [Y, X, B-Y]
     use crate::modular::channel::{Channel, ModularImage};
 
+    // Dimension-driven reference-frame channels — honor the runtime
+    // fallible-alloc policy; byte-identical when infallible.
+    let fallible = budget.is_some_and(|b| b.is_fallible());
+
     // Channel 0: Y (from ref_image[1], which is the Y plane in XYB)
-    let mut ch_y = Vec::with_capacity(n);
+    let mut ch_y = crate::budget::vec_with_capacity_fallible(fallible, n)?;
     for i in 0..n {
         ch_y.push(safe_round_to_i32(patches.ref_image[1][i] * inv_dc_quant_y));
     }
 
     // Channel 1: X (from ref_image[0], which is the X plane in XYB)
-    let mut ch_x = Vec::with_capacity(n);
+    let mut ch_x = crate::budget::vec_with_capacity_fallible(fallible, n)?;
     for i in 0..n {
         ch_x.push(safe_round_to_i32(patches.ref_image[0][i] * inv_dc_quant_x));
     }
 
     // Channel 2: B-Y (B scaled by INV_DC_QUANT_B, minus Y_int from channel 0)
-    let mut ch_by = Vec::with_capacity(n);
+    let mut ch_by = crate::budget::vec_with_capacity_fallible(fallible, n)?;
     for i in 0..n {
         let b_int = safe_round_to_i32(patches.ref_image[2][i] * inv_dc_quant_b);
         ch_by.push(b_int - ch_y[i]);

--- a/jxl-encoder/src/vardct/resampling.rs
+++ b/jxl-encoder/src/vardct/resampling.rs
@@ -41,16 +41,22 @@ pub fn box_downsample_rgb(
     width: usize,
     height: usize,
     factor: u32,
-) -> (Vec<f32>, u32, u32) {
+    budget: Option<&alloc::sync::Arc<crate::budget::MemoryBudget>>,
+) -> crate::error::Result<(Vec<f32>, u32, u32)> {
     debug_assert!(matches!(factor, 1 | 2 | 4 | 8), "factor must be 1/2/4/8");
     debug_assert_eq!(rgb_interleaved.len(), width * height * 3);
     if factor == 1 {
-        return (rgb_interleaved.to_vec(), width as u32, height as u32);
+        return Ok((rgb_interleaved.to_vec(), width as u32, height as u32));
     }
     let f = factor as usize;
     let out_w = width.div_ceil(f);
     let out_h = height.div_ceil(f);
-    let mut out = Vec::with_capacity(out_w * out_h * 3);
+    // Dimension-driven output buffer — honor the runtime fallible-alloc policy;
+    // byte-identical when infallible.
+    let mut out = crate::budget::vec_with_capacity_fallible(
+        budget.is_some_and(|b| b.is_fallible()),
+        out_w * out_h * 3,
+    )?;
     for oy in 0..out_h {
         let y0 = oy * f;
         let y1 = (y0 + f).min(height);
@@ -74,7 +80,7 @@ pub fn box_downsample_rgb(
             out.push(sum[2] * inv);
         }
     }
-    (out, out_w as u32, out_h as u32)
+    Ok((out, out_w as u32, out_h as u32))
 }
 
 /// 12×12 weighted kernel used by [`sharper_downsample_2x_rgb`]. Ported
@@ -406,7 +412,8 @@ pub fn sharper_downsample_2x_rgb(
     rgb_interleaved: &[f32],
     width: usize,
     height: usize,
-) -> (Vec<f32>, u32, u32) {
+    budget: Option<&alloc::sync::Arc<crate::budget::MemoryBudget>>,
+) -> crate::error::Result<(Vec<f32>, u32, u32)> {
     debug_assert_eq!(rgb_interleaved.len(), width * height * 3);
     let out_w = width.div_ceil(2);
     let out_h = height.div_ceil(2);
@@ -428,14 +435,18 @@ pub fn sharper_downsample_2x_rgb(
     sharper_downsample_2x_plane(&plane_g, width, height, &mut out_g, out_w, out_h);
     sharper_downsample_2x_plane(&plane_b, width, height, &mut out_b, out_w, out_h);
 
-    // Re-interleave.
-    let mut out = Vec::with_capacity(out_w * out_h * 3);
+    // Re-interleave. Dimension-driven output buffer — honor the runtime
+    // fallible-alloc policy; byte-identical when infallible.
+    let mut out = crate::budget::vec_with_capacity_fallible(
+        budget.is_some_and(|b| b.is_fallible()),
+        out_w * out_h * 3,
+    )?;
     for i in 0..(out_w * out_h) {
         out.push(out_r[i]);
         out.push(out_g[i]);
         out.push(out_b[i]);
     }
-    (out, out_w as u32, out_h as u32)
+    Ok((out, out_w as u32, out_h as u32))
 }
 
 /// Box-filter downsample a single-channel u8 buffer (alpha) by an
@@ -446,16 +457,22 @@ pub fn box_downsample_alpha_u8(
     width: usize,
     height: usize,
     factor: u32,
-) -> (Vec<u8>, u32, u32) {
+    budget: Option<&alloc::sync::Arc<crate::budget::MemoryBudget>>,
+) -> crate::error::Result<(Vec<u8>, u32, u32)> {
     debug_assert!(matches!(factor, 1 | 2 | 4 | 8), "factor must be 1/2/4/8");
     debug_assert_eq!(alpha.len(), width * height);
     if factor == 1 {
-        return (alpha.to_vec(), width as u32, height as u32);
+        return Ok((alpha.to_vec(), width as u32, height as u32));
     }
     let f = factor as usize;
     let out_w = width.div_ceil(f);
     let out_h = height.div_ceil(f);
-    let mut out = Vec::with_capacity(out_w * out_h);
+    // Dimension-driven output buffer — honor the runtime fallible-alloc policy;
+    // byte-identical when infallible.
+    let mut out = crate::budget::vec_with_capacity_fallible(
+        budget.is_some_and(|b| b.is_fallible()),
+        out_w * out_h,
+    )?;
     for oy in 0..out_h {
         let y0 = oy * f;
         let y1 = (y0 + f).min(height);
@@ -475,7 +492,7 @@ pub fn box_downsample_alpha_u8(
             out.push(((sum + count / 2) / count) as u8);
         }
     }
-    (out, out_w as u32, out_h as u32)
+    Ok((out, out_w as u32, out_h as u32))
 }
 
 #[cfg(test)]
@@ -485,7 +502,7 @@ mod tests {
     #[test]
     fn test_factor_1_is_clone() {
         let rgb = vec![0.5_f32, 0.25, 0.75, 0.1, 0.2, 0.3]; // 2 px
-        let (out, w, h) = box_downsample_rgb(&rgb, 2, 1, 1);
+        let (out, w, h) = box_downsample_rgb(&rgb, 2, 1, 1, None).unwrap();
         assert_eq!(out, rgb);
         assert_eq!(w, 2);
         assert_eq!(h, 1);
@@ -500,7 +517,7 @@ mod tests {
             .cycle()
             .take(4 * 4 * 3)
             .collect::<Vec<_>>();
-        let (out, w, h) = box_downsample_rgb(&rgb, 4, 4, 2);
+        let (out, w, h) = box_downsample_rgb(&rgb, 4, 4, 2, None).unwrap();
         assert_eq!(w, 2);
         assert_eq!(h, 2);
         assert_eq!(out.len(), 2 * 2 * 3);
@@ -518,7 +535,7 @@ mod tests {
         //  3, 0, 0,  4, 0, 0]
         // 2× downsample → 1×1 with R = (1+2+3+4)/4 = 2.5.
         let rgb = vec![1.0, 0.0, 0.0, 2.0, 0.0, 0.0, 3.0, 0.0, 0.0, 4.0, 0.0, 0.0];
-        let (out, w, h) = box_downsample_rgb(&rgb, 2, 2, 2);
+        let (out, w, h) = box_downsample_rgb(&rgb, 2, 2, 2, None).unwrap();
         assert_eq!(w, 1);
         assert_eq!(h, 1);
         assert!((out[0] - 2.5).abs() < 1e-6);
@@ -537,7 +554,7 @@ mod tests {
                 rgb.push(v);
             }
         }
-        let (out, w, h) = box_downsample_rgb(&rgb, 5, 3, 4);
+        let (out, w, h) = box_downsample_rgb(&rgb, 5, 3, 4, None).unwrap();
         assert_eq!(w, 2);
         assert_eq!(h, 1);
         // Cell 0: averages cols 0..4, rows 0..3 → 12 cells with values
@@ -552,7 +569,7 @@ mod tests {
     fn test_factor_8() {
         // 8×8 uniform RGB image, factor 8 → 1×1 output equal to input value.
         let rgb = vec![0.42_f32; 8 * 8 * 3];
-        let (out, w, h) = box_downsample_rgb(&rgb, 8, 8, 8);
+        let (out, w, h) = box_downsample_rgb(&rgb, 8, 8, 8, None).unwrap();
         assert_eq!(w, 1);
         assert_eq!(h, 1);
         assert!((out[0] - 0.42).abs() < 1e-6);
@@ -562,7 +579,7 @@ mod tests {
     fn test_alpha_factor_2_averages() {
         // 2×2 alpha: [255, 0, 0, 255]. Factor 2 → 1×1 with mean ≈ 128.
         let alpha = vec![255u8, 0, 0, 255];
-        let (out, w, h) = box_downsample_alpha_u8(&alpha, 2, 2, 2);
+        let (out, w, h) = box_downsample_alpha_u8(&alpha, 2, 2, 2, None).unwrap();
         assert_eq!(w, 1);
         assert_eq!(h, 1);
         // (255 + 0 + 0 + 255 + 2) / 4 = 512 / 4 = 128.
@@ -572,7 +589,7 @@ mod tests {
     #[test]
     fn test_alpha_factor_1_is_clone() {
         let alpha = vec![1u8, 2, 3, 4, 5];
-        let (out, w, h) = box_downsample_alpha_u8(&alpha, 5, 1, 1);
+        let (out, w, h) = box_downsample_alpha_u8(&alpha, 5, 1, 1, None).unwrap();
         assert_eq!(out, alpha);
         assert_eq!(w, 5);
         assert_eq!(h, 1);
@@ -582,12 +599,12 @@ mod tests {
     fn test_sharper_2x_dimensions() {
         // 64×64 → 32×32; 65×64 → 33×32 (div_ceil).
         let rgb = vec![0.5_f32; 64 * 64 * 3];
-        let (out, w, h) = sharper_downsample_2x_rgb(&rgb, 64, 64);
+        let (out, w, h) = sharper_downsample_2x_rgb(&rgb, 64, 64, None).unwrap();
         assert_eq!(w, 32);
         assert_eq!(h, 32);
         assert_eq!(out.len(), 32 * 32 * 3);
         let rgb = vec![0.5_f32; 65 * 64 * 3];
-        let (_, w, h) = sharper_downsample_2x_rgb(&rgb, 65, 64);
+        let (_, w, h) = sharper_downsample_2x_rgb(&rgb, 65, 64, None).unwrap();
         assert_eq!(w, 33);
         assert_eq!(h, 32);
     }
@@ -597,7 +614,7 @@ mod tests {
         // Uniform input → kernel sum × value. The kernel sums to ~1.0
         // by construction; confirm output is approximately the input.
         let rgb = vec![0.5_f32; 32 * 32 * 3];
-        let (out, w, h) = sharper_downsample_2x_rgb(&rgb, 32, 32);
+        let (out, w, h) = sharper_downsample_2x_rgb(&rgb, 32, 32, None).unwrap();
         assert_eq!(w, 16);
         assert_eq!(h, 16);
         for &v in &out {
@@ -614,7 +631,7 @@ mod tests {
         // background away from the spike, output stays in the dark range.
         let mut rgb = vec![0.0_f32; 16 * 16 * 3];
         rgb[((8 * 16) + 8) * 3] = 1.0; // R-channel spike at (8,8)
-        let (out, _, _) = sharper_downsample_2x_rgb(&rgb, 16, 16);
+        let (out, _, _) = sharper_downsample_2x_rgb(&rgb, 16, 16, None).unwrap();
         // Far-corner output (0,0) sees no spike in its 2×2 input window
         // (covers input (0..2, 0..2)) — must be clamped to ~0.
         assert!(

--- a/jxl-encoder/src/vardct/splines.rs
+++ b/jxl-encoder/src/vardct/splines.rs
@@ -874,25 +874,31 @@ pub(crate) fn looks_like_screenshot(
     width: usize,
     height: usize,
     stride: usize,
-) -> bool {
+    budget: Option<&alloc::sync::Arc<crate::budget::MemoryBudget>>,
+) -> crate::error::Result<bool> {
     if width < 8 || height < 8 {
         // Below one full 8x8 block — there's no meaningful median to take,
         // and `find_splines_at_distance` already short-circuits at
         // `width < 16 || height < 16` anyway. Treat as "not screenshot".
-        return false;
+        return Ok(false);
     }
 
     // Re-pack the (possibly strided) Y plane into a contiguous buffer
     // because `compute_mask1x1` assumes `stride == width`. The mask1x1
     // computation expects row-major contiguous input — see callers in
     // `vardct/encoder.rs:1218` which pass `padded_width` directly as
-    // both width AND stride.
+    // both width AND stride. The strided repack is dimension-driven, so
+    // route it through the runtime fallible-alloc policy; byte-identical
+    // when infallible.
     let y_contig: alloc::vec::Vec<f32> = if stride == width {
         // SAFETY: stride == width means buffer is already contiguous.
         // Slice up to width*height to drop any trailing slop.
         xyb_y[..width * height].to_vec()
     } else {
-        let mut buf = alloc::vec::Vec::with_capacity(width * height);
+        let mut buf = crate::budget::vec_with_capacity_fallible(
+            budget.is_some_and(|b| b.is_fallible()),
+            width * height,
+        )?;
         for y in 0..height {
             let row_start = y * stride;
             buf.extend_from_slice(&xyb_y[row_start..row_start + width]);
@@ -907,7 +913,7 @@ pub(crate) fn looks_like_screenshot(
     let blocks_per_row = width / 8;
     let blocks_per_col = height / 8;
     if blocks_per_row == 0 || blocks_per_col == 0 {
-        return false;
+        return Ok(false);
     }
     let n_blocks = blocks_per_row * blocks_per_col;
     let mut block_means: alloc::vec::Vec<f32> = alloc::vec::Vec::with_capacity(n_blocks);
@@ -950,7 +956,7 @@ pub(crate) fn looks_like_screenshot(
             "non-screenshot"
         }
     );
-    median > SCREENSHOT_MEDIAN_MASK_THRESHOLD
+    Ok(median > SCREENSHOT_MEDIAN_MASK_THRESHOLD)
 }
 
 /// Distance-aware variant of [`find_splines`]. Internal entry used by
@@ -2518,7 +2524,7 @@ mod tests {
         let (w, h) = (128usize, 128usize);
         let y_plane = alloc::vec![0.4f32; w * h];
         assert!(
-            looks_like_screenshot(&y_plane, w, h, w),
+            looks_like_screenshot(&y_plane, w, h, w, None).unwrap(),
             "constant-color image must be classified as screenshot-like"
         );
     }
@@ -2541,7 +2547,7 @@ mod tests {
             }
         }
         assert!(
-            !looks_like_screenshot(&y_plane, w, h, w),
+            !looks_like_screenshot(&y_plane, w, h, w, None).unwrap(),
             "photo-like gradient with spatial noise must NOT be classified as screenshot"
         );
     }
@@ -2566,7 +2572,7 @@ mod tests {
             }
         }
         assert!(
-            looks_like_screenshot(&y_plane, w, h, stride),
+            looks_like_screenshot(&y_plane, w, h, stride, None).unwrap(),
             "strided flat image must still be classified as screenshot"
         );
     }
@@ -2578,7 +2584,7 @@ mod tests {
     fn test_looks_like_screenshot_tiny_image() {
         let y_plane = alloc::vec![0.4f32; 4 * 4];
         assert!(
-            !looks_like_screenshot(&y_plane, 4, 4, 4),
+            !looks_like_screenshot(&y_plane, 4, 4, 4, None).unwrap(),
             "tiny image must safely return false"
         );
     }


### PR DESCRIPTION
Follow-up to #78. Extends the runtime fallible-alloc policy (`Limits::with_fallible_alloc`) + `MemoryBudget` from the dominant allocations (done in #78) to the remaining **>1 MB dimension-driven** heap buffers in the encoder.

**Byte-identical on the default (infallible) path** — `vec_with_capacity_fallible(false, n)` is literally `Vec::with_capacity(n)`. The toggle only changes the allocation *mechanism* (fast `vec!`/`calloc` vs graceful `try_reserve`) for untrusted-input callers.

### Wired
Routed through `crate::budget::vec_with_capacity_fallible`, budget threaded as `Option<&Arc<MemoryBudget>>` (or `self.budget` on `VarDctEncoder`/`FrameEncoder` methods):

- **dc_coding** — WP collector (already had budget) + the 3 region collectors (JPEG path; budget from `encode_jpeg_to_jxl_inner`); `Vec<Token>` → `Result<Vec<Token>>`.
- **dc_tree_learn** — `collect_dc_tokens_with_tree{,_variable}` + `learn_and_collect_dc_tokens`.
- **bitstream** — DC-group tokenizers; per-DC-group fan-out `parallel_map` → `parallel_map_result` (closures `Ok`-wrap, capture a `Copy` budget).
- **modular/frame** — both multi-group residual closures (`-> Result<Vec<u32>>`).
- **vardct/encoder** — `patches_dispatch_block_mask_median` mask repack.
- **vardct/splines** — `looks_like_screenshot` Y buffer (now `Result<bool>`).
- **vardct/lf_frame** — the 6 DC-plane buffers.
- **vardct/resampling** — box/sharper RGB downsamplers + alpha (callers in `api.rs`).
- **vardct/extras** — alpha-squeeze plane. **vardct/patches** — reference-frame channel buffers.

### Honest-stop (left infallible)
Deep multi-hop refactors with little marginal safety (these buffers fail after the already-covered dominant ones under OOM):
- `encoder` `median_mask1x1`/`percentile_mask1x1` — `bool`-predicate cascade through `pixel_loss_auto_should_skip`.
- `patches` BFS detection queue; `lz77` optimal-parse token buffer (no budget infrastructure).

### Verification
- **hash-locks 48/48** (byte-identical default path)
- **full 1986 lib+it tests pass**
- clippy `-D warnings` clean (default + `jpeg-reencoding` + `zensim-loop`), fmt clean
- No gate/constant/algorithm change → `docs/LIBJXL_DIVERGENCES.md` N/A