### PR TITLE
Wire the 3 deep >1 MB allocations (AQ mask, patches detection, lz77-optimal) to fallible policy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -132,13 +132,48 @@
   the JPEG-preprocessing `resampling` box/sharper downsamplers + alpha, the
   `extras` alpha-squeeze plane, and the `patches` reference-frame channel
   buffers. Budget is threaded as `Option<&Arc<MemoryBudget>>` (or `self.budget`
-  on `VarDctEncoder`/`FrameEncoder` methods). Three sites intentionally stay
-  infallible (honest-stop): `encoder` `median_mask1x1`/`percentile_mask1x1` (a
-  `bool`-predicate cascade through `pixel_loss_auto_should_skip`), the
-  `patches` BFS detection queue, and the `lz77` optimal-parse token buffer
-  (no budget infrastructure) — all reachable only via deep multi-hop refactors
-  with little marginal safety. Verified byte-identical (hash-locks 48/48; full
-  1986-test suite) and clippy `-D warnings` clean (default + jpeg + zensim).
+  on `VarDctEncoder`/`FrameEncoder` methods). Verified byte-identical
+  (hash-locks 48/48; full 1986-test suite) and clippy `-D warnings` clean
+  (default + jpeg + zensim).
+- **Two of the #88 honest-stopped >1 MB sites now wired through the
+  fallible-alloc policy (follow-up).** The AQ-mask statistics and the patches
+  BFS detection — both >1 MB at realistic sizes — now route through the budget
+  policy (byte-identical on the default infallible path):
+  - **AQ mask buffers** (`encoder` `median_mask1x1` / `percentile_mask1x1`, the
+    `width * height` `f32` copy allocated on every lossy encode, 4–50 MB at
+    ≥ 1 MP). Both helpers now take an `Option<&Arc<MemoryBudget>>` and return
+    `crate::error::Result<f32>`; the `bool`-predicate cascade through
+    `pixel_loss_auto_should_skip` (now `Result<bool>` + budget) propagates
+    through its three `encode_inner` / `encode_frame_to_writer` /
+    `compute_with_budget_and_buffering` callers (the `.map(..).transpose()?`
+    pattern at the `mask1x1_median` / `mask1x1_p25` sites; `?` at the inline
+    gate sites). Budget threaded from `self.budget` / the existing `budget`
+    param.
+  - **Patches detection** (`patches` `find_text_like_patches{,_with_min_peak}`
+    and `find_and_build_lossless`, the BFS `queue` + 3 `background` f32 planes +
+    `is_background` / `visited` bool planes + the lossless `planes` triple, all
+    `stride * height`, ~13 MB at 1 MP). The two detectors return
+    `crate::error::Result<Vec<PatchInfo>>` and `find_and_build_with_per_patch_gate`
+    / `find_and_build_lossless` return `crate::error::Result<Option<PatchesData>>`,
+    threaded `Option<&Arc<MemoryBudget>>` from the four VarDCT encode paths
+    (`encoder` `encode_inner` / `encode_from_precomputed_inner`, `bitstream`
+    `encode_frame_to_writer`, `precomputed` `compute_global_only`) and the two
+    lossless paths (`api` `encode_lossless` + the streaming `finish_inner`
+    closure). The public calibration wrappers (`find_and_build` /
+    `find_and_build_with_min_peak` / `find_and_build_patches_lossless`) keep
+    their `Option`-returning signatures (public API unchanged) and call the
+    inner with `None` budget on the infallible path.
+  Verified byte-identical (hash-locks 48/48; full 1986-test suite) and clippy
+  `-D warnings` clean (default + jpeg + zensim). The third #88 honest-stopped
+  site — the `lz77` optimal-parse buffers (`prefix_costs` / `sym_cost` / `out`,
+  multi-MB at lossless e9+) — **stays infallible (honest-stop continues)**:
+  wiring it requires threading a budget through `apply_lz77` and its 13+
+  callers across `icc.rs` / `modular/{encode,section,frame}.rs` /
+  `vardct/bitstream.rs` plus the public `pub(crate)` modular wrapper stack
+  (`write_modular_stream_with_tree*`, `write_global_modular_section_with_tree*`,
+  `write_group_modular_section_idx`) and three top-level `api.rs` encode
+  entries via the `write_icc` branch — well past the ~5-hop threshold, with the
+  lossless-e9 modular path (the size that matters) requiring the deepest leg.
 - **Checked SOF-derived overflow in the JPEG coefficient parser (#77 item 3).**
   `extract_coefficients_zenjpeg` computed `width_in_blocks * height_in_blocks`
   (and `* 64`) as unchecked `u32` / `usize` on attacker-controlled SOF dims —

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -135,10 +135,11 @@
   on `VarDctEncoder`/`FrameEncoder` methods). Verified byte-identical
   (hash-locks 48/48; full 1986-test suite) and clippy `-D warnings` clean
   (default + jpeg + zensim).
-- **Two of the #88 honest-stopped >1 MB sites now wired through the
-  fallible-alloc policy (follow-up).** The AQ-mask statistics and the patches
-  BFS detection — both >1 MB at realistic sizes — now route through the budget
-  policy (byte-identical on the default infallible path):
+- **All three #88 honest-stopped >1 MB sites now wired through the
+  fallible-alloc policy (follow-up).** The AQ-mask statistics, the patches
+  BFS detection, and the lz77 optimal-parse buffers — all >1 MB at realistic
+  sizes — now route through the budget policy (byte-identical on the default
+  infallible path):
   - **AQ mask buffers** (`encoder` `median_mask1x1` / `percentile_mask1x1`, the
     `width * height` `f32` copy allocated on every lossy encode, 4–50 MB at
     ≥ 1 MP). Both helpers now take an `Option<&Arc<MemoryBudget>>` and return
@@ -163,17 +164,16 @@
     `find_and_build_with_min_peak` / `find_and_build_patches_lossless`) keep
     their `Option`-returning signatures (public API unchanged) and call the
     inner with `None` budget on the infallible path.
+  - **lz77 optimal-parse buffers** (`apply_lz77_optimal`'s `prefix_costs` +
+    `out`, both `O(token_count)`, multi-MB to 10s of MB at lossless e9+). The
+    `budget` is threaded through `apply_lz77` and all its callers: the
+    `pub(crate)` modular wrapper stack (`write_modular_stream_with_tree*`,
+    `write_global_modular_section_with_tree*`, `write_group_modular_section_idx`)
+    takes the param and bottoms out at `FrameEncoder` (`self.budget`);
+    `vardct/bitstream`'s `encode_two_pass_to_writer` passes `self.budget`; the
+    small `icc.rs` profile-compression call passes `None` (not a >1 MB site).
   Verified byte-identical (hash-locks 48/48; full 1986-test suite) and clippy
-  `-D warnings` clean (default + jpeg + zensim). The third #88 honest-stopped
-  site — the `lz77` optimal-parse buffers (`prefix_costs` / `sym_cost` / `out`,
-  multi-MB at lossless e9+) — **stays infallible (honest-stop continues)**:
-  wiring it requires threading a budget through `apply_lz77` and its 13+
-  callers across `icc.rs` / `modular/{encode,section,frame}.rs` /
-  `vardct/bitstream.rs` plus the public `pub(crate)` modular wrapper stack
-  (`write_modular_stream_with_tree*`, `write_global_modular_section_with_tree*`,
-  `write_group_modular_section_idx`) and three top-level `api.rs` encode
-  entries via the `write_icc` branch — well past the ~5-hop threshold, with the
-  lossless-e9 modular path (the size that matters) requiring the deepest leg.
+  `-D warnings` clean (default + jpeg + zensim).
 - **Checked SOF-derived overflow in the JPEG coefficient parser (#77 item 3).**
   `extract_coefficients_zenjpeg` computed `width_in_blocks * height_in_blocks`
   (and `* 64`) as unchecked `u32` / `usize` on attacker-controlled SOF dims —

--- a/jxl-encoder/src/api.rs
+++ b/jxl-encoder/src/api.rs
@@ -9150,7 +9150,9 @@ impl<'a> EncodeRequest<'a> {
                     h,
                     num_channels,
                     image.bit_depth,
-                );
+                    Some(budget),
+                )
+                .map_err(EncodeError::from)?;
                 // RFC#45 chunks 4-7 lossless backport (chunk 5 lossless
                 // trial encoder): per-image cost gate. Trial-encodes
                 // lossless-shape ref-frame + dictionary overhead,
@@ -12337,7 +12339,9 @@ impl LosslessEncoder {
                     h,
                     num_channels,
                     image.bit_depth,
-                );
+                    Some(&budget),
+                )
+                .map_err(EncodeError::from)?;
                 // RFC#45 chunks 4-7 lossless backport (chunk 5 lossless
                 // trial encoder): per-image cost gate (see
                 // `PatchesData::is_cost_effective_lossless`).

--- a/jxl-encoder/src/entropy_coding/lz77.rs
+++ b/jxl-encoder/src/entropy_coding/lz77.rs
@@ -14,8 +14,11 @@
 
 use hashbrown::HashMap;
 
+use alloc::sync::Arc;
+
 use super::token::{Lz77UintCoder, Token, UintCoder};
 use crate::bit_writer::BitWriter;
+use crate::budget::{MemoryBudget, vec_with_capacity_fallible};
 use crate::error::Result;
 
 /// Maximum window size for LZ77 matching (1MB, matches libjxl).
@@ -1097,23 +1100,41 @@ pub enum Lz77Method {
 /// For photographic content, `Greedy` typically provides 1-3% additional compression
 /// over RLE-only. `Optimal` finds the minimum-cost parse via dynamic programming.
 ///
-/// Returns `Some((transformed_tokens, params))` if LZ77 is beneficial,
-/// or `None` if the savings are insufficient.
+/// Returns `Ok(Some((transformed_tokens, params)))` if LZ77 is beneficial,
+/// `Ok(None)` if the savings are insufficient, or `Err` if a (potentially
+/// large, untrusted-size) working buffer could not be allocated under the
+/// caller's fallible-allocation policy. The RLE and greedy methods never
+/// allocate against `budget`; only the `Optimal` method's Viterbi DP buffers
+/// are threaded through it (`out` and `prefix_costs`, both `O(token_count)`).
+#[allow(clippy::too_many_arguments)]
 pub fn apply_lz77(
     tokens: &[Token],
     num_contexts: usize,
     force_huffman: bool,
     method: Lz77Method,
     distance_multiplier: i32,
-) -> Option<(Vec<Token>, Lz77Params)> {
+    budget: Option<&Arc<MemoryBudget>>,
+) -> Result<Option<(Vec<Token>, Lz77Params)>> {
     match method {
-        Lz77Method::Rle => apply_lz77_rle(tokens, num_contexts, force_huffman, distance_multiplier),
-        Lz77Method::Greedy => {
-            apply_lz77_backref(tokens, num_contexts, force_huffman, distance_multiplier)
-        }
-        Lz77Method::Optimal => {
-            apply_lz77_optimal(tokens, num_contexts, force_huffman, distance_multiplier)
-        }
+        Lz77Method::Rle => Ok(apply_lz77_rle(
+            tokens,
+            num_contexts,
+            force_huffman,
+            distance_multiplier,
+        )),
+        Lz77Method::Greedy => Ok(apply_lz77_backref(
+            tokens,
+            num_contexts,
+            force_huffman,
+            distance_multiplier,
+        )),
+        Lz77Method::Optimal => apply_lz77_optimal(
+            tokens,
+            num_contexts,
+            force_huffman,
+            distance_multiplier,
+            budget,
+        ),
     }
 }
 
@@ -1123,17 +1144,26 @@ pub fn apply_lz77(
 /// First runs greedy LZ77 to build a cost model, then uses that model with
 /// forward-pass DP to find the optimal literal/match decisions at each position.
 ///
-/// Returns `Some((transformed_tokens, params))` if LZ77 is beneficial,
-/// or `None` if the savings are insufficient.
+/// Returns `Ok(Some((transformed_tokens, params)))` if LZ77 is beneficial,
+/// `Ok(None)` if the savings are insufficient, or `Err` if the Viterbi DP
+/// working buffers (`out` and `prefix_costs`, both `O(token_count)` — multi-MB
+/// to tens of MB on lossless e9+) could not be allocated under the caller's
+/// fallible-allocation policy.
+#[allow(clippy::too_many_arguments)]
 pub fn apply_lz77_optimal(
     tokens: &[Token],
     num_contexts: usize,
     force_huffman: bool,
     distance_multiplier: i32,
-) -> Option<(Vec<Token>, Lz77Params)> {
+    budget: Option<&Arc<MemoryBudget>>,
+) -> Result<Option<(Vec<Token>, Lz77Params)>> {
     if tokens.is_empty() {
-        return None;
+        return Ok(None);
     }
+
+    // Whether the (token-count-sized) DP buffers should be allocated fallibly
+    // (`try_reserve`) rather than via the faster infallible path.
+    let fallible = budget.is_some_and(|b| b.is_fallible());
 
     // Step 1: Run greedy LZ77 to get a cost estimate.
     // If greedy doesn't help, optimal won't either.
@@ -1141,7 +1171,7 @@ pub fn apply_lz77_optimal(
         apply_lz77_backref(tokens, num_contexts, force_huffman, distance_multiplier);
     let greedy_tokens = match &greedy_result {
         Some((t, _)) => t,
-        None => return None,
+        None => return Ok(None),
     };
 
     let mut lz77 = Lz77Params::new(num_contexts, force_huffman);
@@ -1196,14 +1226,21 @@ pub fn apply_lz77_optimal(
     }
 
     let n = tokens.len();
-    let mut prefix_costs: Vec<PrefixInfo> = (0..=n)
-        .map(|_| PrefixInfo {
-            len: 0,
-            dist_symbol: 0,
-            ctx: 0,
-            total_cost: f32::MAX,
-        })
-        .collect();
+    // `prefix_costs` holds n+1 `PrefixInfo` entries — the larger of the two
+    // token-count-sized DP buffers. Reserve its bytes against the budget and
+    // honor the fallible-alloc policy, then fill with the same initial values
+    // (byte-identical to the previous `(0..=n).map(..).collect()`).
+    MemoryBudget::reserve_permanent_opt(
+        budget,
+        ((n + 1) as u64).saturating_mul(core::mem::size_of::<PrefixInfo>() as u64),
+    )?;
+    let mut prefix_costs: Vec<PrefixInfo> = vec_with_capacity_fallible(fallible, n + 1)?;
+    prefix_costs.extend((0..=n).map(|_| PrefixInfo {
+        len: 0,
+        dist_symbol: 0,
+        ctx: 0,
+        total_cost: f32::MAX,
+    }));
     prefix_costs[0].total_cost = 0.0;
 
     let mut rle_length = 0usize;
@@ -1287,7 +1324,13 @@ pub fn apply_lz77_optimal(
     }
 
     // Step 5: Backtrace from end to beginning.
-    let mut out = Vec::with_capacity(n);
+    // `out` is the second token-count-sized DP buffer (`Vec<Token>`, ~8 B each).
+    // Reserve its bytes against the budget and honor the fallible-alloc policy.
+    MemoryBudget::reserve_permanent_opt(
+        budget,
+        (n as u64).saturating_mul(core::mem::size_of::<Token>() as u64),
+    )?;
+    let mut out: Vec<Token> = vec_with_capacity_fallible(fallible, n)?;
     let mut pos = n;
     while pos > 0 {
         let info = &prefix_costs[pos];
@@ -1311,7 +1354,7 @@ pub fn apply_lz77_optimal(
     }
 
     out.reverse();
-    Some((out, lz77))
+    Ok(Some((out, lz77)))
 }
 
 /// Try both LZ77 methods and return the one with better compression.
@@ -1558,13 +1601,13 @@ mod tests {
         }
 
         // Test RLE method
-        let rle_result = apply_lz77(&tokens, 1, false, Lz77Method::Rle, 0);
+        let rle_result = apply_lz77(&tokens, 1, false, Lz77Method::Rle, 0, None).unwrap();
         if let Some((_, params)) = &rle_result {
             assert!(params.enabled);
         }
 
         // Test Greedy method
-        let greedy_result = apply_lz77(&tokens, 1, false, Lz77Method::Greedy, 0);
+        let greedy_result = apply_lz77(&tokens, 1, false, Lz77Method::Greedy, 0, None).unwrap();
         if let Some((_, params)) = &greedy_result {
             assert!(params.enabled);
         }

--- a/jxl-encoder/src/icc.rs
+++ b/jxl-encoder/src/icc.rs
@@ -775,8 +775,9 @@ pub fn write_icc(icc: &[u8], writer: &mut BitWriter) -> Result<()> {
         NUM_ICC_CONTEXTS,
         true, // force_huffman
         lz77_method,
-        0, // no special distance codes for ICC
-    ) {
+        0,    // no special distance codes for ICC
+        None, // ICC profiles are small — not a budget-tracked allocation site
+    )? {
         Some((lz77_tokens, params)) => (lz77_tokens, Some(params)),
         None => (tokens, None),
     };

--- a/jxl-encoder/src/lib.rs
+++ b/jxl-encoder/src/lib.rs
@@ -271,13 +271,20 @@ pub mod __internals {
         num_channels: usize,
         bit_depth: u32,
     ) -> Option<crate::vardct::patches::PatchesData> {
+        // Calibration-harness entry — no `MemoryBudget` (infallible alloc).
+        // `find_and_build_lossless` only returns `Err` here on an
+        // allocation-size `usize` overflow (the same condition that would
+        // abort the underlying `vec!` today), so unwrapping preserves the
+        // historical `Option`-returning public signature unchanged.
         crate::vardct::patches::find_and_build_lossless(
             pixels,
             width,
             height,
             num_channels,
             bit_depth,
+            None,
         )
+        .expect("lossless patches detection allocation overflow (infallible path)")
     }
 
     /// Telemetry for a [`crate::vardct::patches::PatchesData`]:

--- a/jxl-encoder/src/modular/encode.rs
+++ b/jxl-encoder/src/modular/encode.rs
@@ -1681,6 +1681,7 @@ pub(crate) fn select_best_rct_at(
 /// - GroupHeader (use_global_tree=1, wp_header, num_transforms=0..2)
 /// - ANS-encoded residuals (write_tokens_ans)
 /// - byte padding
+#[allow(clippy::too_many_arguments)]
 pub fn write_modular_stream_with_tree(
     image: &ModularImage,
     writer: &mut BitWriter,
@@ -1688,6 +1689,7 @@ pub fn write_modular_stream_with_tree(
     rct: bool,
     use_lz77: bool,
     lz77_method: crate::entropy_coding::lz77::Lz77Method,
+    budget: Option<&alloc::sync::Arc<crate::budget::MemoryBudget>>,
 ) -> Result<()> {
     write_modular_stream_with_tree_dc_quant(
         image,
@@ -1699,6 +1701,7 @@ pub fn write_modular_stream_with_tree(
         None,
         None, // no lossy modular options
         true, // enable palette detection
+        budget,
     )
 }
 
@@ -1709,6 +1712,7 @@ pub fn write_modular_stream_with_tree(
 /// `-E N`) into the tree-learning + palette + channel-compact pipeline.
 /// `None` knobs (the default) gives byte-identical output to
 /// [`write_modular_stream_with_tree`].
+#[allow(clippy::too_many_arguments)]
 pub fn write_modular_stream_with_tree_knobs(
     image: &ModularImage,
     writer: &mut BitWriter,
@@ -1717,6 +1721,7 @@ pub fn write_modular_stream_with_tree_knobs(
     use_lz77: bool,
     lz77_method: crate::entropy_coding::lz77::Lz77Method,
     knobs: &super::palette::ModularKnobs,
+    budget: Option<&alloc::sync::Arc<crate::budget::MemoryBudget>>,
 ) -> Result<()> {
     write_modular_stream_with_tree_dc_quant_knobs(
         image,
@@ -1729,6 +1734,7 @@ pub fn write_modular_stream_with_tree_knobs(
         None, // no lossy modular options
         true, // enable palette detection
         knobs,
+        budget,
     )
 }
 
@@ -1768,6 +1774,7 @@ pub(crate) fn write_modular_stream_with_tree_dc_quant(
     dc_quant_custom: Option<[f32; 3]>,
     lossy_options: Option<LossyModularOptions>,
     palette: bool,
+    budget: Option<&alloc::sync::Arc<crate::budget::MemoryBudget>>,
 ) -> Result<()> {
     write_modular_stream_with_tree_dc_quant_knobs(
         image,
@@ -1780,6 +1787,7 @@ pub(crate) fn write_modular_stream_with_tree_dc_quant(
         lossy_options,
         palette,
         &super::palette::ModularKnobs::default(),
+        budget,
     )
 }
 
@@ -1804,6 +1812,7 @@ pub(crate) fn write_modular_stream_with_tree_dc_quant_knobs(
     lossy_options: Option<LossyModularOptions>,
     palette: bool,
     knobs: &super::palette::ModularKnobs,
+    budget: Option<&alloc::sync::Arc<crate::budget::MemoryBudget>>,
 ) -> Result<()> {
     use super::tree::count_contexts;
     use super::tree_learn::{
@@ -2176,7 +2185,14 @@ pub(crate) fn write_modular_stream_with_tree_dc_quant_knobs(
         .unwrap_or(0) as i32;
     let (tokens, lz77_params) = if use_lz77 {
         // LZ77 application
-        match apply_lz77(&tokens, num_contexts, false, lz77_method, dist_multiplier) {
+        match apply_lz77(
+            &tokens,
+            num_contexts,
+            false,
+            lz77_method,
+            dist_multiplier,
+            budget,
+        )? {
             Some((lz77_tokens, params)) => (lz77_tokens, Some(params)),
             None => (tokens, None),
         }
@@ -2300,6 +2316,7 @@ pub(crate) fn write_modular_stream_with_tree_dc_quant_presqueezed(
     squeeze_params: &[super::squeeze::SqueezeParams],
     multiplier_info: &[super::quantize::ModularMultiplierInfo],
     _quants: &[i32],
+    budget: Option<&alloc::sync::Arc<crate::budget::MemoryBudget>>,
 ) -> Result<()> {
     use super::tree::count_contexts;
     use super::tree_learn::{
@@ -2379,7 +2396,14 @@ pub(crate) fn write_modular_stream_with_tree_dc_quant_presqueezed(
     // Step 3b: Optionally apply LZ77 to the token stream
     let dist_multiplier = image.channels.iter().map(|c| c.width()).max().unwrap_or(0) as i32;
     let (tokens, lz77_params) = if use_lz77 {
-        match apply_lz77(&tokens, num_contexts, false, lz77_method, dist_multiplier) {
+        match apply_lz77(
+            &tokens,
+            num_contexts,
+            false,
+            lz77_method,
+            dist_multiplier,
+            budget,
+        )? {
             Some((lz77_tokens, params)) => (lz77_tokens, Some(params)),
             None => (tokens, None),
         }
@@ -2474,6 +2498,7 @@ pub fn write_modular_stream_with_squeeze_and_tree(
     profile: &crate::effort::EffortProfile,
     use_lz77: bool,
     lz77_method: crate::entropy_coding::lz77::Lz77Method,
+    budget: Option<&alloc::sync::Arc<crate::budget::MemoryBudget>>,
 ) -> Result<()> {
     use super::rct::{RctType, forward_rct};
     use super::squeeze::{apply_squeeze, default_squeeze_params};
@@ -2497,6 +2522,7 @@ pub fn write_modular_stream_with_squeeze_and_tree(
             image.channels.len() >= 3,
             use_lz77,
             lz77_method,
+            budget,
         );
     }
 
@@ -2596,7 +2622,14 @@ pub fn write_modular_stream_with_squeeze_and_tree(
         .max()
         .unwrap_or(0) as i32;
     let (tokens, lz77_params) = if use_lz77 {
-        match apply_lz77(&tokens, num_contexts, false, lz77_method, dist_multiplier) {
+        match apply_lz77(
+            &tokens,
+            num_contexts,
+            false,
+            lz77_method,
+            dist_multiplier,
+            budget,
+        )? {
             Some((lz77_tokens, params)) => {
                 crate::trace::debug_eprintln!(
                     "SQUEEZE LZ77: {} → {} tokens ({:.1}x), method={:?}, dm={}",

--- a/jxl-encoder/src/modular/frame.rs
+++ b/jxl-encoder/src/modular/frame.rs
@@ -397,6 +397,7 @@ impl FrameEncoder {
                     &self.options.profile,
                     self.options.enable_lz77,
                     self.options.lz77_method,
+                    self.budget.as_ref(),
                 )?;
             } else if has_squeeze {
                 super::encode::write_modular_stream_with_squeeze(
@@ -414,6 +415,7 @@ impl FrameEncoder {
                     self.options.enable_lz77,
                     self.options.lz77_method,
                     &self.options.modular_knobs,
+                    self.budget.as_ref(),
                 )?;
             } else if image.channels.len() >= 3 {
                 super::encode::write_modular_stream_with_rct_knobs(
@@ -515,6 +517,7 @@ impl FrameEncoder {
                     &self.options.profile,
                     self.options.enable_lz77,
                     self.options.lz77_method,
+                    self.budget.as_ref(),
                 )?;
             } else if has_squeeze {
                 // Squeeze without tree learning (lower effort levels)
@@ -533,6 +536,7 @@ impl FrameEncoder {
                     self.options.enable_lz77,
                     self.options.lz77_method,
                     &self.options.modular_knobs,
+                    self.budget.as_ref(),
                 )?;
             } else if image.channels.len() >= 3 {
                 super::encode::write_modular_stream_with_rct_knobs(
@@ -919,6 +923,7 @@ impl FrameEncoder {
                 meta_image.as_ref(),
                 &self.options.modular_knobs,
                 super::section::modular_hf_stream_id_base(self.num_lf_groups() as u32),
+                self.budget.as_ref(),
             )?
         } else if self.options.use_tree_learning && self.options.use_ans {
             // Tree learning path: gather samples, learn tree, build multi-context ANS.
@@ -936,6 +941,7 @@ impl FrameEncoder {
                 meta_image.as_ref(),
                 &self.options.modular_knobs,
                 super::section::modular_hf_stream_id_base(self.num_lf_groups() as u32),
+                self.budget.as_ref(),
             )?
         } else {
             // Standard path: collect residuals using the requested predictor
@@ -1015,6 +1021,7 @@ impl FrameEncoder {
             s.check().map_err(|_| crate::error::Error::Cancelled)?;
         }
         // PassGroup sections — parallelizable (each group writes to its own BitWriter)
+        let budget = self.budget.as_ref();
         let pass_group_data: Vec<Vec<u8>> =
             crate::parallel::parallel_map_result(num_groups * num_passes, |flat_idx| {
                 let group_idx = flat_idx / num_passes;
@@ -1027,6 +1034,7 @@ impl FrameEncoder {
                     group_idx as u32 + per_group_id_offset,
                     &group_transforms[group_idx],
                     &mut group_writer,
+                    budget,
                 )?;
 
                 crate::trace::debug_eprintln!(
@@ -2176,14 +2184,24 @@ impl FrameEncoder {
         let lz77_params = if use_lz77 {
             use crate::entropy_coding::lz77::apply_lz77;
 
-            let try_lz77 = |tokens: &[AnsToken], dist_multiplier: i32| -> Vec<AnsToken> {
+            let budget = self.budget.as_ref();
+            let try_lz77 = |tokens: &[AnsToken], dist_multiplier: i32| -> Result<Vec<AnsToken>> {
                 if tokens.is_empty() {
-                    return tokens.to_vec();
+                    return Ok(tokens.to_vec());
                 }
-                match apply_lz77(tokens, num_contexts, false, lz77_method, dist_multiplier) {
-                    Some((lz77_tokens, _)) => lz77_tokens,
-                    None => tokens.to_vec(),
-                }
+                Ok(
+                    match apply_lz77(
+                        tokens,
+                        num_contexts,
+                        false,
+                        lz77_method,
+                        dist_multiplier,
+                        budget,
+                    )? {
+                        Some((lz77_tokens, _)) => lz77_tokens,
+                        None => tokens.to_vec(),
+                    },
+                )
             };
 
             // Global section: dist_multiplier from global channels
@@ -2192,7 +2210,7 @@ impl FrameEncoder {
                 .map(|c| c.width())
                 .max()
                 .unwrap_or(0) as i32;
-            global_tokens = try_lz77(&global_tokens, global_dm);
+            global_tokens = try_lz77(&global_tokens, global_dm)?;
 
             // LfGroup sections: dist_multiplier from each LfGroup's channels
             for (lg, lg_tokens) in lf_group_tokens.iter_mut().enumerate() {
@@ -2201,7 +2219,7 @@ impl FrameEncoder {
                     .map(|c| c.width())
                     .max()
                     .unwrap_or(0) as i32;
-                *lg_tokens = try_lz77(lg_tokens, dm);
+                *lg_tokens = try_lz77(lg_tokens, dm)?;
             }
 
             // PassGroup sections: dist_multiplier from each PassGroup's channels
@@ -2211,7 +2229,7 @@ impl FrameEncoder {
                     .map(|c| c.width())
                     .max()
                     .unwrap_or(0) as i32;
-                *pg_tokens = try_lz77(pg_tokens, dm);
+                *pg_tokens = try_lz77(pg_tokens, dm)?;
             }
 
             // Check if any section has LZ77 references
@@ -2451,6 +2469,7 @@ impl FrameEncoder {
                     None, // not lossy modular (no Squeeze + multiplier-info path)
                     true, // palette detection ok
                     &self.options.modular_knobs,
+                    self.budget.as_ref(),
                 )?;
             } else if self.options.use_tree_learning && self.options.use_ans {
                 super::encode::write_modular_stream_with_tree_knobs(
@@ -2461,6 +2480,7 @@ impl FrameEncoder {
                     self.options.enable_lz77,
                     self.options.lz77_method,
                     &self.options.modular_knobs,
+                    self.budget.as_ref(),
                 )?;
             } else if use_rct {
                 super::encode::write_modular_stream_with_rct_knobs(

--- a/jxl-encoder/src/modular/section.rs
+++ b/jxl-encoder/src/modular/section.rs
@@ -354,6 +354,7 @@ pub fn write_global_modular_section_with_tree(
     lz77_method: crate::entropy_coding::lz77::Lz77Method,
     meta_image: Option<&ModularImage>,
     hf_stream_id_base: u32,
+    budget: Option<&alloc::sync::Arc<crate::budget::MemoryBudget>>,
 ) -> Result<GlobalModularState> {
     write_global_modular_section_with_tree_dc_quant_knobs(
         images,
@@ -366,6 +367,7 @@ pub fn write_global_modular_section_with_tree(
         meta_image,
         &super::palette::ModularKnobs::default(),
         hf_stream_id_base,
+        budget,
     )
 }
 
@@ -396,6 +398,7 @@ pub fn write_global_modular_section_with_tree_knobs(
     meta_image: Option<&ModularImage>,
     knobs: &super::palette::ModularKnobs,
     hf_stream_id_base: u32,
+    budget: Option<&alloc::sync::Arc<crate::budget::MemoryBudget>>,
 ) -> Result<GlobalModularState> {
     write_global_modular_section_with_tree_dc_quant_knobs(
         images,
@@ -408,6 +411,7 @@ pub fn write_global_modular_section_with_tree_knobs(
         meta_image,
         knobs,
         hf_stream_id_base,
+        budget,
     )
 }
 
@@ -423,6 +427,7 @@ pub(crate) fn write_global_modular_section_with_tree_dc_quant(
     dc_quant_custom: Option<[f32; 3]>,
     meta_image: Option<&ModularImage>,
     hf_stream_id_base: u32,
+    budget: Option<&alloc::sync::Arc<crate::budget::MemoryBudget>>,
 ) -> Result<GlobalModularState> {
     write_global_modular_section_with_tree_dc_quant_knobs(
         images,
@@ -435,6 +440,7 @@ pub(crate) fn write_global_modular_section_with_tree_dc_quant(
         meta_image,
         &super::palette::ModularKnobs::default(),
         hf_stream_id_base,
+        budget,
     )
 }
 
@@ -454,6 +460,7 @@ pub(crate) fn write_global_modular_section_with_tree_dc_quant_knobs(
     meta_image: Option<&ModularImage>,
     knobs: &super::palette::ModularKnobs,
     hf_stream_id_base: u32,
+    budget: Option<&alloc::sync::Arc<crate::budget::MemoryBudget>>,
 ) -> Result<GlobalModularState> {
     use super::encode::write_tree;
     use super::encode::write_wp_header;
@@ -937,20 +944,29 @@ pub(crate) fn write_global_modular_section_with_tree_dc_quant_knobs(
     //   histogram-time slices and the write-time streams stay in lockstep.
     let lz77_applied = if use_lz77 {
         use crate::entropy_coding::lz77::{Lz77Params, apply_lz77};
-        let try_lz77 = |tokens: &[AnsToken], dist_multiplier: i32| -> Vec<AnsToken> {
+        let try_lz77 = |tokens: &[AnsToken], dist_multiplier: i32| -> Result<Vec<AnsToken>> {
             if tokens.is_empty() {
-                return Vec::new();
+                return Ok(Vec::new());
             }
-            match apply_lz77(tokens, num_contexts, false, lz77_method, dist_multiplier) {
-                Some((lz77_tokens, _)) => lz77_tokens,
-                None => tokens.to_vec(),
-            }
+            Ok(
+                match apply_lz77(
+                    tokens,
+                    num_contexts,
+                    false,
+                    lz77_method,
+                    dist_multiplier,
+                    budget,
+                )? {
+                    Some((lz77_tokens, _)) => lz77_tokens,
+                    None => tokens.to_vec(),
+                },
+            )
         };
         let meta_dm = meta_image
             .map(|m| m.channels.iter().map(|c| c.width()).max().unwrap_or(0))
             .unwrap_or(0) as i32;
         let mut transformed = Vec::with_capacity(all_tokens.len());
-        transformed.extend(try_lz77(&all_tokens[..nb_meta_tokens], meta_dm));
+        transformed.extend(try_lz77(&all_tokens[..nb_meta_tokens], meta_dm)?);
         let transformed_nb_meta = transformed.len();
         for (g, range) in group_ranges.iter().enumerate() {
             let dm = images[g]
@@ -959,7 +975,7 @@ pub(crate) fn write_global_modular_section_with_tree_dc_quant_knobs(
                 .map(|c| c.width())
                 .max()
                 .unwrap_or(0) as i32;
-            transformed.extend(try_lz77(&all_tokens[range.clone()], dm));
+            transformed.extend(try_lz77(&all_tokens[range.clone()], dm)?);
         }
         // Header params come from the same (num_contexts, force_huffman)
         // construction apply_lz77 uses internally, so min_symbol/min_length
@@ -1168,12 +1184,25 @@ fn collect_group_residuals_with_predictor(
 /// - Encoded pixel residuals using HybridUint {4,2,0} + global entropy codes
 ///
 /// The `group_image` should be the extracted region for this group.
+// `MemoryBudget` is a `pub(crate)` type; this `pub` fn lives in the
+// `pub(crate) mod section` (re-exported only inside `pub(crate) mod encode`),
+// so it is not externally reachable despite the `pub` keyword. The budget
+// param is an internal allocation-policy detail.
+#[allow(private_interfaces)]
 pub fn write_group_modular_section(
     group_image: &ModularImage,
     state: &GlobalModularState,
     writer: &mut BitWriter,
+    budget: Option<&alloc::sync::Arc<crate::budget::MemoryBudget>>,
 ) -> Result<()> {
-    write_group_modular_section_idx(group_image, state, 0, &GroupTransforms::none(), writer)
+    write_group_modular_section_idx(
+        group_image,
+        state,
+        0,
+        &GroupTransforms::none(),
+        writer,
+        budget,
+    )
 }
 
 /// Like [`write_group_modular_section`] but with an explicit group index
@@ -1206,6 +1235,7 @@ pub fn write_group_modular_section_idx(
     group_idx: u32,
     transforms: &GroupTransforms,
     writer: &mut BitWriter,
+    budget: Option<&alloc::sync::Arc<crate::budget::MemoryBudget>>,
 ) -> Result<()> {
     crate::trace::debug_eprintln!(
         "GROUP_MODULAR [bit {}]: Starting group section ({}x{}, compact={}, rct={:?})",
@@ -1317,7 +1347,8 @@ pub fn write_group_modular_section_idx(
                         false,
                         *method,
                         dist_multiplier,
-                    ) {
+                        budget,
+                    )? {
                         Some((lz77_tokens, _)) => lz77_tokens,
                         None => tokens,
                     };

--- a/jxl-encoder/src/vardct/bitstream.rs
+++ b/jxl-encoder/src/vardct/bitstream.rs
@@ -1769,7 +1769,8 @@ impl VarDctEncoder {
                 min_peak,
                 Some(self.distance),
                 self.use_ans,
-            )
+                self.budget.as_ref(),
+            )?
         } else {
             None
         };
@@ -1895,8 +1896,13 @@ impl VarDctEncoder {
             if matches!(
                 self.pixel_loss_dispatch,
                 crate::api::PixelLossDispatch::Auto
-            ) && super::encoder::pixel_loss_auto_should_skip(&m, padded_width, width, height)
-            {
+            ) && super::encoder::pixel_loss_auto_should_skip(
+                &m,
+                padded_width,
+                width,
+                height,
+                self.budget.as_ref(),
+            )? {
                 None
             } else {
                 Some(m)
@@ -1985,13 +1991,26 @@ impl VarDctEncoder {
         // for the gate cascade.
         let mask1x1_median_for_search = mask1x1
             .as_deref()
-            .map(|m| super::encoder::median_mask1x1(m, padded_width, width, height));
+            .map(|m| {
+                super::encoder::median_mask1x1(m, padded_width, width, height, self.budget.as_ref())
+            })
+            .transpose()?;
         // W44-151: also compute mask1x1 p25 for the new mask_p25 >= 85
         // admission branch in the W44-29 outer gate. Same None-semantics
         // (mask1x1 unavailable → gate degrades to off).
         let mask1x1_p25_for_search = mask1x1
             .as_deref()
-            .map(|m| super::encoder::percentile_mask1x1(m, padded_width, width, height, 0.25));
+            .map(|m| {
+                super::encoder::percentile_mask1x1(
+                    m,
+                    padded_width,
+                    width,
+                    height,
+                    0.25,
+                    self.budget.as_ref(),
+                )
+            })
+            .transpose()?;
         let profile_for_search =
             self.compute_profile_for_search(mask1x1_median_for_search, mask1x1_p25_for_search);
         let active_profile_for_search = profile_for_search.as_ref().unwrap_or(&self.profile);

--- a/jxl-encoder/src/vardct/bitstream.rs
+++ b/jxl-encoder/src/vardct/bitstream.rs
@@ -3150,7 +3150,8 @@ impl VarDctEncoder {
                 false,
                 self.lz77_method,
                 _dc_distance_multiplier,
-            ) {
+                self.budget.as_ref(),
+            )? {
                 #[cfg(feature = "debug-tokens")]
                 eprintln!(
                     "[LZ77] DC LZ77 ACTIVATED: {} -> {} tokens",
@@ -3178,7 +3179,8 @@ impl VarDctEncoder {
                         false,
                         self.lz77_method,
                         group_dc_width,
-                    ) {
+                        self.budget.as_ref(),
+                    )? {
                         new_dc_per_group.push(lz77_dc);
                     } else {
                         new_dc_per_group.push(dc_tokens_per_group[i].clone());
@@ -3209,7 +3211,8 @@ impl VarDctEncoder {
                         false,
                         self.lz77_method,
                         md_dist_mult,
-                    ) {
+                        self.budget.as_ref(),
+                    )? {
                         new_md_per_group.push(lz77_md);
                     } else {
                         new_md_per_group.push(ac_metadata_tokens_per_group[i].clone());
@@ -3247,7 +3250,8 @@ impl VarDctEncoder {
                     false,
                     self.lz77_method,
                     ac_distance_multiplier,
-                ) {
+                    self.budget.as_ref(),
+                )? {
                     #[cfg(feature = "debug-tokens")]
                     eprintln!(
                         "[LZ77] AC pass {} LZ77 ACTIVATED: {} -> {} tokens",
@@ -3264,7 +3268,8 @@ impl VarDctEncoder {
                             false,
                             self.lz77_method,
                             ac_distance_multiplier,
-                        ) {
+                            self.budget.as_ref(),
+                        )? {
                             new_sections.push(lz77_ac);
                         } else {
                             new_sections.push(tokens.clone());

--- a/jxl-encoder/src/vardct/encoder.rs
+++ b/jxl-encoder/src/vardct/encoder.rs
@@ -1426,9 +1426,10 @@ pub(crate) fn pixel_loss_auto_should_skip(
     stride: usize,
     width: usize,
     height: usize,
-) -> bool {
-    let med = median_mask1x1(mask1x1, stride, width, height);
-    med > PIXEL_LOSS_DISPATCH_MEDIAN_THRESHOLD
+    budget: Option<&alloc::sync::Arc<crate::budget::MemoryBudget>>,
+) -> crate::error::Result<bool> {
+    let med = median_mask1x1(mask1x1, stride, width, height, budget)?;
+    Ok(med > PIXEL_LOSS_DISPATCH_MEDIAN_THRESHOLD)
 }
 
 /// W36-3 patches photo-skip dispatch helper: returns the per-8×8-block
@@ -1521,18 +1522,32 @@ fn patches_dispatch_block_mask_median(
 /// expected, no allocation outside the temporary buffer) — exact median
 /// rather than histogram approximation because the field is small
 /// (≤ 12 MP) and `mask1x1` is allocated once per encode anyway.
-pub(super) fn median_mask1x1(mask: &[f32], stride: usize, width: usize, height: usize) -> f32 {
+pub(super) fn median_mask1x1(
+    mask: &[f32],
+    stride: usize,
+    width: usize,
+    height: usize,
+    budget: Option<&alloc::sync::Arc<crate::budget::MemoryBudget>>,
+) -> crate::error::Result<f32> {
     if width == 0 || height == 0 {
-        return 0.0;
+        return Ok(0.0);
     }
-    let mut buf: Vec<f32> = Vec::with_capacity(width * height);
+    // Temporary `width * height` copy of the unpadded values; dimension-driven
+    // (4–50 MB at ≥1 MP), so route it through the runtime fallible-alloc policy.
+    // Byte-identical when infallible (`vec_with_capacity_fallible(false, n)` ==
+    // `with_capacity(n)`); reserves nothing against the budget (the buffer is
+    // scratch and freed before return).
+    let mut buf: Vec<f32> = crate::budget::vec_with_capacity_fallible(
+        budget.is_some_and(|b| b.is_fallible()),
+        width * height,
+    )?;
     for y in 0..height {
         let row_off = y * stride;
         let row_end = row_off + width;
         if row_end > mask.len() {
             // Defensive: pad / row-stride mismatch — return 0.0 so the
             // gate stays off rather than reading uninitialised memory.
-            return 0.0;
+            return Ok(0.0);
         }
         buf.extend_from_slice(&mask[row_off..row_end]);
     }
@@ -1545,7 +1560,7 @@ pub(super) fn median_mask1x1(mask: &[f32], stride: usize, width: usize, height: 
     buf.select_nth_unstable_by(mid, |a, b| {
         a.partial_cmp(b).unwrap_or(core::cmp::Ordering::Equal)
     });
-    buf[mid]
+    Ok(buf[mid])
 }
 
 /// W44-150: arbitrary-percentile selector on the unpadded `width × height`
@@ -1576,22 +1591,29 @@ pub(super) fn percentile_mask1x1(
     width: usize,
     height: usize,
     p: f32,
-) -> f32 {
+    budget: Option<&alloc::sync::Arc<crate::budget::MemoryBudget>>,
+) -> crate::error::Result<f32> {
     if width == 0 || height == 0 {
-        return 0.0;
+        return Ok(0.0);
     }
-    let mut buf: Vec<f32> = Vec::with_capacity(width * height);
+    // Temporary `width * height` copy of the unpadded values; dimension-driven,
+    // routed through the runtime fallible-alloc policy. Byte-identical when
+    // infallible; reserves nothing (scratch, freed before return).
+    let mut buf: Vec<f32> = crate::budget::vec_with_capacity_fallible(
+        budget.is_some_and(|b| b.is_fallible()),
+        width * height,
+    )?;
     for y in 0..height {
         let row_off = y * stride;
         let row_end = row_off + width;
         if row_end > mask.len() {
-            return 0.0;
+            return Ok(0.0);
         }
         buf.extend_from_slice(&mask[row_off..row_end]);
     }
     let n = buf.len();
     if n == 0 {
-        return 0.0;
+        return Ok(0.0);
     }
     let p_clamped = p.clamp(0.0, 1.0);
     let idx = ((n as f32 - 1.0) * p_clamped).floor() as usize;
@@ -1599,7 +1621,7 @@ pub(super) fn percentile_mask1x1(
     buf.select_nth_unstable_by(idx, |a, b| {
         a.partial_cmp(b).unwrap_or(core::cmp::Ordering::Equal)
     });
-    buf[idx]
+    Ok(buf[idx])
 }
 
 /// W44-91 cheap encoder-internal zenanalyze proxies used to widen the
@@ -3860,7 +3882,8 @@ impl VarDctEncoder {
                 min_peak,
                 Some(self.distance),
                 self.use_ans,
-            )
+                self.budget.as_ref(),
+            )?
         } else {
             None
         };
@@ -4106,7 +4129,8 @@ impl VarDctEncoder {
             };
         let mask1x1_median_for_pre_scale: Option<f32> = mask1x1_for_pre_scale
             .as_deref()
-            .map(|m| median_mask1x1(m, padded_width, width, height));
+            .map(|m| median_mask1x1(m, padded_width, width, height, self.budget.as_ref()))
+            .transpose()?;
         #[cfg(all(feature = "std", feature = "__env_var_diagnostics"))]
         if std::env::var_os("JXL_WP_DISPATCH_DUMP_MASK").is_some() {
             eprintln!(
@@ -4131,7 +4155,8 @@ impl VarDctEncoder {
         // sRGB layouts).
         let mask1x1_p25_for_pre_scale: Option<f32> = mask1x1_for_pre_scale
             .as_deref()
-            .map(|m| percentile_mask1x1(m, padded_width, width, height, 0.25));
+            .map(|m| percentile_mask1x1(m, padded_width, width, height, 0.25, self.budget.as_ref()))
+            .transpose()?;
         let edge_density_for_pre_scale: Option<f32> =
             self.zenanalyze_proxies.map(|p| p.edge_density);
         #[cfg(feature = "butteraugli-loop")]
@@ -4435,8 +4460,13 @@ impl VarDctEncoder {
             if matches!(
                 self.pixel_loss_dispatch,
                 crate::api::PixelLossDispatch::Auto
-            ) && pixel_loss_auto_should_skip(&m, padded_width, width, height)
-            {
+            ) && pixel_loss_auto_should_skip(
+                &m,
+                padded_width,
+                width,
+                height,
+                self.budget.as_ref(),
+            )? {
                 None
             } else {
                 Some(m)
@@ -4616,7 +4646,8 @@ impl VarDctEncoder {
         // hint that bypasses the mask discriminator.
         let mask1x1_median: Option<f32> = mask1x1
             .as_deref()
-            .map(|mask| median_mask1x1(mask, padded_width, width, height));
+            .map(|mask| median_mask1x1(mask, padded_width, width, height, self.budget.as_ref()))
+            .transpose()?;
         // W44-151: compute `mask_p25` (mask1x1 25th percentile) for the
         // W44-29 outer gate's mask_p25 >= 85 admission branch. Same
         // None-semantics as `mask1x1_median` (gates degrade to off).
@@ -4624,7 +4655,17 @@ impl VarDctEncoder {
         // plane — negligible vs the median compute above.
         let mask1x1_p25: Option<f32> = mask1x1
             .as_deref()
-            .map(|mask| percentile_mask1x1(mask, padded_width, width, height, 0.25));
+            .map(|mask| {
+                percentile_mask1x1(
+                    mask,
+                    padded_width,
+                    width,
+                    height,
+                    0.25,
+                    self.budget.as_ref(),
+                )
+            })
+            .transpose()?;
 
         // W44-118 probe: env-gated dump of mask1x1_median + key
         // zenanalyze proxies to discriminate lift firing on the wedge
@@ -5516,9 +5557,11 @@ impl VarDctEncoder {
                     super::perceptual_tuning::SCREENSHOT_MEDIAN_THRESHOLD,
                     screenshot_median_threshold,
                 );
-                let is_screenshot = mask1x1.as_deref().is_some_and(|m| {
-                    median_mask1x1(m, padded_width, width, height) > median_threshold
-                });
+                let is_screenshot = mask1x1
+                    .as_deref()
+                    .map(|m| median_mask1x1(m, padded_width, width, height, self.budget.as_ref()))
+                    .transpose()?
+                    .is_some_and(|med| med > median_threshold);
                 // W44-150 Phase 2 HONEST-STOP (2026-05-21): the
                 // Mechanism A photo-admission path (was: admit
                 // `is_screenshot || (mask_p25 >= 85.0 AND distance >=
@@ -6716,7 +6759,8 @@ impl VarDctEncoder {
                     min_peak,
                     Some(self.distance),
                     self.use_ans,
-                );
+                    self.budget.as_ref(),
+                )?;
                 if matches!(self.encoder_mode, crate::api::EncoderMode::Experimental)
                     && let Some(ref p) = pd
                     && !p.is_cost_effective(self.distance, self.use_ans)
@@ -7213,16 +7257,16 @@ mod tests {
             5.0, 6.0, 7.0, 8.0,  0.0, 0.0, // row 1: 5..8 + padding
             9.0,10.0,11.0,12.0, 0.0, 0.0, // row 2: 9..12 + padding
         ];
-        let med = median_mask1x1(&mask, 6, 4, 3);
+        let med = median_mask1x1(&mask, 6, 4, 3, None).unwrap();
         assert_eq!(med, 7.0);
     }
 
     #[test]
     fn test_median_mask1x1_zero_dim() {
         // 0-width / 0-height shouldn't panic.
-        assert_eq!(median_mask1x1(&[], 0, 0, 0), 0.0);
-        assert_eq!(median_mask1x1(&[1.0, 2.0], 2, 0, 1), 0.0);
-        assert_eq!(median_mask1x1(&[1.0, 2.0], 2, 2, 0), 0.0);
+        assert_eq!(median_mask1x1(&[], 0, 0, 0, None).unwrap(), 0.0);
+        assert_eq!(median_mask1x1(&[1.0, 2.0], 2, 0, 1, None).unwrap(), 0.0);
+        assert_eq!(median_mask1x1(&[1.0, 2.0], 2, 2, 0, None).unwrap(), 0.0);
     }
 
     /// W44-151: verify the new [`W44_151_HIGH_MASK_P25_MIN`] constant
@@ -7305,11 +7349,11 @@ mod tests {
             5.0, 6.0, 7.0, 8.0,  0.0, 0.0,
             9.0,10.0,11.0,12.0, 0.0, 0.0,
         ];
-        let p25 = percentile_mask1x1(&mask, 6, 4, 3, 0.25);
+        let p25 = percentile_mask1x1(&mask, 6, 4, 3, 0.25, None).unwrap();
         assert_eq!(p25, 3.0);
-        let p50 = percentile_mask1x1(&mask, 6, 4, 3, 0.50);
+        let p50 = percentile_mask1x1(&mask, 6, 4, 3, 0.50, None).unwrap();
         assert_eq!(p50, 6.0); // floor(11 * 0.5) = 5 → value 6
-        let p100 = percentile_mask1x1(&mask, 6, 4, 3, 1.0);
+        let p100 = percentile_mask1x1(&mask, 6, 4, 3, 1.0, None).unwrap();
         assert_eq!(p100, 12.0);
     }
 
@@ -7322,7 +7366,7 @@ mod tests {
         let high_smooth: Vec<f32> = (0..(32 * 32))
             .map(|i| if i < 32 { 50.0 } else { 90.0 + (i % 10) as f32 })
             .collect();
-        let p25_hi = percentile_mask1x1(&high_smooth, 32, 32, 32, 0.25);
+        let p25_hi = percentile_mask1x1(&high_smooth, 32, 32, 32, 0.25, None).unwrap();
         assert!(
             p25_hi >= W44_151_HIGH_MASK_P25_MIN,
             "high-smooth synthetic p25 = {p25_hi}, expected >= {W44_151_HIGH_MASK_P25_MIN}"
@@ -7331,7 +7375,7 @@ mod tests {
         // Low-mask case: photo-class with values around 40-70 — p25
         // far below the threshold, should reject.
         let low_mask: Vec<f32> = (0..(32 * 32)).map(|i| 40.0 + (i % 30) as f32).collect();
-        let p25_lo = percentile_mask1x1(&low_mask, 32, 32, 32, 0.25);
+        let p25_lo = percentile_mask1x1(&low_mask, 32, 32, 32, 0.25, None).unwrap();
         assert!(
             p25_lo < W44_151_HIGH_MASK_P25_MIN,
             "photo-class synthetic p25 = {p25_lo}, expected < {W44_151_HIGH_MASK_P25_MIN}"
@@ -7344,7 +7388,7 @@ mod tests {
         // (compute_mask1x1 produces 1/(log1p(diff) + 0.01) — high local
         // activity → low mask). Expected median far below 95.
         let photo: Vec<f32> = (0..(64 * 64)).map(|i| 5.0 + (i % 35) as f32).collect();
-        let m_photo = median_mask1x1(&photo, 64, 64, 64);
+        let m_photo = median_mask1x1(&photo, 64, 64, 64, None).unwrap();
         assert!(
             m_photo < 95.0,
             "photo-band median {m_photo} should be < 95.0 threshold"
@@ -7353,7 +7397,7 @@ mod tests {
         // Screenshot-class: high mask values (flat regions, low activity)
         // clustered around 110..170. Expected median above 95.
         let screen: Vec<f32> = (0..(64 * 64)).map(|i| 110.0 + (i % 30) as f32).collect();
-        let m_screen = median_mask1x1(&screen, 64, 64, 64);
+        let m_screen = median_mask1x1(&screen, 64, 64, 64, None).unwrap();
         assert!(
             m_screen > 95.0,
             "screen-band median {m_screen} should be > 95.0 threshold"
@@ -7370,7 +7414,7 @@ mod tests {
         // (keep the pixel-domain loss term — strategy search benefits).
         let photo: Vec<f32> = (0..(64 * 64)).map(|i| 5.0 + (i % 35) as f32).collect();
         assert!(
-            !pixel_loss_auto_should_skip(&photo, 64, 64, 64),
+            !pixel_loss_auto_should_skip(&photo, 64, 64, 64, None).unwrap(),
             "photo-band content should keep pixel-domain loss"
         );
 
@@ -7379,14 +7423,14 @@ mod tests {
         // bokeh). Should skip.
         let smooth: Vec<f32> = vec![85.0; 64 * 64];
         assert!(
-            pixel_loss_auto_should_skip(&smooth, 64, 64, 64),
+            pixel_loss_auto_should_skip(&smooth, 64, 64, 64, None).unwrap(),
             "smooth-photo content (median 85 > 80) should skip pixel-domain loss"
         );
 
         // Screenshot-class: median far above the threshold → skip.
         let screen: Vec<f32> = (0..(64 * 64)).map(|i| 110.0 + (i % 30) as f32).collect();
         assert!(
-            pixel_loss_auto_should_skip(&screen, 64, 64, 64),
+            pixel_loss_auto_should_skip(&screen, 64, 64, 64, None).unwrap(),
             "screenshot-band content (median ~125 > 80) should skip pixel-domain loss"
         );
 
@@ -7394,12 +7438,12 @@ mod tests {
         // (the `>` comparator excludes the boundary).
         let at_threshold: Vec<f32> = vec![PIXEL_LOSS_DISPATCH_MEDIAN_THRESHOLD; 64 * 64];
         assert!(
-            !pixel_loss_auto_should_skip(&at_threshold, 64, 64, 64),
+            !pixel_loss_auto_should_skip(&at_threshold, 64, 64, 64, None).unwrap(),
             "median exactly at 80 should NOT skip (strict `>`)"
         );
         let just_above: Vec<f32> = vec![PIXEL_LOSS_DISPATCH_MEDIAN_THRESHOLD + 0.1; 64 * 64];
         assert!(
-            pixel_loss_auto_should_skip(&just_above, 64, 64, 64),
+            pixel_loss_auto_should_skip(&just_above, 64, 64, 64, None).unwrap(),
             "median 80.1 (just above strict threshold) should skip"
         );
     }

--- a/jxl-encoder/src/vardct/lf_frame.rs
+++ b/jxl-encoder/src/vardct/lf_frame.rs
@@ -300,6 +300,7 @@ pub(crate) fn encode_lf_frame(
             Some(factors.dc_quant),
             Some(lossy_opts),
             false, // no palette for lossy LfFrame
+            budget,
         )?;
 
         let section_data = section_writer.finish();
@@ -323,6 +324,7 @@ pub(crate) fn encode_lf_frame(
             ysize_blocks,
             use_ans,
             writer,
+            budget,
         )?;
     }
 
@@ -339,6 +341,7 @@ pub(crate) fn encode_lf_frame(
 /// - Sections 1..num_lf_groups: LfGroup (empty for modular)
 /// - Section num_lf_groups+1: HfGlobal (empty for modular)
 /// - Sections num_lf_groups+2..: PassGroup (modular data per group)
+#[allow(clippy::too_many_arguments)]
 fn encode_lf_frame_multi_group(
     image: &ModularImage,
     factors: &DcQuantFactors,
@@ -347,6 +350,7 @@ fn encode_lf_frame_multi_group(
     ysize_blocks: usize,
     _use_ans: bool,
     writer: &mut BitWriter,
+    budget: Option<&alloc::sync::Arc<crate::budget::MemoryBudget>>,
 ) -> Result<()> {
     use crate::modular::encode::write_group_modular_section_idx;
     use crate::modular::section::{
@@ -390,6 +394,7 @@ fn encode_lf_frame_multi_group(
         Some(factors.dc_quant),
         None, // no ChannelCompact meta-channels for LfFrame
         crate::modular::section::modular_hf_stream_id_base(num_lf_groups as u32),
+        budget,
     )?;
     let lf_global_data = lf_global_writer.finish();
 
@@ -413,6 +418,7 @@ fn encode_lf_frame_multi_group(
                     + group_idx as u32,
                 &GroupTransforms::none(),
                 &mut group_writer,
+                budget,
             )?;
             pass_group_data.push(group_writer.finish());
         }

--- a/jxl-encoder/src/vardct/patches.rs
+++ b/jxl-encoder/src/vardct/patches.rs
@@ -879,8 +879,9 @@ pub(crate) fn find_text_like_patches(
     height: usize,
     stride: usize,
     is_xyb: bool,
-) -> Vec<PatchInfo> {
-    find_text_like_patches_with_min_peak(xyb, width, height, stride, is_xyb, MIN_PEAK)
+    budget: Option<&alloc::sync::Arc<crate::budget::MemoryBudget>>,
+) -> crate::error::Result<Vec<PatchInfo>> {
+    find_text_like_patches_with_min_peak(xyb, width, height, stride, is_xyb, MIN_PEAK, budget)
 }
 
 /// Variant of [`find_text_like_patches`] that lets the caller override the
@@ -890,6 +891,7 @@ pub(crate) fn find_text_like_patches(
 /// `min_peak == 2` matches libjxl `enc_patch_dictionary.cc` exactly
 /// (drops all-{-1, 0, +1} patches). `min_peak == 1` matches W2-5 chunk 1
 /// (accepts low-contrast anti-aliased glyph edges).
+#[allow(clippy::too_many_arguments)]
 pub(crate) fn find_text_like_patches_with_min_peak(
     xyb: [&[f32]; 3],
     width: usize,
@@ -897,7 +899,8 @@ pub(crate) fn find_text_like_patches_with_min_peak(
     stride: usize,
     is_xyb: bool,
     min_peak: i32,
-) -> Vec<PatchInfo> {
+    budget: Option<&alloc::sync::Arc<crate::budget::MemoryBudget>>,
+) -> crate::error::Result<Vec<PatchInfo>> {
     let cs = if is_xyb {
         PatchColorspaceInfo::xyb()
     } else {
@@ -906,8 +909,11 @@ pub(crate) fn find_text_like_patches_with_min_peak(
     let bw = width / PATCH_SIDE;
     let bh = height / PATCH_SIDE;
     if bw < 3 || bh < 3 {
-        return Vec::new();
+        return Ok(Vec::new());
     }
+    // Runtime fallible-alloc policy flag for the dimension-driven (`stride *
+    // height`) BFS buffers below; byte-identical when infallible.
+    let fallible = budget.is_some_and(|b| b.is_fallible());
 
     let xyb_ref = [xyb[0], xyb[1], xyb[2]];
     let n = stride * height;
@@ -967,18 +973,28 @@ pub(crate) fn find_text_like_patches_with_min_peak(
     );
 
     if num_seeds == 0 {
-        return Vec::new();
+        return Ok(Vec::new());
     }
 
     // Step 3: BFS background flood-fill with (current, source) pairs.
     // Each background pixel stores its seed's opsin color in the background image.
     // Source propagates unchanged through BFS — Manhattan distance is from source.
-    let mut is_background = vec![false; n];
-    let mut background = [vec![0.0f32; n], vec![0.0f32; n], vec![0.0f32; n]];
+    // These `n = stride * height` planes (~13 MB at 1 MP for the 3 f32 + 2 bool
+    // buffers) are the largest patches-detection allocations; route them through
+    // the runtime fallible-alloc policy. `try_alloc_zeroed_permanent(None, n)`
+    // zeroes exactly like `vec![v; n]`, so byte-identical on the infallible path.
+    let mut is_background = crate::budget::try_alloc_zeroed_permanent::<bool>(budget, n)?;
+    let mut background = [
+        crate::budget::try_alloc_zeroed_permanent::<f32>(budget, n)?,
+        crate::budget::try_alloc_zeroed_permanent::<f32>(budget, n)?,
+        crate::budget::try_alloc_zeroed_permanent::<f32>(budget, n)?,
+    ];
     // Queue entries: (cur_x, cur_y, src_x, src_y) as u32 to match libjxl's
     // std::pair<XY, XY> (16 bytes vs 32 bytes with usize — halves cache pressure).
-    let mut queue: Vec<(u32, u32, u32, u32)> =
-        Vec::with_capacity(2 * num_seeds as usize * PATCH_SIDE * PATCH_SIDE);
+    let mut queue: Vec<(u32, u32, u32, u32)> = crate::budget::vec_with_capacity_fallible(
+        fallible,
+        2 * num_seeds as usize * PATCH_SIDE * PATCH_SIDE,
+    )?;
 
     // Seed from screenshot-like block pixels
     for by in 1..bh.saturating_sub(1) {
@@ -1105,7 +1121,9 @@ pub(crate) fn find_text_like_patches_with_min_peak(
     // Step 4: Extract foreground connected components (8-connected DFS).
     // Track border consistency: first background neighbor = reference,
     // all subsequent must match reference via background image colors.
-    let mut visited = vec![false; n];
+    // `n = stride * height` (~1 MB bool plane at 1 MP) — same fallible-alloc
+    // policy as the BFS planes above; byte-identical when infallible.
+    let mut visited = crate::budget::try_alloc_zeroed_permanent::<bool>(budget, n)?;
     let mut patches: Vec<(QuantizedPatch, u32, u32)> = Vec::new();
 
     // Diagnostic counters (zero-cost when debug-rect is disabled)
@@ -1589,10 +1607,10 @@ pub(crate) fn find_text_like_patches_with_min_peak(
         .max()
         .unwrap_or(0);
     if max_patch_pixels < MIN_MAX_PATCH_SIZE {
-        return Vec::new();
+        return Ok(Vec::new());
     }
 
-    result
+    Ok(result)
 }
 
 // ── Bin Packing ────────────────────────────────────────────────────────────────
@@ -2053,7 +2071,13 @@ pub fn find_and_build_with_min_peak(
     stride: usize,
     min_peak: i32,
 ) -> Option<PatchesData> {
-    find_and_build_with_per_patch_gate(xyb, width, height, stride, min_peak, None, true)
+    // Public calibration/GPU-helper entry — no `MemoryBudget` (infallible
+    // alloc path). `find_and_build_with_per_patch_gate` only returns `Err`
+    // here on an allocation-size `usize` overflow (the same condition that
+    // would abort the underlying `vec!` today), so unwrapping preserves the
+    // historical `Option`-returning contract without changing the public API.
+    find_and_build_with_per_patch_gate(xyb, width, height, stride, min_peak, None, true, None)
+        .expect("patches detection allocation overflow (infallible path)")
 }
 
 /// Variant of [`find_and_build_with_min_peak`] that, when `distance` is
@@ -2085,6 +2109,7 @@ pub fn find_and_build_with_min_peak(
 /// When `distance` is `None`, behaviour is identical to the
 /// no-per-patch path (back-compat for downstream `__pre_quantized`
 /// callers that hand us pre-detected infos and run their own gate).
+#[allow(clippy::too_many_arguments)]
 pub fn find_and_build_with_per_patch_gate(
     xyb: [&[f32]; 3],
     width: usize,
@@ -2093,11 +2118,13 @@ pub fn find_and_build_with_per_patch_gate(
     min_peak: i32,
     distance: Option<f32>,
     use_ans: bool,
-) -> Option<PatchesData> {
-    let infos = find_text_like_patches_with_min_peak(xyb, width, height, stride, true, min_peak);
+    budget: Option<&alloc::sync::Arc<crate::budget::MemoryBudget>>,
+) -> crate::error::Result<Option<PatchesData>> {
+    let infos =
+        find_text_like_patches_with_min_peak(xyb, width, height, stride, true, min_peak, budget)?;
     if infos.is_empty() {
         debug_rect!("patches/detect", 0, 0, width, height, "no patches detected");
-        return None;
+        return Ok(None);
     }
 
     // Compute coverage statistics before building
@@ -2155,10 +2182,15 @@ pub fn find_and_build_with_per_patch_gate(
         );
         #[cfg(feature = "debug-tokens")]
         eprintln!("PATCHES: skipping — too little coverage ({coverage_pct:.1}% < 1%)");
-        return None;
+        return Ok(None);
     }
 
-    let patches_data = build_patches_data(infos)?;
+    // `build_patches_data` returns `None` when there's nothing to build —
+    // surface that as `Ok(None)` (no patches), preserving the original
+    // Option-`?` short-circuit semantics now that the fn returns `Result`.
+    let Some(patches_data) = build_patches_data(infos) else {
+        return Ok(None);
+    };
 
     #[cfg(feature = "debug-tokens")]
     eprintln!(
@@ -2183,7 +2215,11 @@ pub fn find_and_build_with_per_patch_gate(
     // does not beat their `pixels * empirical_bpp + occurrences * 5`
     // overhead. Then rebuild from the survivors.
     let patches_data = if let Some(d) = distance {
-        apply_per_patch_cost_gate(patches_data, d, use_ans, width, height)?
+        // Cost gate may reject all survivors (`None`) → `Ok(None)`.
+        let Some(gated) = apply_per_patch_cost_gate(patches_data, d, use_ans, width, height) else {
+            return Ok(None);
+        };
+        gated
     } else {
         patches_data
     };
@@ -2209,7 +2245,7 @@ pub fn find_and_build_with_per_patch_gate(
         patches_data.positions.len()
     );
 
-    Some(patches_data)
+    Ok(Some(patches_data))
 }
 
 /// Apply per-patch cost decision. The empirical winning configuration
@@ -2416,9 +2452,10 @@ pub(crate) fn find_and_build_lossless(
     height: usize,
     num_channels: usize,
     bit_depth: u32,
-) -> Option<PatchesData> {
+    budget: Option<&alloc::sync::Arc<crate::budget::MemoryBudget>>,
+) -> crate::error::Result<Option<PatchesData>> {
     if width < 16 || height < 16 || num_channels < 3 {
-        return None;
+        return Ok(None);
     }
 
     let max_val = ((1u32 << bit_depth) - 1) as f32;
@@ -2434,10 +2471,17 @@ pub(crate) fn find_and_build_lossless(
     // image is f32 until `quantize_ref_image_rgb` snaps it to the
     // integer grid at `bit_depth`, and subtraction happens in integer
     // space — so full-precision planes are all 16-bit needed.
-    let mut planes = [vec![0.0f32; n], vec![0.0f32; n], vec![0.0f32; n]];
+    // These 3 `n = width * height` f32 planes are dimension-driven (>1 MB at
+    // ≥1 MP) — route through the runtime fallible-alloc policy. Zeroed exactly
+    // like `vec![0.0; n]`, so byte-identical on the infallible path.
+    let mut planes = [
+        crate::budget::try_alloc_zeroed_permanent::<f32>(budget, n)?,
+        crate::budget::try_alloc_zeroed_permanent::<f32>(budget, n)?,
+        crate::budget::try_alloc_zeroed_permanent::<f32>(budget, n)?,
+    ];
     if bit_depth > 8 {
         if pixels.len() < n * num_channels * 2 {
-            return None;
+            return Ok(None);
         }
         for i in 0..n {
             let base = (i * num_channels) * 2;
@@ -2462,9 +2506,10 @@ pub(crate) fn find_and_build_lossless(
         height,
         width,
         false, // RGB colorspace
-    );
+        budget,
+    )?;
     if infos.is_empty() {
-        return None;
+        return Ok(None);
     }
 
     // Coverage filter (same as lossy)
@@ -2474,16 +2519,20 @@ pub(crate) fn find_and_build_lossless(
         .sum();
     let image_pixels = width * height;
     if total_patch_pixels * 100 < image_pixels {
-        return None;
+        return Ok(None);
     }
 
-    let mut patches_data = build_patches_data(infos)?;
+    // `None` here means nothing to build → `Ok(None)` (preserves the original
+    // Option-`?` short-circuit now that the fn returns `Result`).
+    let Some(mut patches_data) = build_patches_data(infos) else {
+        return Ok(None);
+    };
 
     // Roundtrip ref image through integer quantization to match decoder.
     // For non-XYB: round(v * max_val) / max_val for each channel.
     quantize_ref_image_rgb(&mut patches_data, bit_depth);
 
-    Some(patches_data)
+    Ok(Some(patches_data))
 }
 
 /// Roundtrip reference image through integer quantization for non-XYB (lossless).
@@ -3085,7 +3134,7 @@ mod tests {
                 b[i] = (px as f32 + py as f32) / (w + h) as f32;
             }
         }
-        let result = find_text_like_patches([&x, &y, &b], w, h, w, true);
+        let result = find_text_like_patches([&x, &y, &b], w, h, w, true, None).unwrap();
         assert!(result.is_empty(), "Photos should produce no patches");
     }
 
@@ -3122,7 +3171,7 @@ mod tests {
             }
         }
 
-        let result = find_text_like_patches([&x, &y, &b], w, h, w, true);
+        let result = find_text_like_patches([&x, &y, &b], w, h, w, true, None).unwrap();
         // Should find at least one patch group with >= 2 occurrences
         // Note: the exact number depends on detection thresholds
         if !result.is_empty() {
@@ -3161,7 +3210,7 @@ mod tests {
         let mut b_out = vec![0.0f32; n];
         crate::color::xyb::srgb_image_to_xyb(&r, &g, &b, &mut x_out, &mut y_out, &mut b_out);
 
-        let result = find_text_like_patches([&x_out, &y_out, &b_out], w, h, w, true);
+        let result = find_text_like_patches([&x_out, &y_out, &b_out], w, h, w, true, None).unwrap();
         let patches_data = build_patches_data(result).unwrap();
 
         let ref_w = patches_data.ref_width;
@@ -3256,7 +3305,7 @@ mod tests {
         crate::color::xyb::srgb_image_to_xyb(&r, &g, &b, &mut x_out, &mut y_out, &mut b_out);
 
         // Run detection (eprintln stats from cfg(test) instrumentation)
-        let result = find_text_like_patches([&x_out, &y_out, &b_out], w, h, w, true);
+        let result = find_text_like_patches([&x_out, &y_out, &b_out], w, h, w, true, None).unwrap();
 
         // Print size distribution
         let mut size_dist: std::collections::HashMap<(usize, usize), (usize, usize)> =
@@ -3291,7 +3340,8 @@ mod tests {
 
         // Analyze near-miss dedup: find singletons that are close to popular patterns
         // Count singleton dimensions
-        let _all_patches = find_text_like_patches([&x_out, &y_out, &b_out], w, h, w, true);
+        let _all_patches =
+            find_text_like_patches([&x_out, &y_out, &b_out], w, h, w, true, None).unwrap();
         // Re-run to get raw CCs with their positions (need to access raw data)
         // For now, just analyze the final result's dimension distribution
         eprintln!("\nAnalyzing dedup quality...");

--- a/jxl-encoder/src/vardct/precomputed.rs
+++ b/jxl-encoder/src/vardct/precomputed.rs
@@ -412,7 +412,13 @@ impl EncoderPrecomputed {
         // released early so peak working-set doesn't include it.
         if matches!(pixel_loss_dispatch, crate::api::PixelLossDispatch::Auto)
             && let Some(ref m) = mask1x1_after_fill
-            && super::encoder::pixel_loss_auto_should_skip(m, global.padded_width, width, height)
+            && super::encoder::pixel_loss_auto_should_skip(
+                m,
+                global.padded_width,
+                width,
+                height,
+                budget,
+            )?
         {
             mask1x1_after_fill = None;
         }
@@ -876,7 +882,8 @@ impl EncoderPrecomputedGlobal {
                 min_peak,
                 Some(distance),
                 use_ans,
-            )
+                budget,
+            )?
         } else {
             None
         };


### PR DESCRIPTION
Completes the >1 MB fallible-alloc sweep (after #78/#88) with the three remaining large sites — the ones #88 honest-stopped as deep-threading. All **byte-identical** on the default infallible path (`vec_with_capacity_fallible(false, n)` == `Vec::with_capacity(n)`).

### Sites wired
- **AQ mask** (`encoder::median_mask1x1`/`percentile_mask1x1`, `width·height` f32, **4–50 MB on every lossy encode**) → `Result<f32>` + budget; cascaded through `pixel_loss_auto_should_skip` (`Result<bool>`) and its `encode_inner`/`bitstream`/`precomputed` callers (`.map().transpose()?`, `?` in `&&` gates).
- **Patches detection** (`find_text_like_patches{,_with_min_peak}` + `find_and_build_lossless`: BFS queue + 3 background f32 planes + bool planes, `stride·height`, **~13 MB at 1 MP**) → `Result<…>` + budget from the VarDCT + lossless encode paths. Public calibration wrappers keep `Option` signatures (call inner with `None`).
- **lz77-optimal** (`apply_lz77_optimal`'s `prefix_costs` + `out`, `O(token_count)`, **multi-MB→10s of MB at lossless e9+**) → `vec_with_capacity_fallible`; budget threaded through `apply_lz77` and the `pub(crate)` modular wrapper stack down to `FrameEncoder.budget`, `bitstream::encode_two_pass_to_writer` (`self.budget`), `icc.rs` → `None` (small).

This means every encoder allocation that can exceed ~1 MB now honors `Limits::with_fallible_alloc` + the `MemoryBudget` cap. Sub-1 MB / fixed buffers stay infallible by design.

### Verification
- **hash-locks 48/48** (byte-identical default path)
- **full 1986 lib+it tests pass**
- clippy `-D warnings` clean (default + `jpeg-reencoding` + `zensim-loop`), fmt clean
- No gate/constant/algorithm change → `LIBJXL_DIVERGENCES.md` N/A

2 commits: AQ-mask+patches, then lz77.