### PR TITLE
with_effort: preserve ALL caller-preference fields (completes #80)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -210,6 +210,41 @@
   `new().with_effort(N)` path keeps adopting the effort default and stays
   byte-identical (hash-locks 48/48). New test
   `tests/it/with_effort_preserves_explicit.rs`.
+- **`with_effort()` follow-up: also preserve the FIXED-DEFAULT
+  caller-preference fields (#80).** The first #80 fix covered the
+  effort-*derived* fields (whose value in the rebuild is `profile.X`) via
+  `*_explicit` flags, but missed the caller-preference fields whose value
+  in `new_with_effort` / `with_effort_level` is a *fixed literal* (e.g.
+  `threads: 0`, `dot_detection: true`, `forced_rct: None`) — these have a
+  public `with_*` setter yet were still silently reset by `with_effort`
+  (the same footgun, e.g. `.with_threads(8).with_effort(7)` → threads back
+  to 0). Since these are not effort-derived, `with_effort` now carries the
+  caller's value across *unconditionally* (like the pre-existing
+  `noise` / `force_strategy` / `splines` / `buffering` preserves), so the
+  chain is order-independent in both orders. Now-preserved across
+  `with_effort`: on `LossyConfig` — `with_dot_detection`,
+  `with_adaptive_gaborish`, `with_already_downsampled`,
+  `with_auto_resampling`, `with_lf_frame`, `with_non_finite_action`,
+  `with_resampling` (via its existing `resampling_explicit` companion,
+  which also gates auto-resample-at-d≥10), `with_simplify_invisible` /
+  `with_keep_invisible`, `with_threads`, plus the additional gaps found in
+  the same audit — `with_epf_level`, `with_center_first`,
+  `with_progressive_dc`, `with_auto_delta_frames`, `with_faster_decoding`,
+  `with_container_mode`, and (feature-gated) the perceptual-loop knobs
+  (`with_perceptual_metric` / `with_perceptual_device` /
+  `with_perceptual_target_score` / `with_cvvdp_bytes_tighten` /
+  `with_target_display`) and `with_knobs`; on `LosslessConfig` —
+  `with_auto_delta_frames`, `with_container_mode`, `with_faster_decoding`,
+  `with_force_rct`, `with_lossy_palette`,
+  `with_modular_channel_colors_global_percent` /
+  `..._group_percent`, `with_modular_group_size`,
+  `with_modular_nb_prev_channels`, `with_modular_palette_colors`,
+  `with_modular_predictor`, `with_keep_invisible`, `with_threads`,
+  `with_tree_learning_sample_fraction`, and (feature-gated) `with_limits`.
+  The common `new().with_effort(N)` path stays byte-identical because each
+  preserve is a no-op-equivalent there (hash-locks 48/48). Extended
+  `tests/it/with_effort_preserves_explicit.rs` (+ in-crate unit tests for
+  the getter-less `simplify_invisible` flag).
 - **Test builds: pin `alloc-stdlib` so `alloc-no-stdlib` stays on 2.x (#82).**
   `brotli` (a dev-dep via `zenjxl-decoder`, plus our optional `brotli-metadata`
   dep) provides `impl BrotliAlloc for StandardAlloc`, where `StandardAlloc`

--- a/jxl-encoder/src/api.rs
+++ b/jxl-encoder/src/api.rs
@@ -2863,6 +2863,36 @@ impl LosslessConfig {
         // `LosslessConfig::new().with_buffering(_).with_effort(_)` is
         // order-independent.
         new.buffering = self.buffering;
+        // Issue #80 follow-up: preserve the FIXED-DEFAULT caller-preference
+        // knobs too. Every field here is assigned a fixed literal in
+        // `with_effort_level` (`threads: 0`, `forced_rct: None`,
+        // `container_mode: ContainerMode::Auto`, `simplify_invisible:
+        // false`, …) — NOT `profile.X` — so an unconditional copy keeps the
+        // common `new().with_effort(N)` path byte-identical (each line is a
+        // no-op-equivalent there: `self.<field> == new.<field>`, both the
+        // construction default) while making the builder chain
+        // order-independent in BOTH orders for callers that set the value.
+        new.auto_delta_frames = self.auto_delta_frames;
+        new.container_mode = self.container_mode;
+        new.faster_decoding = self.faster_decoding;
+        new.forced_rct = self.forced_rct;
+        new.lossy_palette = self.lossy_palette;
+        new.modular_channel_colors_global_percent = self.modular_channel_colors_global_percent;
+        new.modular_channel_colors_group_percent = self.modular_channel_colors_group_percent;
+        new.modular_group_size_shift = self.modular_group_size_shift;
+        new.modular_nb_prev_channels = self.modular_nb_prev_channels;
+        new.modular_palette_colors = self.modular_palette_colors;
+        new.modular_predictor = self.modular_predictor;
+        new.simplify_invisible = self.simplify_invisible;
+        new.threads = self.threads;
+        new.tree_sample_fraction_override = self.tree_sample_fraction_override;
+        // `limits` is a pure caller-supplied resource cap (JPEG-transcode
+        // path); never effort-derived. Non-`Copy` (`Option<Limits>`), so
+        // clone. Feature-gated identically to the field.
+        #[cfg(feature = "jpeg-reencoding")]
+        {
+            new.limits = self.limits.clone();
+        }
         new
     }
 
@@ -3086,6 +3116,15 @@ impl LosslessConfig {
         // branch is a single boolean read on the hot path.
         self.simplify_invisible = !keep;
         self
+    }
+
+    /// Test-only accessor for the private `simplify_invisible` flag
+    /// (the public surface is the inverse `with_keep_invisible` setter,
+    /// which has no getter). Used by `with_effort_preserves_explicit` to
+    /// prove the flag survives `with_effort` (issue #80 follow-up).
+    #[cfg(test)]
+    pub(crate) fn simplify_invisible_for_test(&self) -> bool {
+        self.simplify_invisible
     }
 
     /// Force a fixed modular predictor (CLI passthrough — mirrors libjxl
@@ -5951,11 +5990,13 @@ impl LossyConfig {
         new.center_x = self.center_x;
         new.center_y = self.center_y;
         new.upsampling_mode = self.upsampling_mode;
-        // If group_order was set to 1 (center-first), keep center_first
-        // wired through with_effort too.
-        if matches!(self.group_order, Some(1)) {
-            new.center_first = true;
-        }
+        // (`center_first` is preserved unconditionally in the #80
+        // follow-up block below — `new.center_first = self.center_first`.
+        // `with_group_order`/`with_center_first` already maintain
+        // `self.center_first`, so carrying the field straight across
+        // subsumes the former `group_order == Some(1)` re-derivation that
+        // used to live here and also honours an explicit
+        // `with_center_first(false)`.)
         // Chroma subsampling — never effort-derived; carry across
         // `with_effort` so the builder chain
         // `LossyConfig::new(d).with_chroma_subsampling(Sub420).with_effort(5)`
@@ -5966,6 +6007,60 @@ impl LossyConfig {
         // `LossyConfig::new(d).with_buffering(_).with_effort(_)` is
         // order-independent.
         new.buffering = self.buffering;
+        // Issue #80 follow-up: preserve the FIXED-DEFAULT caller-preference
+        // knobs too. Unlike the `*_explicit`-gated block above (which
+        // guards effort-DERIVED `profile.X` defaults), every field here is
+        // assigned a fixed literal in `new_with_effort` — `dot_detection:
+        // true`, `threads: 0`, `simplify_invisible: true`, etc. — so an
+        // unconditional copy is the right shape: on the common
+        // `new(d).with_effort(N)` path `self.<field> == new.<field>` (both
+        // the construction default), making each line a no-op-equivalent
+        // and keeping the bitstream byte-identical (proved by the
+        // hash-locks). A caller that *did* set the value via `with_<field>`
+        // now keeps it, making the chain order-independent in BOTH orders.
+        new.dot_detection = self.dot_detection;
+        new.adaptive_gaborish = self.adaptive_gaborish;
+        new.already_downsampled = self.already_downsampled;
+        new.auto_resampling = self.auto_resampling;
+        new.lf_frame = self.lf_frame;
+        new.non_finite_action = self.non_finite_action;
+        new.simplify_invisible = self.simplify_invisible;
+        new.threads = self.threads;
+        new.epf_level = self.epf_level;
+        new.center_first = self.center_first;
+        new.progressive_dc = self.progressive_dc;
+        new.auto_delta_frames = self.auto_delta_frames;
+        new.faster_decoding = self.faster_decoding;
+        new.container_mode = self.container_mode;
+        // `resampling` carries an existing `resampling_explicit` companion
+        // that gates the auto-resample-at-d>=10 rule (see
+        // `effective_resampling` / `effective_distance`). A bare
+        // `new.resampling = self.resampling` would NOT be enough — it would
+        // leave `resampling_explicit == false`, so a caller's
+        // `with_resampling(1)` (which suppresses auto-resample) would
+        // silently re-enable it at d>=10 after `with_effort`. So this one
+        // uses the `*_explicit` pattern, preserving both fields together.
+        if self.resampling_explicit {
+            new.resampling = self.resampling;
+            new.resampling_explicit = true;
+        }
+        // Perceptual-loop knobs (metric / device / target / display) are
+        // fixed defaults too; carry them across like `ssim2_iters` /
+        // `zensim_iters` / `hdr_loss` already are above.
+        #[cfg(feature = "butteraugli-loop")]
+        {
+            new.perceptual_metric = self.perceptual_metric;
+            new.perceptual_device = self.perceptual_device;
+            new.perceptual_target_score = self.perceptual_target_score;
+            new.cvvdp_bytes_tighten = self.cvvdp_bytes_tighten;
+            new.target_display = self.target_display;
+        }
+        // Tier-2 coupling knobs (opt-in sweep override) — fixed `None`
+        // default, never effort-derived.
+        #[cfg(feature = "tuning-override")]
+        {
+            new.tier2_knobs = self.tier2_knobs;
+        }
         new
     }
 
@@ -6463,6 +6558,16 @@ impl LossyConfig {
     pub fn with_keep_invisible(mut self, keep: bool) -> Self {
         self.simplify_invisible = !keep;
         self
+    }
+
+    /// Test-only accessor for the private `simplify_invisible` flag
+    /// (the public surface is `with_simplify_invisible` /
+    /// `with_keep_invisible` setters, neither with a getter). Used by
+    /// `with_effort_preserves_explicit` to prove the flag survives
+    /// `with_effort` (issue #80 follow-up).
+    #[cfg(test)]
+    pub(crate) fn simplify_invisible_for_test(&self) -> bool {
+        self.simplify_invisible
     }
 
     /// Enable/disable input canonicalization pre-pass (default: `false`).
@@ -18319,5 +18424,65 @@ mod tests {
                 "good target_score {good} MUST pass through"
             );
         }
+    }
+
+    // ── Issue #80 follow-up: `simplify_invisible` preservation across
+    //    `with_effort`. In-crate unit tests because the flag has no public
+    //    getter (only the private `simplify_invisible_for_test` accessor,
+    //    which an external integration crate cannot reach). The
+    //    public-getter fields are covered in
+    //    `tests/it/with_effort_preserves_explicit.rs`.
+
+    #[test]
+    fn with_effort_simplify_invisible_lossy_both_orders() {
+        // lossy default simplify_invisible = true; flip to false.
+        assert!(
+            !LossyConfig::new(1.0)
+                .with_simplify_invisible(false)
+                .with_effort(7)
+                .simplify_invisible_for_test(),
+            "lossy with_simplify_invisible(false) before with_effort must be preserved (#80 follow-up)"
+        );
+        assert!(
+            !LossyConfig::new(1.0)
+                .with_effort(7)
+                .with_simplify_invisible(false)
+                .simplify_invisible_for_test(),
+            "lossy with_simplify_invisible(false) after with_effort must be preserved"
+        );
+        // Untouched common path keeps the fixed default (true) — byte-identical.
+        assert!(
+            LossyConfig::new(1.0)
+                .with_effort(7)
+                .simplify_invisible_for_test(),
+            "untouched lossy config keeps the fixed simplify_invisible default (true)"
+        );
+    }
+
+    #[test]
+    fn with_effort_simplify_invisible_lossless_both_orders() {
+        // lossless default simplify_invisible = false (keep_invisible = true);
+        // `with_keep_invisible(false)` sets simplify_invisible = true.
+        assert!(
+            LosslessConfig::new()
+                .with_keep_invisible(false)
+                .with_effort(7)
+                .simplify_invisible_for_test(),
+            "lossless with_keep_invisible(false) before with_effort must be preserved (#80 follow-up)"
+        );
+        assert!(
+            LosslessConfig::new()
+                .with_effort(7)
+                .with_keep_invisible(false)
+                .simplify_invisible_for_test(),
+            "lossless with_keep_invisible(false) after with_effort must be preserved"
+        );
+        // Untouched common path keeps the fixed default (false).
+        assert!(
+            !LosslessConfig::new()
+                .with_effort(7)
+                .simplify_invisible_for_test(),
+            "untouched lossless config keeps the fixed simplify_invisible default (false)"
+        );
     }
 }

--- a/jxl-encoder/tests/it/with_effort_preserves_explicit.rs
+++ b/jxl-encoder/tests/it/with_effort_preserves_explicit.rs
@@ -21,7 +21,7 @@
 //! stay byte-identical — proven separately by the hash-lock suite; here we
 //! just pin the default-adoption behaviour at the API level).
 
-use jxl_encoder::{LosslessConfig, LossyConfig, Lz77Method};
+use jxl_encoder::{ContainerMode, LosslessConfig, LossyConfig, Lz77Method, RctType};
 
 // ----------------------------------------------------------------------
 // LossyConfig
@@ -267,5 +267,272 @@ fn lossless_with_lz77_method_survives_with_effort_both_orders() {
             .lz77_method(),
         Lz77Method::Optimal,
         "with_lz77_method after with_effort must be preserved"
+    );
+}
+
+// ----------------------------------------------------------------------
+// Issue #80 FOLLOW-UP: fixed-default caller-preference fields.
+//
+// PR #90 (above) covered the effort-DERIVED fields via `*_explicit`
+// flags. These fields take a FIXED literal in `new_with_effort` /
+// `with_effort_level` (not `profile.X`), so `with_effort` now preserves
+// the caller's value UNCONDITIONALLY. Each test pins a value that
+// differs from the construction default and asserts it survives
+// `with_effort` in BOTH chain orders.
+// ----------------------------------------------------------------------
+
+// ---- LossyConfig fixed-default fields ----
+
+#[test]
+fn lossy_with_threads_survives_with_effort_both_orders() {
+    // default threads = 0; pick 8.
+    assert_eq!(
+        LossyConfig::new(1.0)
+            .with_threads(8)
+            .with_effort(7)
+            .threads(),
+        8,
+        "with_threads(8) before with_effort must be preserved (#80 follow-up)"
+    );
+    assert_eq!(
+        LossyConfig::new(1.0)
+            .with_effort(7)
+            .with_threads(8)
+            .threads(),
+        8,
+        "with_threads(8) after with_effort must be preserved"
+    );
+    // Untouched common path keeps the fixed default (0) — byte-identical.
+    assert_eq!(
+        LossyConfig::new(1.0).with_effort(7).threads(),
+        0,
+        "untouched config keeps the fixed threads default (0)"
+    );
+}
+
+#[test]
+fn lossy_with_resampling_survives_with_effort_both_orders() {
+    // default resampling = 1; pick 2. resampling carries an `_explicit`
+    // companion (gates auto-resample), so this uses the *_explicit pattern.
+    assert_eq!(
+        LossyConfig::new(1.0)
+            .with_resampling(2)
+            .with_effort(7)
+            .resampling(),
+        2,
+        "with_resampling(2) before with_effort must be preserved (#80 follow-up)"
+    );
+    assert_eq!(
+        LossyConfig::new(1.0)
+            .with_effort(7)
+            .with_resampling(2)
+            .resampling(),
+        2,
+        "with_resampling(2) after with_effort must be preserved"
+    );
+    // The `_explicit` flag itself must survive too: an explicit
+    // `with_resampling(1)` suppresses auto-resample at d>=10, so the
+    // EFFECTIVE factor must stay 1 (not auto-bumped to 2) after with_effort.
+    assert_eq!(
+        LossyConfig::new(12.0)
+            .with_resampling(1)
+            .with_effort(7)
+            .effective_resampling(),
+        1,
+        "explicit with_resampling(1) must keep suppressing auto-resample at d>=10 after with_effort (#80 follow-up)"
+    );
+    // Sanity: WITHOUT the explicit pin, auto-resample still fires at d>=10.
+    assert_eq!(
+        LossyConfig::new(12.0).with_effort(7).effective_resampling(),
+        2,
+        "auto-resample default must still engage at d>=10 when resampling is untouched"
+    );
+}
+
+#[test]
+fn lossy_with_dot_detection_survives_with_effort_both_orders() {
+    // default dot_detection = true; flip to false.
+    assert!(
+        !LossyConfig::new(1.0)
+            .with_dot_detection(false)
+            .with_effort(7)
+            .dot_detection(),
+        "with_dot_detection(false) before with_effort must be preserved (#80 follow-up)"
+    );
+    assert!(
+        !LossyConfig::new(1.0)
+            .with_effort(7)
+            .with_dot_detection(false)
+            .dot_detection(),
+        "with_dot_detection(false) after with_effort must be preserved"
+    );
+    assert!(
+        LossyConfig::new(1.0).with_effort(7).dot_detection(),
+        "untouched config keeps the fixed dot_detection default (true)"
+    );
+}
+
+// NOTE: `simplify_invisible` (lossy `with_simplify_invisible` / lossless
+// `with_keep_invisible`) has no public getter, only a private flag. Its
+// `with_effort` preservation is proven by the in-crate unit tests in
+// `src/api.rs` (`with_effort_simplify_invisible_*`), which CAN reach the
+// `#[cfg(test)]` accessor — an external integration crate cannot.
+
+#[test]
+fn lossy_with_lf_frame_survives_with_effort_both_orders() {
+    // default lf_frame = false; flip to true.
+    assert!(
+        LossyConfig::new(1.0)
+            .with_lf_frame(true)
+            .with_effort(7)
+            .lf_frame(),
+        "with_lf_frame(true) before with_effort must be preserved (#80 follow-up)"
+    );
+    assert!(
+        LossyConfig::new(1.0)
+            .with_effort(7)
+            .with_lf_frame(true)
+            .lf_frame(),
+        "with_lf_frame(true) after with_effort must be preserved"
+    );
+    assert!(
+        !LossyConfig::new(1.0).with_effort(7).lf_frame(),
+        "untouched config keeps the fixed lf_frame default (false)"
+    );
+}
+
+// ---- LosslessConfig fixed-default fields ----
+
+#[test]
+fn lossless_with_lossy_palette_survives_with_effort_both_orders() {
+    // default lossy_palette = false; flip to true.
+    assert!(
+        LosslessConfig::new()
+            .with_lossy_palette(true)
+            .with_effort(7)
+            .lossy_palette(),
+        "with_lossy_palette(true) before with_effort must be preserved (#80 follow-up)"
+    );
+    assert!(
+        LosslessConfig::new()
+            .with_effort(7)
+            .with_lossy_palette(true)
+            .lossy_palette(),
+        "with_lossy_palette(true) after with_effort must be preserved"
+    );
+    assert!(
+        !LosslessConfig::new().with_effort(7).lossy_palette(),
+        "untouched config keeps the fixed lossy_palette default (false)"
+    );
+}
+
+#[test]
+fn lossless_with_modular_predictor_survives_with_effort_both_orders() {
+    // default modular_predictor = None; pick Some(5).
+    assert_eq!(
+        LosslessConfig::new()
+            .with_modular_predictor(Some(5))
+            .with_effort(7)
+            .modular_predictor(),
+        Some(5),
+        "with_modular_predictor before with_effort must be preserved (#80 follow-up)"
+    );
+    assert_eq!(
+        LosslessConfig::new()
+            .with_effort(7)
+            .with_modular_predictor(Some(5))
+            .modular_predictor(),
+        Some(5),
+        "with_modular_predictor after with_effort must be preserved"
+    );
+    assert_eq!(
+        LosslessConfig::new().with_effort(7).modular_predictor(),
+        None,
+        "untouched config keeps the fixed modular_predictor default (None)"
+    );
+}
+
+#[test]
+fn lossless_with_force_rct_survives_with_effort_both_orders() {
+    // default forced_rct = None; force YCoCg (RctType inner = 6). RctType
+    // has no PartialEq, so compare the public `.0` byte.
+    assert_eq!(
+        LosslessConfig::new()
+            .with_force_rct(Some(RctType::YCOCG))
+            .with_effort(7)
+            .force_rct()
+            .map(|r| r.0),
+        Some(RctType::YCOCG.0),
+        "with_force_rct before with_effort must be preserved (#80 follow-up)"
+    );
+    assert_eq!(
+        LosslessConfig::new()
+            .with_effort(7)
+            .with_force_rct(Some(RctType::YCOCG))
+            .force_rct()
+            .map(|r| r.0),
+        Some(RctType::YCOCG.0),
+        "with_force_rct after with_effort must be preserved"
+    );
+    assert!(
+        LosslessConfig::new().with_effort(7).force_rct().is_none(),
+        "untouched config keeps the fixed forced_rct default (None)"
+    );
+}
+
+#[test]
+fn lossless_with_container_mode_survives_with_effort_both_orders() {
+    // default container_mode = Auto; pick Always.
+    assert!(
+        matches!(
+            LosslessConfig::new()
+                .with_container_mode(ContainerMode::Always)
+                .with_effort(7)
+                .container_mode(),
+            ContainerMode::Always
+        ),
+        "with_container_mode before with_effort must be preserved (#80 follow-up)"
+    );
+    assert!(
+        matches!(
+            LosslessConfig::new()
+                .with_effort(7)
+                .with_container_mode(ContainerMode::Always)
+                .container_mode(),
+            ContainerMode::Always
+        ),
+        "with_container_mode after with_effort must be preserved"
+    );
+    assert!(
+        matches!(
+            LosslessConfig::new().with_effort(7).container_mode(),
+            ContainerMode::Auto
+        ),
+        "untouched config keeps the fixed container_mode default (Auto)"
+    );
+}
+
+#[test]
+fn lossless_with_threads_survives_with_effort_both_orders() {
+    assert_eq!(
+        LosslessConfig::new()
+            .with_threads(8)
+            .with_effort(7)
+            .threads(),
+        8,
+        "with_threads(8) before with_effort must be preserved (#80 follow-up)"
+    );
+    assert_eq!(
+        LosslessConfig::new()
+            .with_effort(7)
+            .with_threads(8)
+            .threads(),
+        8,
+        "with_threads(8) after with_effort must be preserved"
+    );
+    assert_eq!(
+        LosslessConfig::new().with_effort(7).threads(),
+        0,
+        "untouched config keeps the fixed threads default (0)"
     );
 }


### PR DESCRIPTION
Follow-up completing the #80 fix. PR #90 made `with_effort()` preserve explicitly-set **effort-derived** fields (via the `*_explicit` flags), but it missed the **fixed-default caller-preference** fields: `with_effort` rebuilds the config and only preserved a subset, so any of these set *before* `with_effort` was silently reset (same footgun, e.g. `.with_threads(8).with_effort(7)` → 0; `.with_dot_detection(false).with_effort(7)` → true).

Found via a reset-vs-preserved diff on both `with_effort` bodies. These fields aren't effort-controlled (fixed literals in `new_with_effort`/`with_effort_level`), so the fix is an **unconditional preserve** (`new.X = self.X`, like the existing `noise`/`force_strategy`/`splines` lines) — no `_explicit` flag.

### Now preserved
- **Lossy:** `dot_detection`, `adaptive_gaborish`, `already_downsampled`, `auto_resampling`, `lf_frame`, `non_finite_action`, `simplify_invisible`, `threads`, `epf_level`, `center_first`, `progressive_dc`, `auto_delta_frames`, `faster_decoding`, `container_mode`, and (feature-gated) `perceptual_metric`/`perceptual_device`/`perceptual_target_score`/`cvvdp_bytes_tighten`/`target_display`, `tier2_knobs`.
- **Lossless:** `auto_delta_frames`, `container_mode`, `faster_decoding`, `forced_rct`, `lossy_palette`, `modular_channel_colors_{global,group}_percent`, `modular_group_size_shift`, `modular_nb_prev_channels`, `modular_palette_colors`, `modular_predictor`, `simplify_invisible`, `threads`, `tree_sample_fraction_override`, and (feature-gated) `limits`.

### Notable
- **`resampling`** is NOT a plain preserve — it has a `resampling_explicit` companion that gates the auto-resample-at-d≥10 rule, so it uses the `_explicit` pattern (a bare copy would leave the flag false and silently re-enable auto-resample after `with_effort`).
- Removed a now-redundant `group_order==1 ⇒ center_first` write (subsumed by the unconditional `center_first` preserve; `group_order` wiring tests still pass both chain orders).

### Verification (re-run by me)
- **hash-locks 48/48** byte-identical (the common path `new().with_effort(N)` is unchanged — `self.X == default` there, so the preserve is a no-op-equivalent)
- **2009 lib+it tests pass** (new order-independence cases for `threads`/`resampling`/`dot_detection`/`lf_frame`/`lossy_palette`/`modular_predictor`/`force_rct`/`container_mode` + in-crate `simplify_invisible` tests)
- clippy `-D warnings` clean (default + jpeg), fmt clean; no public API change

Completes #80.