### PR TITLE
Fix #80 (with_effort field-clobber footgun) + #82 (brotli alloc-no-stdlib pin)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -189,6 +189,21 @@
   `write_u32_jbrd_no_selector_match_is_typed_error` (jbrd).
 
 ### Fixed
+- **Test builds: pin `alloc-stdlib` so `alloc-no-stdlib` stays on 2.x (#82).**
+  `brotli` (a dev-dep via `zenjxl-decoder`, plus our optional `brotli-metadata`
+  dep) provides `impl BrotliAlloc for StandardAlloc`, where `StandardAlloc`
+  comes from `alloc-stdlib` and impls `alloc_no_stdlib::Allocator`. When
+  `alloc-stdlib 0.2.3` loosened its `alloc-no-stdlib` range to `>=2.0.4, <4.0`,
+  a fresh (non-`--locked`) resolve pulled `alloc-no-stdlib 3.0.0` for
+  `StandardAlloc` while `brotli` stayed on the 2.x trait → `E0277` mismatch
+  that broke **every** test build (the `hash_lock_features` / byte-lock gate
+  was down from ~2026-06-14). Upstream is now fixed (`alloc-stdlib 0.2.4`
+  re-tightened to `<3.0`; `brotli 8.0.4` added the same caps), but the durable
+  guard is a Cargo.toml constraint, not the lockfile: `jxl-encoder`'s
+  dev-dependencies now pin `alloc-stdlib = "0.2.4"`, which keeps
+  `alloc-no-stdlib` on 2.x even under a fresh `--locked`-less resolve and
+  blocks the 3.x-pulling `0.3.x`. Verified: `cargo tree -i alloc-no-stdlib`
+  shows only `2.0.4`, and `cargo test -p jxl-encoder --lib --no-run` compiles.
 - **Cooperative cancellation now aborts on every VarDCT entropy path (#77
   item 2 / #81).** `#81` wired per-DC/AC-group `Stop` checkpoints into
   `VarDctEncoder::encode_inner`, but they lived only in the multi-group

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -189,6 +189,27 @@
   `write_u32_jbrd_no_selector_match_is_typed_error` (jbrd).
 
 ### Fixed
+- **`with_effort()` no longer silently discards builder settings placed
+  before it in the chain (#80).** `LossyConfig::with_effort` /
+  `LosslessConfig::with_effort` rebuild the config from the effort profile
+  and previously preserved only a hand-picked field list, so any other
+  setter called *before* `with_effort` was dropped — e.g.
+  `LossyConfig::new(1.0).with_ans(false).with_effort(7)` silently lost
+  `with_ans(false)`. Extended the existing `auto_splines_explicit` /
+  `patches_explicit` / `tree_learning_user_set` touched-tracking pattern
+  with private `*_explicit` flags so `with_effort` preserves a value only
+  when its setter was actually called; the builder chain is now
+  order-independent. Now-preserved across `with_effort`: on `LossyConfig`
+  — `with_ans`, `with_gaborish`, `with_error_diffusion`,
+  `with_pixel_domain_loss`, `with_lz77`, `with_lz77_method` (and the
+  gaborish/pixel-domain-loss knobs that `with_perceptual_optimizations`
+  sets, matching its pre-existing patches pin); on `LosslessConfig` —
+  `with_ans`, `with_patches`, `with_lz77`, `with_lz77_method`, and
+  `with_tree_learning` (whose `tree_learning_user_set` flag existed but
+  was not honored by `with_effort`). The untouched common
+  `new().with_effort(N)` path keeps adopting the effort default and stays
+  byte-identical (hash-locks 48/48). New test
+  `tests/it/with_effort_preserves_explicit.rs`.
 - **Test builds: pin `alloc-stdlib` so `alloc-no-stdlib` stays on 2.x (#82).**
   `brotli` (a dev-dep via `zenjxl-decoder`, plus our optional `brotli-metadata`
   dep) provides `impl BrotliAlloc for StandardAlloc`, where `StandardAlloc`

--- a/jxl-encoder/Cargo.toml
+++ b/jxl-encoder/Cargo.toml
@@ -338,6 +338,17 @@ path = "examples/hdr_tree_budget_probe.rs"
 required-features = ["__expert"]
 
 [dev-dependencies]
+# Transitive-version pin (#82), NOT used directly. `brotli` (a dev-dep via
+# `zenjxl-decoder`, and our own optional `brotli-metadata` dep) pulls
+# `alloc-stdlib`, which provides `StandardAlloc: alloc_no_stdlib::Allocator`.
+# `alloc-stdlib 0.2.3` loosened its `alloc-no-stdlib` range to `>=2.0.4, <4.0`,
+# so a fresh (non-`--locked`) resolve pulled `alloc-no-stdlib 3.0.0` for
+# `StandardAlloc` while `brotli` stayed on the 2.x trait → E0277 trait mismatch
+# that broke EVERY test build (byte-lock gate down ~2026-06-14). `0.2.4`
+# re-tightened the range to `<3.0`. Pinning to the `0.2.4`+ line (and thereby
+# excluding the 3.x-pulling `0.3.x`) keeps `alloc-no-stdlib` on 2.x in
+# Cargo.toml — durable regardless of `--locked` or future upstream drift.
+alloc-stdlib = "0.2.4"
 image = "0.25"
 # jxl-rs (github.com/lilith/jxl-rs) is the PRIMARY decoder for roundtrip tests
 jxl = "0.4.0"

--- a/jxl-encoder/src/api.rs
+++ b/jxl-encoder/src/api.rs
@@ -2147,6 +2147,11 @@ pub struct LosslessConfig {
     effort: u8,
     mode: EncoderMode,
     use_ans: bool,
+    /// `true` once [`Self::with_ans`] was called explicitly. Mirrors the
+    /// `tree_learning_user_set` pattern so `with_effort` preserves a
+    /// caller-set `use_ans` instead of re-adopting the effort default
+    /// (issue #80).
+    use_ans_explicit: bool,
     squeeze: bool,
     tree_learning: bool,
     /// True once the caller has explicitly chosen via
@@ -2154,8 +2159,20 @@ pub struct LosslessConfig {
     /// e5/e6 budgeted-tree lift (same pattern as `patches_user_set`).
     tree_learning_user_set: bool,
     lz77: bool,
+    /// `true` once [`Self::with_lz77`] was called explicitly. Mirrors the
+    /// `tree_learning_user_set` pattern so `with_effort` preserves a
+    /// caller-set `lz77` (issue #80).
+    lz77_explicit: bool,
     lz77_method: Lz77Method,
+    /// `true` once [`Self::with_lz77_method`] was called explicitly.
+    /// Mirrors the `tree_learning_user_set` pattern so `with_effort`
+    /// preserves a caller-set `lz77_method` (issue #80).
+    lz77_method_explicit: bool,
     patches: bool,
+    /// `true` once [`Self::with_patches`] was called explicitly. Mirrors
+    /// the `tree_learning_user_set` pattern so `with_effort` preserves a
+    /// caller-set `patches` (issue #80).
+    patches_explicit: bool,
     lossy_palette: bool,
     threads: usize,
     /// Override for the effort-derived tree-learning sample fraction
@@ -2319,12 +2336,16 @@ impl LosslessConfig {
             effort: profile.effort,
             mode: EncoderMode::Reference,
             use_ans: profile.use_ans,
+            use_ans_explicit: false,
             tree_learning: profile.tree_learning,
             tree_learning_user_set: false,
             squeeze: false, // squeeze hurts even with tree learning (14-62% larger on both photos and screenshots)
             lz77: profile.lz77,
+            lz77_explicit: false,
             lz77_method: profile.lz77_method,
+            lz77_method_explicit: false,
             patches: profile.patches,
+            patches_explicit: false,
             lossy_palette: false,
             threads: 0,
             tree_sample_fraction_override: None,
@@ -2811,6 +2832,32 @@ impl LosslessConfig {
         new.profile_override = self.profile_override;
         new.tree_parallel_smart = self.tree_parallel_smart;
         new.small_image_fallback_override = self.small_image_fallback_override;
+        // Issue #80: preserve explicitly-set effort-derived knobs across
+        // `with_effort`. Each defaults from the effort profile in `new`,
+        // so an untouched config (the common `new().with_effort(N)` path)
+        // keeps `*_explicit`/`*_user_set == false` and adopts the effort
+        // value exactly as before — byte-identical. A caller that *did*
+        // set the value now keeps it, making the chain order-independent.
+        if self.use_ans_explicit {
+            new.use_ans = self.use_ans;
+            new.use_ans_explicit = true;
+        }
+        if self.tree_learning_user_set {
+            new.tree_learning = self.tree_learning;
+            new.tree_learning_user_set = true;
+        }
+        if self.lz77_explicit {
+            new.lz77 = self.lz77;
+            new.lz77_explicit = true;
+        }
+        if self.lz77_method_explicit {
+            new.lz77_method = self.lz77_method;
+            new.lz77_method_explicit = true;
+        }
+        if self.patches_explicit {
+            new.patches = self.patches;
+            new.patches_explicit = true;
+        }
         // Buffering policy — never effort-derived; pure caller
         // preference. Carry across `with_effort` so the builder chain
         // `LosslessConfig::new().with_buffering(_).with_effort(_)` is
@@ -2843,12 +2890,14 @@ impl LosslessConfig {
     /// not change lossless output bytes today.
     pub fn with_patches(mut self, enable: bool) -> Self {
         self.patches = enable;
+        self.patches_explicit = true;
         self
     }
 
     /// Enable/disable ANS entropy coding (default: true).
     pub fn with_ans(mut self, enable: bool) -> Self {
         self.use_ans = enable;
+        self.use_ans_explicit = true;
         self
     }
 
@@ -2981,6 +3030,7 @@ impl LosslessConfig {
     /// lossless output bytes today.
     pub fn with_lz77(mut self, enable: bool) -> Self {
         self.lz77 = enable;
+        self.lz77_explicit = true;
         self
     }
 
@@ -2991,6 +3041,7 @@ impl LosslessConfig {
     /// (jxl-encoder#69): on that path this is stored but unused today.
     pub fn with_lz77_method(mut self, method: Lz77Method) -> Self {
         self.lz77_method = method;
+        self.lz77_method_explicit = true;
         self
     }
 
@@ -4635,7 +4686,16 @@ pub struct LossyConfig {
     effort: u8,
     mode: EncoderMode,
     use_ans: bool,
+    /// `true` once [`Self::with_ans`] was called explicitly. Mirrors the
+    /// `patches_explicit` / `auto_splines_explicit` pattern so that
+    /// `with_effort` preserves a caller-set `use_ans` instead of
+    /// re-adopting the effort-derived default (issue #80).
+    use_ans_explicit: bool,
     gaborish: bool,
+    /// `true` once [`Self::with_gaborish`] was called explicitly.
+    /// Mirrors the `auto_splines_explicit` pattern so `with_effort`
+    /// preserves a caller-set `gaborish` (issue #80).
+    gaborish_explicit: bool,
     /// EX-J13 — per-tile contrast-adaptive gaborish kernel strength.
     /// Encoder-only; decoder always applies the fixed 3x3 inverse blur.
     /// Default `false`. See [`Self::with_adaptive_gaborish`].
@@ -4660,9 +4720,25 @@ pub struct LossyConfig {
     original_distance: Option<f32>,
     denoise: bool,
     error_diffusion: bool,
+    /// `true` once [`Self::with_error_diffusion`] was called explicitly.
+    /// Mirrors the `auto_splines_explicit` pattern so `with_effort`
+    /// preserves a caller-set `error_diffusion` (issue #80).
+    error_diffusion_explicit: bool,
     pixel_domain_loss: bool,
+    /// `true` once [`Self::with_pixel_domain_loss`] was called explicitly.
+    /// Mirrors the `auto_splines_explicit` pattern so `with_effort`
+    /// preserves a caller-set `pixel_domain_loss` (issue #80).
+    pixel_domain_loss_explicit: bool,
     lz77: bool,
+    /// `true` once [`Self::with_lz77`] was called explicitly. Mirrors
+    /// the `auto_splines_explicit` pattern so `with_effort` preserves a
+    /// caller-set `lz77` (issue #80).
+    lz77_explicit: bool,
     lz77_method: Lz77Method,
+    /// `true` once [`Self::with_lz77_method`] was called explicitly.
+    /// Mirrors the `auto_splines_explicit` pattern so `with_effort`
+    /// preserves a caller-set `lz77_method` (issue #80).
+    lz77_method_explicit: bool,
     force_strategy: Option<u8>,
     max_strategy_size: Option<u8>,
     patches: bool,
@@ -5333,7 +5409,9 @@ impl LossyConfig {
             effort: profile.effort,
             mode: EncoderMode::Reference,
             use_ans: profile.use_ans,
+            use_ans_explicit: false,
             gaborish: profile.gaborish,
+            gaborish_explicit: false,
             adaptive_gaborish: false,
             noise: false,
             photon_noise_iso: None,
@@ -5342,9 +5420,13 @@ impl LossyConfig {
             original_distance: None,
             denoise: false,
             error_diffusion: profile.error_diffusion,
+            error_diffusion_explicit: false,
             pixel_domain_loss: profile.pixel_domain_loss,
+            pixel_domain_loss_explicit: false,
             lz77: profile.lz77,
+            lz77_explicit: false,
             lz77_method: profile.lz77_method,
+            lz77_method_explicit: false,
             force_strategy: None,
             max_strategy_size: None,
             patches: profile.patches,
@@ -5782,6 +5864,37 @@ impl LossyConfig {
             new.auto_splines = self.auto_splines;
             new.auto_splines_explicit = true;
         }
+        // Issue #80: preserve explicitly-set effort-derived knobs across
+        // `with_effort`. Each defaults from the effort profile in `new`,
+        // so an untouched config (the common `new().with_effort(N)` path)
+        // keeps `*_explicit == false` and adopts the effort value exactly
+        // as before — byte-identical. A caller that *did* set the value
+        // (e.g. `with_ans(false).with_effort(7)`) now keeps it, making
+        // the builder chain order-independent.
+        if self.use_ans_explicit {
+            new.use_ans = self.use_ans;
+            new.use_ans_explicit = true;
+        }
+        if self.gaborish_explicit {
+            new.gaborish = self.gaborish;
+            new.gaborish_explicit = true;
+        }
+        if self.error_diffusion_explicit {
+            new.error_diffusion = self.error_diffusion;
+            new.error_diffusion_explicit = true;
+        }
+        if self.pixel_domain_loss_explicit {
+            new.pixel_domain_loss = self.pixel_domain_loss;
+            new.pixel_domain_loss_explicit = true;
+        }
+        if self.lz77_explicit {
+            new.lz77 = self.lz77;
+            new.lz77_explicit = true;
+        }
+        if self.lz77_method_explicit {
+            new.lz77_method = self.lz77_method;
+            new.lz77_method_explicit = true;
+        }
         new.progressive = self.progressive;
         // Preserve explicit butteraugli override
         #[cfg(feature = "butteraugli-loop")]
@@ -5873,12 +5986,14 @@ impl LossyConfig {
     /// Enable/disable ANS entropy coding (default: true).
     pub fn with_ans(mut self, enable: bool) -> Self {
         self.use_ans = enable;
+        self.use_ans_explicit = true;
         self
     }
 
     /// Enable/disable gaborish inverse pre-filter (default: true).
     pub fn with_gaborish(mut self, enable: bool) -> Self {
         self.gaborish = enable;
+        self.gaborish_explicit = true;
         self
     }
 
@@ -6142,12 +6257,14 @@ impl LossyConfig {
     /// in dark regions), especially when combined with gaborish.
     pub fn with_error_diffusion(mut self, enable: bool) -> Self {
         self.error_diffusion = enable;
+        self.error_diffusion_explicit = true;
         self
     }
 
     /// Enable/disable pixel-domain loss in strategy selection (default: true).
     pub fn with_pixel_domain_loss(mut self, enable: bool) -> Self {
         self.pixel_domain_loss = enable;
+        self.pixel_domain_loss_explicit = true;
         self
     }
 
@@ -6209,18 +6326,27 @@ impl LossyConfig {
         self.dot_detection = enable; // libjxl `Override::kDefault`; in-encoder effort/distance gates make this niche-only
         self.noise = false; // off by default in libjxl too
         self.pixel_domain_loss = enable;
+        // Issue #80: pin the knobs this convenience wrapper touches so a
+        // following `with_effort` preserves them (matching the existing
+        // `patches_explicit` pin above — otherwise gaborish/pixel-domain
+        // loss would silently revert to the effort default while patches
+        // stuck, an inconsistent half-pin).
+        self.gaborish_explicit = true;
+        self.pixel_domain_loss_explicit = true;
         self
     }
 
     /// Enable/disable LZ77 backward references (default: false).
     pub fn with_lz77(mut self, enable: bool) -> Self {
         self.lz77 = enable;
+        self.lz77_explicit = true;
         self
     }
 
     /// Set LZ77 method (default: Greedy).
     pub fn with_lz77_method(mut self, method: Lz77Method) -> Self {
         self.lz77_method = method;
+        self.lz77_method_explicit = true;
         self
     }
 

--- a/jxl-encoder/tests/it/main.rs
+++ b/jxl-encoder/tests/it/main.rs
@@ -121,6 +121,7 @@ mod w44_63_decoder_roundtrip;
 mod w44_65_decoder_roundtrip;
 mod w44_78_decoder_roundtrip;
 mod w44_phase3_b1_gpu_buttloop_roundtrip;
+mod with_effort_preserves_explicit;
 mod with_patches_data;
 mod zenjxl_regression_gate;
 mod zensim_backend_smoke;

--- a/jxl-encoder/tests/it/with_effort_preserves_explicit.rs
+++ b/jxl-encoder/tests/it/with_effort_preserves_explicit.rs
@@ -1,0 +1,271 @@
+// Copyright (c) Imazen LLC and the JPEG XL Project Authors.
+// Algorithms and constants derived from libjxl (BSD-3-Clause).
+// Licensed under AGPL-3.0-or-later. Commercial licenses at https://www.imazen.io/pricing
+
+//! Regression tests for issue #80: `with_effort()` silently discarded
+//! every builder setting placed BEFORE it in the chain.
+//!
+//! `LossyConfig::with_effort` / `LosslessConfig::with_effort` rebuild the
+//! config from the effort profile and used to preserve only a hand-picked
+//! list of fields. So `LossyConfig::new(1.0).with_ans(false).with_effort(7)`
+//! silently lost `with_ans(false)`.
+//!
+//! The fix mirrors the existing `auto_splines_explicit` / `patches_explicit`
+//! / `tree_learning_user_set` touched-tracking pattern: each effort-derived
+//! field with a public setter now has a private `*_explicit` flag that the
+//! setter flips, and `with_effort` preserves the value when the flag is set.
+//!
+//! These tests assert BOTH directions of the chain produce the explicitly
+//! set value (order-independence), and that the untouched common path keeps
+//! adopting the effort-derived default unchanged (so existing hash-locks
+//! stay byte-identical — proven separately by the hash-lock suite; here we
+//! just pin the default-adoption behaviour at the API level).
+
+use jxl_encoder::{LosslessConfig, LossyConfig, Lz77Method};
+
+// ----------------------------------------------------------------------
+// LossyConfig
+// ----------------------------------------------------------------------
+
+#[test]
+fn lossy_with_ans_survives_with_effort_both_orders() {
+    // setter BEFORE with_effort — the footgun #80 reported.
+    assert!(
+        !LossyConfig::new(1.0).with_ans(false).with_effort(7).ans(),
+        "with_ans(false) before with_effort must be preserved (#80)"
+    );
+    // setter AFTER with_effort — already worked, must keep working.
+    assert!(
+        !LossyConfig::new(1.0).with_effort(7).with_ans(false).ans(),
+        "with_ans(false) after with_effort must be preserved"
+    );
+    // Untouched common path: with_effort adopts the effort default (true).
+    assert!(
+        LossyConfig::new(1.0).with_effort(7).ans(),
+        "untouched config must keep the effort-derived ans default"
+    );
+}
+
+#[test]
+fn lossy_with_gaborish_survives_with_effort_both_orders() {
+    assert!(
+        !LossyConfig::new(1.0)
+            .with_gaborish(false)
+            .with_effort(7)
+            .gaborish(),
+        "with_gaborish(false) before with_effort must be preserved (#80)"
+    );
+    assert!(
+        !LossyConfig::new(1.0)
+            .with_effort(7)
+            .with_gaborish(false)
+            .gaborish(),
+        "with_gaborish(false) after with_effort must be preserved"
+    );
+    assert!(
+        LossyConfig::new(1.0).with_effort(7).gaborish(),
+        "untouched config must keep the effort-derived gaborish default"
+    );
+}
+
+#[test]
+fn lossy_with_error_diffusion_survives_with_effort_both_orders() {
+    // Default error_diffusion is false; flip to true and check it sticks.
+    assert!(
+        LossyConfig::new(1.0)
+            .with_error_diffusion(true)
+            .with_effort(7)
+            .error_diffusion(),
+        "with_error_diffusion(true) before with_effort must be preserved (#80)"
+    );
+    assert!(
+        LossyConfig::new(1.0)
+            .with_effort(7)
+            .with_error_diffusion(true)
+            .error_diffusion(),
+        "with_error_diffusion(true) after with_effort must be preserved"
+    );
+}
+
+#[test]
+fn lossy_with_pixel_domain_loss_survives_with_effort_both_orders() {
+    assert!(
+        !LossyConfig::new(1.0)
+            .with_pixel_domain_loss(false)
+            .with_effort(7)
+            .pixel_domain_loss(),
+        "with_pixel_domain_loss(false) before with_effort must be preserved (#80)"
+    );
+    assert!(
+        !LossyConfig::new(1.0)
+            .with_effort(7)
+            .with_pixel_domain_loss(false)
+            .pixel_domain_loss(),
+        "with_pixel_domain_loss(false) after with_effort must be preserved"
+    );
+}
+
+#[test]
+fn lossy_with_lz77_survives_with_effort_both_orders() {
+    // Pick effort 5 (lz77 default off) and flip on, so the explicit value
+    // genuinely differs from the effort default at that effort.
+    assert!(
+        LossyConfig::new(1.0).with_lz77(true).with_effort(5).lz77(),
+        "with_lz77(true) before with_effort must be preserved (#80)"
+    );
+    assert!(
+        LossyConfig::new(1.0).with_effort(5).with_lz77(true).lz77(),
+        "with_lz77(true) after with_effort must be preserved"
+    );
+    // And the disable direction at an effort where lz77 defaults on (e9).
+    assert!(
+        !LossyConfig::new(1.0).with_lz77(false).with_effort(9).lz77(),
+        "with_lz77(false) before with_effort must be preserved (#80)"
+    );
+}
+
+#[test]
+fn lossy_with_lz77_method_survives_with_effort_both_orders() {
+    assert_eq!(
+        LossyConfig::new(1.0)
+            .with_lz77_method(Lz77Method::Optimal)
+            .with_effort(5)
+            .lz77_method(),
+        Lz77Method::Optimal,
+        "with_lz77_method before with_effort must be preserved (#80)"
+    );
+    assert_eq!(
+        LossyConfig::new(1.0)
+            .with_effort(5)
+            .with_lz77_method(Lz77Method::Optimal)
+            .lz77_method(),
+        Lz77Method::Optimal,
+        "with_lz77_method after with_effort must be preserved"
+    );
+}
+
+#[test]
+fn lossy_perceptual_optimizations_pins_survive_with_effort() {
+    // The convenience wrapper touches gaborish + pixel_domain_loss (+ patches);
+    // #80 pins all of them so a following with_effort keeps them, matching the
+    // pre-existing patches pin.
+    let cfg = LossyConfig::new(1.0)
+        .with_perceptual_optimizations(false)
+        .with_effort(7);
+    assert!(
+        !cfg.gaborish(),
+        "perceptual_optimizations(false) gaborish must survive with_effort"
+    );
+    assert!(
+        !cfg.pixel_domain_loss(),
+        "perceptual_optimizations(false) pixel_domain_loss must survive with_effort"
+    );
+    assert!(
+        !cfg.patches(),
+        "perceptual_optimizations(false) patches must survive with_effort"
+    );
+}
+
+// ----------------------------------------------------------------------
+// LosslessConfig
+// ----------------------------------------------------------------------
+
+#[test]
+fn lossless_with_ans_survives_with_effort_both_orders() {
+    assert!(
+        !LosslessConfig::new().with_ans(false).with_effort(7).ans(),
+        "with_ans(false) before with_effort must be preserved (#80)"
+    );
+    assert!(
+        !LosslessConfig::new().with_effort(7).with_ans(false).ans(),
+        "with_ans(false) after with_effort must be preserved"
+    );
+    assert!(
+        LosslessConfig::new().with_effort(7).ans(),
+        "untouched config must keep the effort-derived ans default"
+    );
+}
+
+#[test]
+fn lossless_with_patches_survives_with_effort_both_orders() {
+    assert!(
+        !LosslessConfig::new()
+            .with_patches(false)
+            .with_effort(7)
+            .patches(),
+        "with_patches(false) before with_effort must be preserved (#80)"
+    );
+    assert!(
+        !LosslessConfig::new()
+            .with_effort(7)
+            .with_patches(false)
+            .patches(),
+        "with_patches(false) after with_effort must be preserved"
+    );
+    // patches default on at e7; off at e3. Untouched config tracks effort.
+    assert!(
+        LosslessConfig::new().with_effort(7).patches(),
+        "untouched config must keep the effort-derived patches default (on at e7)"
+    );
+}
+
+#[test]
+fn lossless_with_tree_learning_survives_with_effort_both_orders() {
+    // tree_learning_user_set existed but with_effort never preserved it (#80).
+    // Enable tree learning at e5 (where it defaults off) and check it sticks.
+    assert!(
+        LosslessConfig::new()
+            .with_tree_learning(true)
+            .with_effort(5)
+            .tree_learning(),
+        "with_tree_learning(true) before with_effort must be preserved (#80)"
+    );
+    assert!(
+        LosslessConfig::new()
+            .with_effort(5)
+            .with_tree_learning(true)
+            .tree_learning(),
+        "with_tree_learning(true) after with_effort must be preserved"
+    );
+    // Disable at e7 (where it defaults on).
+    assert!(
+        !LosslessConfig::new()
+            .with_tree_learning(false)
+            .with_effort(7)
+            .tree_learning(),
+        "with_tree_learning(false) before with_effort must be preserved (#80)"
+    );
+}
+
+#[test]
+fn lossless_with_lz77_survives_with_effort_both_orders() {
+    // lz77 defaults off at e5, on at e7. Flip on at e5.
+    assert!(
+        LosslessConfig::new().with_lz77(true).with_effort(5).lz77(),
+        "with_lz77(true) before with_effort must be preserved (#80)"
+    );
+    assert!(
+        !LosslessConfig::new().with_lz77(false).with_effort(7).lz77(),
+        "with_lz77(false) before with_effort must be preserved (#80)"
+    );
+}
+
+#[test]
+fn lossless_with_lz77_method_survives_with_effort_both_orders() {
+    assert_eq!(
+        LosslessConfig::new()
+            .with_lz77_method(Lz77Method::Optimal)
+            .with_effort(5)
+            .lz77_method(),
+        Lz77Method::Optimal,
+        "with_lz77_method before with_effort must be preserved (#80)"
+    );
+    assert_eq!(
+        LosslessConfig::new()
+            .with_effort(5)
+            .with_lz77_method(Lz77Method::Optimal)
+            .lz77_method(),
+        Lz77Method::Optimal,
+        "with_lz77_method after with_effort must be preserved"
+    );
+}


### PR DESCRIPTION
Two independent issue fixes (one commit each).

## #82 — `alloc-stdlib` pin so `alloc-no-stdlib` stays 2.x (test-build gate)
`brotli` (a dev-dep via `zenjxl-decoder` + our optional `brotli-metadata` dep) impls `BrotliAlloc for StandardAlloc`, where `StandardAlloc` (from `alloc-stdlib`) impls `alloc_no_stdlib::Allocator`. **`alloc-stdlib 0.2.3` loosened its `alloc-no-stdlib` range to `>=2.0.4, <4.0`**, so a fresh (non-`--locked`) resolve pulled `alloc-no-stdlib 3.0.0` for `StandardAlloc` while `brotli` stayed on the 2.x trait → `E0277` that broke **every** test build (#82).

Checked upstream: it's since fixed (`alloc-stdlib 0.2.4` re-tightened to `<3.0`; `brotli 8.0.4` added the same caps) — but the durable guard belongs in **Cargo.toml, not the lockfile/`--locked`**: `jxl-encoder` dev-deps now pin `alloc-stdlib = "0.2.4"`, which keeps `alloc-no-stdlib` on 2.x under any fresh resolve and blocks the 3.x-pulling `0.3.x`. (Pinning `alloc-no-stdlib` directly wouldn't help — the 3.x major coexists via `alloc-stdlib`'s edge.)
Verified: `cargo tree -i alloc-no-stdlib` → only `2.0.4`; `cargo test -p jxl-encoder --lib --no-run` compiles.

## #80 — `with_effort()` no longer silently discards explicitly-set fields
`with_effort()` rebuilt the config from the effort profile and preserved only a hand-picked field list, so anything set **before** it in the chain was dropped (`new(1.0).with_ans(false).with_effort(7)` lost the `with_ans(false)`). Extended the codebase's existing `*_explicit`/`*_user_set` touched-tracking pattern to the effort-derived fields that had a setter but no flag:
- **Lossy:** `use_ans`, `gaborish`, `error_diffusion`, `pixel_domain_loss`, `lz77`, `lz77_method`.
- **Lossless:** `use_ans`, `patches`, `lz77`, `lz77_method`; plus `with_effort` now honors the already-existing `tree_learning_user_set`.

`with_effort` is now **order-independent**; flags are private (no public API change). **Byte-identical common path** (nothing set before `with_effort` → all flags `false` → effort values adopted exactly as before). New `tests/it/with_effort_preserves_explicit.rs` (12 tests) asserts order-independence both ways + pins the untouched common path.

## Verification (both commits)
- **hash-locks 48/48** (byte-identical), **full 1998 lib+it tests pass** (incl. 12 new), clippy `-D warnings` clean (default + jpeg), fmt clean
- No gate/constant/algorithm change → `LIBJXL_DIVERGENCES.md` N/A

Closes #80. Closes #82.